### PR TITLE
Chore : Rename master to main in workflow files

### DIFF
--- a/.agents/workflows/pr-create.md
+++ b/.agents/workflows/pr-create.md
@@ -10,8 +10,8 @@ description: Commit, push, and create a GitHub Pull Request from the current bra
 
 1. **Get the current branch**:
    - Run `git branch --show-current` to get the source branch name.
-   - If the current branch is `master`, STOP and warn the user — do not create a PR from `master`.
-   - If the current branch is `development`, this is a **release PR** — target must be `master`. Skip to step 3.
+   - If the current branch is `main`, STOP and warn the user — do not create a PR from `main`.
+   - If the current branch is `development`, this is a **release PR** — target must be `main`. Skip to step 3.
 
 2. **Commit and push uncommitted changes**:
    - Run `git status` and `git diff --stat` to identify all uncommitted changes.
@@ -46,7 +46,7 @@ description: Commit, push, and create a GitHub Pull Request from the current bra
    If the build fails, STOP immediately, report the failure to the user, and do NOT proceed to create the PR.
 
 5. **Determine the PR type**:
-   - For **release PRs** (`development` → `master`), the type is always `Release`.
+   - For **release PRs** (`development` → `main`), the type is always `Release`.
    - For feature branch PRs, ask the user (or infer from the branch name). Common types:
      - `Feature` — new functionality
      - `Fix` — bug fix
@@ -72,13 +72,13 @@ description: Commit, push, and create a GitHub Pull Request from the current bra
      - Build the PR title as: `<Type> : <Title>` (e.g., `Feature : AI Context Enrichment`).
      - Use the **entire walkthrough content** as the PR body.
      - **Issue Linking**: Ask the user if there is a GitHub Issue number this PR should close/link to (e.g., `#12`). If they provide one, append `Closes #<issue-number>` to the bottom of the PR body.
-   - **For release PRs** (`development` → `master`):
-     - Run `git log master..development --oneline` to get the list of commits being merged.
+   - **For release PRs** (`development` → `main`):
+     - Run `git log main..development --oneline` to get the list of commits being merged.
      - Build the PR title as: `Release : <date>` (e.g., `Release : 2026-04-16`).
      - Build the PR body from the commit list, formatted as a markdown changelog.
 
 7. **Determine the target branch**:
-   - For **release PRs**: always `master`.
+   - For **release PRs**: always `main`.
    - For feature branch PRs: user-specified or default `development`.
 
 8. **Create the PR**:
@@ -113,5 +113,5 @@ description: Commit, push, and create a GitHub Pull Request from the current bra
 - **Do not** use generic messages like "fixes" or "updates".
 - **Do not** invent new commit types; use strictly the ones listed above.
 - **Do not** push if `git commit` fails.
-- **Do not** create a PR from `master`.
+- **Do not** create a PR from `main`.
 - **Do not** create the PR if the build fails.

--- a/.agents/workflows/push.md
+++ b/.agents/workflows/push.md
@@ -10,8 +10,8 @@ description: Intelligently group uncommitted changes into logical commits and pu
 
 1. **Branch guard — auto-create feature branch if needed**:
    - Run `git branch --show-current` to get the current branch.
-   - If the current branch is `master` or `development`:
-     1. Inform the user that pushing directly to `master` or `development` is not allowed.
+   - If the current branch is `main` or `development`:
+     1. Inform the user that pushing directly to `main` or `development` is not allowed.
      2. Attempt to retrieve the current active story name from `_bmad-output/implementation-artifacts/sprint-status.yaml` (e.g., "Story 1.2 — Design System & Token Foundation").
      3. Analyze the uncommitted changes to determine the appropriate commit `<type>` (e.g., `feat`, `fix`, `chore`).
      4. Format the branch name:


### PR DESCRIPTION
# Rename master to main in workflow files

## Overview

Updated all references from the deprecated `master` branch to `main` across workflow files. The `master` branch has been deleted — `main` is now the primary branch.

## Changes

### `.agents/workflows/pr-create.md`
- Updated branch guard (`main` instead of `master`)
- Updated release PR target branch references (7 occurrences)

### `.agents/workflows/push.md`
- Updated branch guard to block direct pushes to `main` instead of `master` (2 occurrences)

### `.agents/workflows/cleanup.md`
- Already used `main` — no changes needed

## Testing

- **Lint**: ✅ Passed
- **TypeScript**: ✅ Passed
- **Format**: ✅ Passed
- **Tests**: ✅ 31 passed, 3 skipped (DB-gated)
- **Build**: ✅ Compiled successfully