### PR TITLE
Chore : Story-Based Branch Naming for Push Workflow

### DIFF
--- a/.agents/workflows/push.md
+++ b/.agents/workflows/push.md
@@ -12,10 +12,14 @@ description: Intelligently group uncommitted changes into logical commits and pu
    - Run `git branch --show-current` to get the current branch.
    - If the current branch is `master` or `development`:
      1. Inform the user that pushing directly to `master` or `development` is not allowed.
-     2. Analyze the uncommitted changes to determine an appropriate branch name using the format `<type>/<short-description>` (e.g., `feat/add-price-alerts`, `fix/login-redirect`).
-     3. Propose the branch name to the user.
-     4. Run `git checkout -b <branch-name>` to create and switch to the new feature branch.
-     5. Continue with the next steps on the new branch.
+     2. Attempt to retrieve the current active story name from `_bmad-output/implementation-artifacts/sprint-status.yaml` (e.g., "Story 1.2 — Design System & Token Foundation").
+     3. Analyze the uncommitted changes to determine the appropriate commit `<type>` (e.g., `feat`, `fix`, `chore`).
+     4. Format the branch name:
+        - If the changes are related to a story, format as `<type>/<story-name>` using the story name in kebab-case (e.g., `feat/1-2-design-system-and-token-foundation`).
+        - If the changes are NOT related to a story, fallback to using a short description of the changes as `<type>/<short-description>` (e.g., `fix/login-redirect`).
+     5. Propose the branch name to the user.
+     6. Run `git checkout -b <branch-name>` to create and switch to the new feature branch.
+     7. Continue with the next steps on the new branch.
 
 2. **Analyze repository status**:
    - Run `git status` and `git diff --stat` to identify all uncommitted changes.


### PR DESCRIPTION
# Story-Based Branch Naming for Push Workflow

## Overview
This PR updates the `[/push]` workflow to automatically determine feature branch names using the active BMAD story from `sprint-status.yaml`. This ensures consistent branch naming conventions aligned with project management artifacts.

## Changes
### `.agents/workflows/push.md`
- Added logic to attempt retrieving the current active story name from `_bmad-output/implementation-artifacts/sprint-status.yaml`.
- Updated branch naming format to `<type>/<story-name>` (e.g., `feat/1-2-design-system-and-token-foundation`).
- Added a fallback to the original `<type>/<short-description>` format if no active story is identified.

## Testing
- Manually verified the updated workflow instructions.
- Verified that the new branch `chore/update-push-workflow` was created successfully using the new logic (falling back to description since no story was active).
- Confirmed `npm run lint` and `npm run build` pass with these changes.