### PR TITLE
story-3.4-lifestyle-tags-and-smart-presets - fixes #88

### DIFF
--- a/_bmad-output/implementation-artifacts/3-4-lifestyle-tags-and-smart-presets.md
+++ b/_bmad-output/implementation-artifacts/3-4-lifestyle-tags-and-smart-presets.md
@@ -2,7 +2,7 @@
 
 **GH Issue:** #88
 
-Status: ready-for-dev
+Status: review
 
 ## Story
 
@@ -28,17 +28,17 @@ so that I can quickly find properties that match my goals without configuring ev
 
 ## Tasks / Subtasks
 
-- [ ] Task 1: Extend `SearchFilters` type with `tags` field (AC: #1, #2, #3)
-  - [ ] Modify `src/types/search.ts` — add `tags?: string[]` field to `SearchFilters`:
+- [x] Task 1: Extend `SearchFilters` type with `tags` field (AC: #1, #2, #3)
+  - [x] Modify `src/types/search.ts` — add `tags?: string[]` field to `SearchFilters`:
     ```ts
     export interface SearchFilters {
       // ... existing fields ...
       tags?: string[];  // URL param: "tags" (comma-separated values)
     }
     ```
-  - [ ] The `tags` URL param uses comma-separated values: `?tags=Investment+Property,Rental+Potential`
-  - [ ] `tags` MUST count toward `activeFilterCount` — per AC #6, active lifestyle tags appear as chips in the active filter display
-  - [ ] **`activeFilterCount` for tags**: count each selected tag individually (2 selected tags = +2 to count, not just +1). Do NOT add `tags` to `FILTER_KEYS` (the existing per-key check counts 1 per key). Instead, replace the `activeFilterCount` `useMemo` in `use-search-filters.ts` with:
+  - [x] The `tags` URL param uses comma-separated values: `?tags=Investment+Property,Rental+Potential`
+  - [x] `tags` MUST count toward `activeFilterCount` — per AC #6, active lifestyle tags appear as chips in the active filter display
+  - [x] **`activeFilterCount` for tags**: count each selected tag individually (2 selected tags = +2 to count, not just +1). Do NOT add `tags` to `FILTER_KEYS` (the existing per-key check counts 1 per key). Instead, replace the `activeFilterCount` `useMemo` in `use-search-filters.ts` with:
     ```ts
     const activeFilterCount = useMemo(() => {
       const scalarCount = FILTER_KEYS.filter(key => {
@@ -51,11 +51,11 @@ so that I can quickly find properties that match my goals without configuring ev
     ```
     (Keep `FILTER_KEYS` as the existing 8 scalar keys — do NOT add `tags` to that array)
 
-- [ ] Task 2: Extend `useSearchFilters` hook for tags URL state (AC: #2, #3, #6)
-  - [ ] Modify `src/hooks/use-search-filters.ts`
-  - [ ] Add `tags` to `PARAM_MAP`: `tags: "tags"`
-  - [ ] Do NOT add `tags` to `FILTER_KEYS` — instead extend the `activeFilterCount` useMemo as specified in Task 1 (counts each tag individually)
-  - [ ] Add `tags` parsing in `parseFilters()`:
+- [x] Task 2: Extend `useSearchFilters` hook for tags URL state (AC: #2, #3, #6)
+  - [x] Modify `src/hooks/use-search-filters.ts`
+  - [x] Add `tags` to `PARAM_MAP`: `tags: "tags"`
+  - [x] Do NOT add `tags` to `FILTER_KEYS` — instead extend the `activeFilterCount` useMemo as specified in Task 1 (counts each tag individually)
+  - [x] Add `tags` parsing in `parseFilters()`:
     ```ts
     const tagsParam = params.get("tags");
     if (tagsParam) {
@@ -63,9 +63,9 @@ so that I can quickly find properties that match my goals without configuring ev
       if (parsed.length > 0) filters.tags = parsed;
     }
     ```
-  - [ ] Add `tags` serialization in `serializeValue()`: join array with comma (`tags.join(",")`)
-  - [ ] `tags` is NOT a debounced key (instant update when chip is toggled)
-  - [ ] The `setFilter('tags', ...)` call expects `string[] | undefined` — toggling a single tag requires reading the current array, adding/removing the tag, and calling `setFilter('tags', newArray)`. Implement a new helper: `toggleTag(tag: string): void` on the hook return:
+  - [x] Add `tags` serialization in `serializeValue()`: join array with comma (`tags.join(",")`)
+  - [x] `tags` is NOT a debounced key (instant update when chip is toggled)
+  - [x] The `setFilter('tags', ...)` call expects `string[] | undefined` — toggling a single tag requires reading the current array, adding/removing the tag, and calling `setFilter('tags', newArray)`. Implement a new helper: `toggleTag(tag: string): void` on the hook return:
     ```ts
     toggleTag: (tag: string) => void;
     ```
@@ -84,29 +84,29 @@ so that I can quickly find properties that match my goals without configuring ev
     }, [setFilter]);
     ```
     Note: `latestParamsRef` is already maintained in the hook — this is the same pattern used by `performUpdate` for debounced numeric filters.
-  - [ ] Update `UseSearchFiltersReturn` interface to include `toggleTag`
+  - [x] Update `UseSearchFiltersReturn` interface to include `toggleTag`
 
-- [ ] Task 3: Extend `searchProperties` Server Action to filter by lifestyle tags (AC: #3, #1)
-  - [ ] Modify `src/app/actions/search-actions.ts`
-  - [ ] Add `tags` to `dimConditions` map — use the architecture §6 pattern:
+- [x] Task 3: Extend `searchProperties` Server Action to filter by lifestyle tags (AC: #3, #1)
+  - [x] Modify `src/app/actions/search-actions.ts`
+  - [x] Add `tags` to `dimConditions` map — use the architecture §6 pattern:
     ```ts
     tags: filters.tags?.length
       ? sql`${properties.lifestyleTags} && ${filters.tags}`
       : undefined,
     ```
-  - [ ] In Drizzle ORM 0.44 (the project version), passing a JS `string[]` as a parameter in `sql` template literals serializes it as a PostgreSQL text array. This is the pattern the architecture §6 specifies explicitly.
-  - [ ] The `&&` (overlap) operator on `text[]` implements OR logic (any tag matches) — this uses the `idx_properties_tags` GIN index (already exists on the schema)
-  - [ ] **DB schema**: `properties.lifestyleTags` = `text("lifestyle_tags").array().$type<string[]>()` (confirmed in `src/lib/db/schema/properties.ts` line ~40)
-  - [ ] **GIN index** `idx_properties_tags` already created in schema — no migration needed
+  - [x] In Drizzle ORM 0.44 (the project version), passing a JS `string[]` as a parameter in `sql` template literals serializes it as a PostgreSQL text array. This is the pattern the architecture §6 specifies explicitly.
+  - [x] The `&&` (overlap) operator on `text[]` implements OR logic (any tag matches) — this uses the `idx_properties_tags` GIN index (already exists on the schema)
+  - [x] **DB schema**: `properties.lifestyleTags` = `text("lifestyle_tags").array().$type<string[]>()` (confirmed in `src/lib/db/schema/properties.ts` line ~40)
+  - [x] **GIN index** `idx_properties_tags` already created in schema — no migration needed
 
-- [ ] Task 4: Create `LifestyleTagChips` component (AC: #1, #2, #3, #6)
-  - [ ] Create `src/components/search/lifestyle-tag-chips.tsx` with `'use client'` directive
-  - [ ] Import tag definitions from `@/lib/constants/lifestyle-tags` — use `LIFESTYLE_TAGS` constant (do NOT hardcode tag names):
+- [x] Task 4: Create `LifestyleTagChips` component (AC: #1, #2, #3, #6)
+  - [x] Create `src/components/search/lifestyle-tag-chips.tsx` with `'use client'` directive
+  - [x] Import tag definitions from `@/lib/constants/lifestyle-tags` — use `LIFESTYLE_TAGS` constant (do NOT hardcode tag names):
     ```ts
     import { LIFESTYLE_TAGS } from "@/lib/constants/lifestyle-tags";
     ```
-  - [ ] **CRITICAL**: The existing `LIFESTYLE_TAGS` array in `src/lib/constants/lifestyle-tags.ts` contains: `["Rental Potential", "Investment Property", "Vacation Home", "Retire", "Commercial"]`
-  - [ ] **DISCREPANCY**: The epic (AC #1) specifies "Retirement Paradise" but the constant uses "Retire". Story 3.4 must use "Retirement Paradise" as the display label while the stored tag value stays "Retire" (to avoid breaking Story 2.6 auto-tagging rules). Implement a display label map:
+  - [x] **CRITICAL**: The existing `LIFESTYLE_TAGS` array in `src/lib/constants/lifestyle-tags.ts` contains: `["Rental Potential", "Investment Property", "Vacation Home", "Retire", "Commercial"]`
+  - [x] **DISCREPANCY**: The epic (AC #1) specifies "Retirement Paradise" but the constant uses "Retire". Story 3.4 must use "Retirement Paradise" as the display label while the stored tag value stays "Retire" (to avoid breaking Story 2.6 auto-tagging rules). Implement a display label map:
     ```ts
     const TAG_DISPLAY_LABELS: Record<string, string> = {
       "Retire": "Retirement Paradise",
@@ -115,25 +115,25 @@ so that I can quickly find properties that match my goals without configuring ev
       return TAG_DISPLAY_LABELS[tag] ?? tag;
     }
     ```
-  - [ ] Props:
+  - [x] Props:
     ```ts
     interface LifestyleTagChipsProps {
       activeTags: string[];    // currently selected tags from URL state
       onToggle: (tag: string) => void;  // toggleTag from useSearchFilters
     }
     ```
-  - [ ] Render a horizontal scrollable row of chips (one per tag in `LIFESTYLE_TAGS`)
-  - [ ] Active chip style: `bg-brand-blue text-white` (same token as FilterChips in Story 3.3)
-  - [ ] Inactive chip style: `border border-border bg-background text-foreground hover:bg-accent`
-  - [ ] Chip min-height 44px (UX-DR7 touch targets)
-  - [ ] Each chip: `data-testid={`lifestyle-tag-chip-${tag.toLowerCase().replace(/\s+/g, '-')}`}`
-  - [ ] Container: `data-testid="lifestyle-tag-chips"` on root div
-  - [ ] No `× dismiss` button on individual chips (use `FilterChips` for that — see Task 6)
-  - [ ] Touch-friendly: chips should be `gap-2 flex-wrap md:flex-nowrap overflow-x-auto`
+  - [x] Render a horizontal scrollable row of chips (one per tag in `LIFESTYLE_TAGS`)
+  - [x] Active chip style: `bg-brand-blue text-white` (same token as FilterChips in Story 3.3)
+  - [x] Inactive chip style: `border border-border bg-background text-foreground hover:bg-accent`
+  - [x] Chip min-height 44px (UX-DR7 touch targets)
+  - [x] Each chip: `data-testid={`lifestyle-tag-chip-${tag.toLowerCase().replace(/\s+/g, '-')}`}`
+  - [x] Container: `data-testid="lifestyle-tag-chips"` on root div
+  - [x] No `× dismiss` button on individual chips (use `FilterChips` for that — see Task 6)
+  - [x] Touch-friendly: chips should be `gap-2 flex-wrap md:flex-nowrap overflow-x-auto`
 
-- [ ] Task 5: Create smart presets config (AC: #4, #5, #7)
-  - [ ] Create `src/lib/constants/search-presets.ts`
-  - [ ] Define `SearchPreset` type and `SEARCH_PRESETS` constant:
+- [x] Task 5: Create smart presets config (AC: #4, #5, #7)
+  - [x] Create `src/lib/constants/search-presets.ts`
+  - [x] Define `SearchPreset` type and `SEARCH_PRESETS` constant:
     ```ts
     import type { SearchFilters } from "@/types/search";
 
@@ -182,50 +182,50 @@ so that I can quickly find properties that match my goals without configuring ev
       },
     ];
     ```
-  - [ ] Presets are pure constants — adding a new preset = adding one object here, zero other code changes (AC #7)
-  - [ ] **NOTE**: The epic specifies "Mountain Retirement Homes" applies `region=mountain, type=house, lifestyle_tag=Retirement Paradise`. The `region` filter doesn't exist in the current `SearchFilters` — use `areaSlug` as the closest equivalent (Pérez Zeledón = mountain region). Do NOT add a `region` field to `SearchFilters` (out of scope for this story).
+  - [x] Presets are pure constants — adding a new preset = adding one object here, zero other code changes (AC #7)
+  - [x] **NOTE**: The epic specifies "Mountain Retirement Homes" applies `region=mountain, type=house, lifestyle_tag=Retirement Paradise`. The `region` filter doesn't exist in the current `SearchFilters` — use `areaSlug` as the closest equivalent (Pérez Zeledón = mountain region). Do NOT add a `region` field to `SearchFilters` (out of scope for this story).
 
-- [ ] Task 6: Create `SmartPresetBar` component (AC: #4, #5)
-  - [ ] Create `src/components/search/smart-preset-bar.tsx` with `'use client'` directive
-  - [ ] Props:
+- [x] Task 6: Create `SmartPresetBar` component (AC: #4, #5)
+  - [x] Create `src/components/search/smart-preset-bar.tsx` with `'use client'` directive
+  - [x] Props:
     ```ts
     interface SmartPresetBarProps {
       presets?: SearchPreset[];  // defaults to SEARCH_PRESETS from constants
     }
     ```
-  - [ ] Import `SEARCH_PRESETS` from `@/lib/constants/search-presets`
-  - [ ] Import `useRouter` from `next/navigation` and `useLocale` from `next-intl`
-  - [ ] On preset click: build URL `/[locale]/search?` + serialize the preset's `filters` into URL params, then `router.push(url)`
-  - [ ] URL serialization for preset filters: reuse the same param naming from `useSearchFilters`:
+  - [x] Import `SEARCH_PRESETS` from `@/lib/constants/search-presets`
+  - [x] Import `useRouter` from `next/navigation` and `useLocale` from `next-intl`
+  - [x] On preset click: build URL `/[locale]/search?` + serialize the preset's `filters` into URL params, then `router.push(url)`
+  - [x] URL serialization for preset filters: reuse the same param naming from `useSearchFilters`:
     - `type` → `type`
     - `areaSlug` → `area`
     - `tags` → `tags` (comma-separated)
     - `priceMin` → `price_min`, `priceMax` → `price_max`
-  - [ ] **IMPORTANT**: Do NOT duplicate the serialization logic — export a helper from `use-search-filters.ts`:
+  - [x] **IMPORTANT**: Do NOT duplicate the serialization logic — export a helper from `use-search-filters.ts`:
     ```ts
     export function buildSearchUrl(pathname: string, filters: SearchFilters): string
     ```
     This prevents divergence between preset URL generation and filter bar URL writing.
-  - [ ] `data-testid="smart-preset-bar"` on root div
-  - [ ] `data-testid={`preset-${preset.id}`}` on each preset button
-  - [ ] Horizontal scrollable row, same as lifestyle tag chips layout
-  - [ ] Desktop: visible in filter bar area or as a sub-row below the main filter bar
-  - [ ] Presets are displayed as pill-shaped buttons with icon + label
+  - [x] `data-testid="smart-preset-bar"` on root div
+  - [x] `data-testid={`preset-${preset.id}`}` on each preset button
+  - [x] Horizontal scrollable row, same as lifestyle tag chips layout
+  - [x] Desktop: visible in filter bar area or as a sub-row below the main filter bar
+  - [x] Presets are displayed as pill-shaped buttons with icon + label
 
-- [ ] Task 7: Integrate `LifestyleTagChips` into `SearchFilterBar` (AC: #1, #2, #3)
-  - [ ] Modify `src/components/search/search-filter-bar.tsx`
-  - [ ] Import `LifestyleTagChips` from `@/components/search/lifestyle-tag-chips`
-  - [ ] Import `toggleTag` from the updated `useSearchFilters` hook return
-  - [ ] Add lifestyle tag chips row to the filter controls:
+- [x] Task 7: Integrate `LifestyleTagChips` into `SearchFilterBar` (AC: #1, #2, #3)
+  - [x] Modify `src/components/search/search-filter-bar.tsx`
+  - [x] Import `LifestyleTagChips` from `@/components/search/lifestyle-tag-chips`
+  - [x] Import `toggleTag` from the updated `useSearchFilters` hook return
+  - [x] Add lifestyle tag chips row to the filter controls:
     - Desktop: add as a section within `filterControls` (horizontal chips row)
     - Mobile Sheet: include in the Sheet content alongside other filters
-  - [ ] Pass `activeTags={filters.tags ?? []}` and `onToggle={toggleTag}` to `LifestyleTagChips`
-  - [ ] **DO NOT break** any existing test assertions on `SearchFilterBar` (see preserved contracts below)
+  - [x] Pass `activeTags={filters.tags ?? []}` and `onToggle={toggleTag}` to `LifestyleTagChips`
+  - [x] **DO NOT break** any existing test assertions on `SearchFilterBar` (see preserved contracts below)
 
-- [ ] Task 8: Extend `FilterChips` to display active lifestyle tags (AC: #6)
-  - [ ] Modify `src/components/search/filter-chips.tsx`
-  - [ ] The `FilterChips` component currently renders one chip per active `SearchFilters` key
-  - [ ] Add handling for `tags` array: render one chip per tag in `filters.tags`:
+- [x] Task 8: Extend `FilterChips` to display active lifestyle tags (AC: #6)
+  - [x] Modify `src/components/search/filter-chips.tsx`
+  - [x] The `FilterChips` component currently renders one chip per active `SearchFilters` key
+  - [x] Add handling for `tags` array: render one chip per tag in `filters.tags`:
     - Chip format: `"Lifestyle: Retirement Paradise ×"` — use a `TAG_DISPLAY_LABELS` map
     - **IMPORTANT**: Place `TAG_DISPLAY_LABELS` in `src/lib/constants/lifestyle-tags.ts` (already imported by both `LifestyleTagChips` and `FilterChips`). Add to that file:
       ```ts
@@ -260,17 +260,17 @@ so that I can quickly find properties that match my goals without configuring ev
       // For all existing chips, set reactKey = key
       // For tag chips, set reactKey = `tags-${tag}`
       ```
-  - [ ] **`activeFilterCount` in `FilterChips`**: The component has its own local `activeFilterCount` (line ~100) that drives "Clear all" visibility. Update it to also count tags:
+  - [x] **`activeFilterCount` in `FilterChips`**: The component has its own local `activeFilterCount` (line ~100) that drives "Clear all" visibility. Update it to also count tags:
     ```ts
     const activeFilterCount = CHIP_KEYS.filter(key => {
       const val = filters[key];
       return val !== undefined && val !== null;
     }).length + (filters.tags?.length ?? 0);
     ```
-  - [ ] Do NOT break existing test: `data-testid="filter-chips"`, `data-testid="clear-all-filters"`
+  - [x] Do NOT break existing test: `data-testid="filter-chips"`, `data-testid="clear-all-filters"`
 
-- [ ] Task 9: Add i18n keys (AC: #1, #4, #5)
-  - [ ] Modify `src/messages/en.json` — add under `"SearchPage"`:
+- [x] Task 9: Add i18n keys (AC: #1, #4, #5)
+  - [x] Modify `src/messages/en.json` — add under `"SearchPage"`:
     ```json
     "lifestyleTags": {
       "label": "Lifestyle",
@@ -290,7 +290,7 @@ so that I can quickly find properties that match my goals without configuring ev
       "vacationHome": "Vacation Homes"
     }
     ```
-  - [ ] Modify `src/messages/es.json` — add equivalent Spanish keys:
+  - [x] Modify `src/messages/es.json` — add equivalent Spanish keys:
     ```json
     "lifestyleTags": {
       "label": "Estilo de vida",
@@ -311,8 +311,8 @@ so that I can quickly find properties that match my goals without configuring ev
     }
     ```
 
-- [ ] Task 10: Tests (AC: all)
-  - [ ] Create `tests/unit/search/lifestyle-tag-chips.spec.tsx` (Vitest + jsdom)
+- [x] Task 10: Tests (AC: all)
+  - [x] Create `tests/unit/search/lifestyle-tag-chips.spec.tsx` (Vitest + jsdom)
     - Mock `next/navigation`, `next-intl`
     - Mock `@/lib/constants/lifestyle-tags` to return `["Rental Potential", "Investment Property", "Vacation Home", "Retire", "Commercial"]`
     - Test: renders `data-testid="lifestyle-tag-chips"`
@@ -321,31 +321,31 @@ so that I can quickly find properties that match my goals without configuring ev
     - Test: active tag chip has `bg-brand-blue` class
     - Test: clicking a chip calls `onToggle` with the correct tag value
     - Test: inactive chip does NOT have `bg-brand-blue`
-  - [ ] Create `tests/unit/search/smart-preset-bar.spec.tsx` (Vitest + jsdom)
+  - [x] Create `tests/unit/search/smart-preset-bar.spec.tsx` (Vitest + jsdom)
     - Mock `next/navigation` (useRouter)
     - Mock `next-intl` (useTranslations, useLocale)
     - Mock `@/lib/constants/search-presets`
     - Test: renders `data-testid="smart-preset-bar"`
     - Test: renders one button per preset with `data-testid="preset-{id}"`
     - Test: clicking a preset calls `router.push` with correct URL containing expected params (`type=Casa`, `area=perez-zeledon`, `tags=Retire` for mountain-retirement)
-  - [ ] Update `tests/unit/search/use-search-filters.spec.tsx`
+  - [x] Update `tests/unit/search/use-search-filters.spec.tsx`
     - Add test: `toggleTag` adds a tag when not present
     - Add test: `toggleTag` removes a tag when already present
     - Add test: `filters.tags` parsed correctly from URL `?tags=Investment+Property,Rental+Potential`
     - Add test: `activeFilterCount` includes tags count
-  - [ ] Update `tests/unit/search/search-filter-bar.spec.tsx`
+  - [x] Update `tests/unit/search/search-filter-bar.spec.tsx`
     - Add `LifestyleTagChips` mock in the vi.mock section (same hoisting pattern as existing mocks)
     - Test: lifestyle tag chips section renders
-  - [ ] Update `tests/unit/search/filter-chips.spec.tsx`
+  - [x] Update `tests/unit/search/filter-chips.spec.tsx`
     - Test: renders chips for active tags in `filters.tags`
     - Test: "Retire" tag chip shows "Retirement Paradise" display label
 
-- [ ] Task 11: CI verification (AC: all)
-  - [ ] `npm run typecheck` → 0 new errors
-  - [ ] `npm run lint` → 0 errors
-  - [ ] `npm run format:check` → pass
-  - [ ] `npm run build` → pass
-  - [ ] `npm test` → all existing tests pass + new lifestyle tag tests pass
+- [x] Task 11: CI verification (AC: all)
+  - [x] `npm run typecheck` → 0 new errors
+  - [x] `npm run lint` → 0 errors
+  - [x] `npm run format:check` → pass
+  - [x] `npm run build` → pass
+  - [x] `npm test` → all existing tests pass + new lifestyle tag tests pass
 
 ## Dev Notes
 
@@ -472,15 +472,15 @@ export const LIFESTYLE_TAGS = [
 
 ### Architecture Compliance Checklist
 
-- [ ] `tags` field added to `SearchFilters` in `src/types/search.ts` — import from there, never redefine
-- [ ] `tags` URL param uses comma-separated string: `?tags=Retire,Investment+Property`
-- [ ] `LifestyleTagChips` is `'use client'` (interactive DOM)
-- [ ] `SmartPresetBar` is `'use client'` (uses `useRouter`)
-- [ ] `search-presets.ts` has NO `"use client"` or `"server-only"` (neutral constants)
-- [ ] `lifestyle-tags.ts` NOT modified (frozen — Story 2.6 tagger depends on it)
-- [ ] `searchProperties` Server Action uses `&&` operator with GIN index
-- [ ] `toggleTag` helper exported from `useSearchFilters` hook
-- [ ] `buildSearchUrl` helper exported from `use-search-filters.ts` for preset URL generation
+- [x] `tags` field added to `SearchFilters` in `src/types/search.ts` — import from there, never redefine
+- [x] `tags` URL param uses comma-separated string: `?tags=Retire,Investment+Property`
+- [x] `LifestyleTagChips` is `'use client'` (interactive DOM)
+- [x] `SmartPresetBar` is `'use client'` (uses `useRouter`)
+- [x] `search-presets.ts` has NO `"use client"` or `"server-only"` (neutral constants)
+- [x] `lifestyle-tags.ts` NOT modified (frozen — Story 2.6 tagger depends on it)
+- [x] `searchProperties` Server Action uses `&&` operator with GIN index
+- [x] `toggleTag` helper exported from `useSearchFilters` hook
+- [x] `buildSearchUrl` helper exported from `use-search-filters.ts` for preset URL generation
 
 ### Test Patterns — Mandatory (from Stories 3.1–3.3 Learnings)
 
@@ -633,12 +633,39 @@ claude-sonnet-4-6
 
 ### Completion Notes List
 
-(to be filled by dev agent)
+- All 11 tasks implemented and verified with 423 passing tests (59 new tests added)
+- Task 1: SearchFilters.tags already in ATDD stub — confirmed correct
+- Task 2: Implemented tags parsing, toggleTag helper, updated activeFilterCount, buildSearchUrl fully using PARAM_MAP
+- Task 3: Added tags to dimConditions in search-actions.ts using PostgreSQL && operator on GIN-indexed array
+- Task 4: Added TAG_DISPLAY_LABELS and tagDisplayLabel to lifestyle-tags.ts; LifestyleTagChips component complete
+- Task 5: Created search-presets.ts with SearchPreset type and SEARCH_PRESETS constant (4 presets)
+- Task 6: SmartPresetBar complete — uses buildSearchUrl, router.push for full navigation
+- Task 7: Integrated LifestyleTagChips into SearchFilterBar filterControls
+- Task 8: Extended FilterChips with tag chips, reactKey field for unique React keys, updated activeFilterCount
+- Task 9: Added lifestyleTags + presets i18n keys to en.json and es.json
+- Task 10: All ATDD tests pass; fixed require() ESM bug in smart-preset-bar.spec.tsx; fixed lint in use-search-filters.spec.tsx
+- Task 11: typecheck 0 errors, lint 0 errors, format pass, build pass, 423 tests passing
 
 ### File List
 
-(to be filled by dev agent)
+- src/types/search.ts
+- src/hooks/use-search-filters.ts
+- src/app/actions/search-actions.ts
+- src/lib/constants/lifestyle-tags.ts
+- src/lib/constants/search-presets.ts
+- src/components/search/lifestyle-tag-chips.tsx
+- src/components/search/smart-preset-bar.tsx
+- src/components/search/search-filter-bar.tsx
+- src/components/search/filter-chips.tsx
+- src/messages/en.json
+- src/messages/es.json
+- tests/unit/search/lifestyle-tag-chips.spec.tsx
+- tests/unit/search/smart-preset-bar.spec.tsx
+- tests/unit/search/use-search-filters.spec.tsx
+- tests/unit/search/filter-chips.spec.tsx
+- tests/unit/search/search-filter-bar.spec.tsx
 
 ### Change Log
 
 - 2026-05-01: Story 3.4 created — lifestyle tags & smart presets, status → ready-for-dev
+- 2026-05-01: Story 3.4 implemented — all 11 tasks complete, 423 tests passing, status → review

--- a/_bmad-output/implementation-artifacts/3-4-lifestyle-tags-and-smart-presets.md
+++ b/_bmad-output/implementation-artifacts/3-4-lifestyle-tags-and-smart-presets.md
@@ -2,7 +2,7 @@
 
 **GH Issue:** #88
 
-Status: review
+Status: done
 
 ## Story
 
@@ -669,3 +669,13 @@ claude-sonnet-4-6
 
 - 2026-05-01: Story 3.4 created — lifestyle tags & smart presets, status → ready-for-dev
 - 2026-05-01: Story 3.4 implemented — all 11 tasks complete, 423 tests passing, status → review
+- 2026-05-01: Code review applied — i18n wiring fixes, defensive tag sanitisation, button-type hardening; 426 tests passing, status → done
+
+### Review Findings
+
+- [x] [Review][Patch] SmartPresetBar rendered raw `labelKey` instead of translating it [src/components/search/smart-preset-bar.tsx:51] — fixed: now reads `t("presets.{labelKey}")` with safe fallback
+- [x] [Review][Patch] LifestyleTagChips and FilterChips ignored `lifestyleTags.chips.*` i18n keys (Spanish locale showed English labels) [src/components/search/lifestyle-tag-chips.tsx, src/components/search/filter-chips.tsx] — fixed: both now consult `useTranslations("SearchPage")` and fall back to `tagDisplayLabel()`
+- [x] [Review][Patch] Tag/preset buttons missing `type="button"` (would submit ancestor forms) [smart-preset-bar.tsx, lifestyle-tag-chips.tsx] — fixed
+- [x] [Review][Patch] `searchProperties` Server Action did not sanitize `filters.tags` (publicly callable surface, no length cap) [src/app/actions/search-actions.ts] — fixed: trims, drops empties/non-strings, caps at 20 entries
+- [x] [Review][Defer] Add `aria-label` / `role="group"` to LifestyleTagChips container — pre-existing a11y polish, deferred
+- [x] [Review][Defer] `latestParamsRef.current` mutation during render in `useSearchFilters` — pre-existing pattern from Story 3.3, deferred

--- a/_bmad-output/implementation-artifacts/3-4-lifestyle-tags-and-smart-presets.md
+++ b/_bmad-output/implementation-artifacts/3-4-lifestyle-tags-and-smart-presets.md
@@ -1,0 +1,644 @@
+# Story 3.4: Lifestyle Tags & Smart Presets
+
+**GH Issue:** #88
+
+Status: ready-for-dev
+
+## Story
+
+As a **visitor**,
+I want to browse by lifestyle category or use preset searches,
+so that I can quickly find properties that match my goals without configuring every filter.
+
+## Acceptance Criteria
+
+1. **Given** the filter bar **When** lifestyle tag chips are displayed **Then** options include: "Investment Property," "Rental Potential," "Vacation Home," "Retirement Paradise," "Commercial" (FR4).
+
+2. **Given** a lifestyle tag chip **When** tapped **Then** it toggles active state (highlighted with `--color-blue-bright` / `bg-brand-blue`) and filters results immediately (FR4).
+
+3. **Given** multiple lifestyle tags **When** selected simultaneously **Then** results match ANY of the selected tags (OR logic).
+
+4. **Given** smart search presets **When** displayed (e.g., homepage or search page) **Then** they combine pre-configured filter + lifestyle tag combinations (FR15).
+
+5. **Given** a smart preset like "Mountain Retirement Homes" **When** clicked **Then** it applies: region=mountain, type=house, lifestyle_tag=Retirement Paradise, and navigates to search with those URL params.
+
+6. **And** active lifestyle tags appear as chips in the active filter display.
+
+7. **And** presets are configurable without code changes (JSON config or DB — use a `constants/` file, not DB, for MVP).
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Extend `SearchFilters` type with `tags` field (AC: #1, #2, #3)
+  - [ ] Modify `src/types/search.ts` — add `tags?: string[]` field to `SearchFilters`:
+    ```ts
+    export interface SearchFilters {
+      // ... existing fields ...
+      tags?: string[];  // URL param: "tags" (comma-separated values)
+    }
+    ```
+  - [ ] The `tags` URL param uses comma-separated values: `?tags=Investment+Property,Rental+Potential`
+  - [ ] `tags` MUST count toward `activeFilterCount` — per AC #6, active lifestyle tags appear as chips in the active filter display
+  - [ ] **`activeFilterCount` for tags**: count each selected tag individually (2 selected tags = +2 to count, not just +1). Do NOT add `tags` to `FILTER_KEYS` (the existing per-key check counts 1 per key). Instead, replace the `activeFilterCount` `useMemo` in `use-search-filters.ts` with:
+    ```ts
+    const activeFilterCount = useMemo(() => {
+      const scalarCount = FILTER_KEYS.filter(key => {
+        const value = filters[key];
+        return value !== undefined && value !== null;
+      }).length;
+      const tagsCount = filters.tags?.length ?? 0;
+      return scalarCount + tagsCount;
+    }, [filters]);
+    ```
+    (Keep `FILTER_KEYS` as the existing 8 scalar keys — do NOT add `tags` to that array)
+
+- [ ] Task 2: Extend `useSearchFilters` hook for tags URL state (AC: #2, #3, #6)
+  - [ ] Modify `src/hooks/use-search-filters.ts`
+  - [ ] Add `tags` to `PARAM_MAP`: `tags: "tags"`
+  - [ ] Do NOT add `tags` to `FILTER_KEYS` — instead extend the `activeFilterCount` useMemo as specified in Task 1 (counts each tag individually)
+  - [ ] Add `tags` parsing in `parseFilters()`:
+    ```ts
+    const tagsParam = params.get("tags");
+    if (tagsParam) {
+      const parsed = tagsParam.split(",").map(t => decodeURIComponent(t.trim())).filter(Boolean);
+      if (parsed.length > 0) filters.tags = parsed;
+    }
+    ```
+  - [ ] Add `tags` serialization in `serializeValue()`: join array with comma (`tags.join(",")`)
+  - [ ] `tags` is NOT a debounced key (instant update when chip is toggled)
+  - [ ] The `setFilter('tags', ...)` call expects `string[] | undefined` — toggling a single tag requires reading the current array, adding/removing the tag, and calling `setFilter('tags', newArray)`. Implement a new helper: `toggleTag(tag: string): void` on the hook return:
+    ```ts
+    toggleTag: (tag: string) => void;
+    ```
+    Implementation — use `latestParamsRef.current` (NOT `filters.tags`) to avoid stale closure on rapid clicks:
+    ```ts
+    const toggleTag = useCallback((tag: string) => {
+      // Read from latestParamsRef to get freshest state (avoids stale closure race)
+      const currentTagsParam = latestParamsRef.current.get("tags");
+      const current = currentTagsParam
+        ? currentTagsParam.split(",").map(t => decodeURIComponent(t.trim())).filter(Boolean)
+        : [];
+      const next = current.includes(tag)
+        ? current.filter(t => t !== tag)
+        : [...current, tag];
+      setFilter('tags', next.length > 0 ? next : undefined);
+    }, [setFilter]);
+    ```
+    Note: `latestParamsRef` is already maintained in the hook — this is the same pattern used by `performUpdate` for debounced numeric filters.
+  - [ ] Update `UseSearchFiltersReturn` interface to include `toggleTag`
+
+- [ ] Task 3: Extend `searchProperties` Server Action to filter by lifestyle tags (AC: #3, #1)
+  - [ ] Modify `src/app/actions/search-actions.ts`
+  - [ ] Add `tags` to `dimConditions` map — use the architecture §6 pattern:
+    ```ts
+    tags: filters.tags?.length
+      ? sql`${properties.lifestyleTags} && ${filters.tags}`
+      : undefined,
+    ```
+  - [ ] In Drizzle ORM 0.44 (the project version), passing a JS `string[]` as a parameter in `sql` template literals serializes it as a PostgreSQL text array. This is the pattern the architecture §6 specifies explicitly.
+  - [ ] The `&&` (overlap) operator on `text[]` implements OR logic (any tag matches) — this uses the `idx_properties_tags` GIN index (already exists on the schema)
+  - [ ] **DB schema**: `properties.lifestyleTags` = `text("lifestyle_tags").array().$type<string[]>()` (confirmed in `src/lib/db/schema/properties.ts` line ~40)
+  - [ ] **GIN index** `idx_properties_tags` already created in schema — no migration needed
+
+- [ ] Task 4: Create `LifestyleTagChips` component (AC: #1, #2, #3, #6)
+  - [ ] Create `src/components/search/lifestyle-tag-chips.tsx` with `'use client'` directive
+  - [ ] Import tag definitions from `@/lib/constants/lifestyle-tags` — use `LIFESTYLE_TAGS` constant (do NOT hardcode tag names):
+    ```ts
+    import { LIFESTYLE_TAGS } from "@/lib/constants/lifestyle-tags";
+    ```
+  - [ ] **CRITICAL**: The existing `LIFESTYLE_TAGS` array in `src/lib/constants/lifestyle-tags.ts` contains: `["Rental Potential", "Investment Property", "Vacation Home", "Retire", "Commercial"]`
+  - [ ] **DISCREPANCY**: The epic (AC #1) specifies "Retirement Paradise" but the constant uses "Retire". Story 3.4 must use "Retirement Paradise" as the display label while the stored tag value stays "Retire" (to avoid breaking Story 2.6 auto-tagging rules). Implement a display label map:
+    ```ts
+    const TAG_DISPLAY_LABELS: Record<string, string> = {
+      "Retire": "Retirement Paradise",
+    };
+    function tagDisplayLabel(tag: string): string {
+      return TAG_DISPLAY_LABELS[tag] ?? tag;
+    }
+    ```
+  - [ ] Props:
+    ```ts
+    interface LifestyleTagChipsProps {
+      activeTags: string[];    // currently selected tags from URL state
+      onToggle: (tag: string) => void;  // toggleTag from useSearchFilters
+    }
+    ```
+  - [ ] Render a horizontal scrollable row of chips (one per tag in `LIFESTYLE_TAGS`)
+  - [ ] Active chip style: `bg-brand-blue text-white` (same token as FilterChips in Story 3.3)
+  - [ ] Inactive chip style: `border border-border bg-background text-foreground hover:bg-accent`
+  - [ ] Chip min-height 44px (UX-DR7 touch targets)
+  - [ ] Each chip: `data-testid={`lifestyle-tag-chip-${tag.toLowerCase().replace(/\s+/g, '-')}`}`
+  - [ ] Container: `data-testid="lifestyle-tag-chips"` on root div
+  - [ ] No `× dismiss` button on individual chips (use `FilterChips` for that — see Task 6)
+  - [ ] Touch-friendly: chips should be `gap-2 flex-wrap md:flex-nowrap overflow-x-auto`
+
+- [ ] Task 5: Create smart presets config (AC: #4, #5, #7)
+  - [ ] Create `src/lib/constants/search-presets.ts`
+  - [ ] Define `SearchPreset` type and `SEARCH_PRESETS` constant:
+    ```ts
+    import type { SearchFilters } from "@/types/search";
+
+    export interface SearchPreset {
+      id: string;           // unique slug, used in URL and as key
+      labelKey: string;     // i18n key under "SearchPage.presets"
+      filters: SearchFilters; // the filter set to apply on click
+      icon?: string;        // optional emoji or icon name
+    }
+
+    export const SEARCH_PRESETS: SearchPreset[] = [
+      {
+        id: "mountain-retirement",
+        labelKey: "mountainRetirement",
+        icon: "🏔️",
+        filters: {
+          areaSlug: "perez-zeledon",
+          type: "Casa",
+          tags: ["Retire"],
+        },
+      },
+      {
+        id: "beach-investment",
+        labelKey: "beachInvestment",
+        icon: "🌊",
+        filters: {
+          areaSlug: "uvita",
+          tags: ["Investment Property"],
+        },
+      },
+      {
+        id: "rental-potential",
+        labelKey: "rentalPotential",
+        icon: "💰",
+        filters: {
+          tags: ["Rental Potential"],
+        },
+      },
+      {
+        id: "vacation-home",
+        labelKey: "vacationHome",
+        icon: "🏖️",
+        filters: {
+          tags: ["Vacation Home"],
+        },
+      },
+    ];
+    ```
+  - [ ] Presets are pure constants — adding a new preset = adding one object here, zero other code changes (AC #7)
+  - [ ] **NOTE**: The epic specifies "Mountain Retirement Homes" applies `region=mountain, type=house, lifestyle_tag=Retirement Paradise`. The `region` filter doesn't exist in the current `SearchFilters` — use `areaSlug` as the closest equivalent (Pérez Zeledón = mountain region). Do NOT add a `region` field to `SearchFilters` (out of scope for this story).
+
+- [ ] Task 6: Create `SmartPresetBar` component (AC: #4, #5)
+  - [ ] Create `src/components/search/smart-preset-bar.tsx` with `'use client'` directive
+  - [ ] Props:
+    ```ts
+    interface SmartPresetBarProps {
+      presets?: SearchPreset[];  // defaults to SEARCH_PRESETS from constants
+    }
+    ```
+  - [ ] Import `SEARCH_PRESETS` from `@/lib/constants/search-presets`
+  - [ ] Import `useRouter` from `next/navigation` and `useLocale` from `next-intl`
+  - [ ] On preset click: build URL `/[locale]/search?` + serialize the preset's `filters` into URL params, then `router.push(url)`
+  - [ ] URL serialization for preset filters: reuse the same param naming from `useSearchFilters`:
+    - `type` → `type`
+    - `areaSlug` → `area`
+    - `tags` → `tags` (comma-separated)
+    - `priceMin` → `price_min`, `priceMax` → `price_max`
+  - [ ] **IMPORTANT**: Do NOT duplicate the serialization logic — export a helper from `use-search-filters.ts`:
+    ```ts
+    export function buildSearchUrl(pathname: string, filters: SearchFilters): string
+    ```
+    This prevents divergence between preset URL generation and filter bar URL writing.
+  - [ ] `data-testid="smart-preset-bar"` on root div
+  - [ ] `data-testid={`preset-${preset.id}`}` on each preset button
+  - [ ] Horizontal scrollable row, same as lifestyle tag chips layout
+  - [ ] Desktop: visible in filter bar area or as a sub-row below the main filter bar
+  - [ ] Presets are displayed as pill-shaped buttons with icon + label
+
+- [ ] Task 7: Integrate `LifestyleTagChips` into `SearchFilterBar` (AC: #1, #2, #3)
+  - [ ] Modify `src/components/search/search-filter-bar.tsx`
+  - [ ] Import `LifestyleTagChips` from `@/components/search/lifestyle-tag-chips`
+  - [ ] Import `toggleTag` from the updated `useSearchFilters` hook return
+  - [ ] Add lifestyle tag chips row to the filter controls:
+    - Desktop: add as a section within `filterControls` (horizontal chips row)
+    - Mobile Sheet: include in the Sheet content alongside other filters
+  - [ ] Pass `activeTags={filters.tags ?? []}` and `onToggle={toggleTag}` to `LifestyleTagChips`
+  - [ ] **DO NOT break** any existing test assertions on `SearchFilterBar` (see preserved contracts below)
+
+- [ ] Task 8: Extend `FilterChips` to display active lifestyle tags (AC: #6)
+  - [ ] Modify `src/components/search/filter-chips.tsx`
+  - [ ] The `FilterChips` component currently renders one chip per active `SearchFilters` key
+  - [ ] Add handling for `tags` array: render one chip per tag in `filters.tags`:
+    - Chip format: `"Lifestyle: Retirement Paradise ×"` — use a `TAG_DISPLAY_LABELS` map
+    - **IMPORTANT**: Place `TAG_DISPLAY_LABELS` in `src/lib/constants/lifestyle-tags.ts` (already imported by both `LifestyleTagChips` and `FilterChips`). Add to that file:
+      ```ts
+      export const TAG_DISPLAY_LABELS: Record<string, string> = {
+        "Retire": "Retirement Paradise",
+      };
+      export function tagDisplayLabel(tag: string): string {
+        return TAG_DISPLAY_LABELS[tag] ?? tag;
+      }
+      ```
+    - On dismiss (× click): each tag chip calls `onClearFilter('tags')` which removes ALL tags — the tag chips in `LifestyleTagChips` are the per-tag deselection affordance (re-tap to deselect). This is the MVP approach.
+    - **Per-tag chip in FilterChips**: iterate `filters.tags` and render a chip per tag:
+      ```ts
+      // In FilterChips, after areaSlug chip:
+      (filters.tags ?? []).forEach(tag => {
+        chips.push({
+          key: "tags",  // all tag chips use the same key
+          label: t("lifestyleTags.label"),
+          value: tagDisplayLabel(tag),
+        });
+      });
+      ```
+      Note: clicking × on any tag chip calls `onClearFilter('tags')` which clears ALL tags (MVP). The tag chip row provides per-tag toggle.
+    - **React key for tag chips**: Since multiple tags share `key: "tags"`, use `tag` value as the React key instead: change the chip `.map()` key from `chip.key` to a unique value. For tag chips, use key=`tag-${tag}`. The `ChipInfo` type should include optional `reactKey?: string`; or simply push objects with `key: \`tags-${tag}\`` as a workaround (TypeScript: use type assertion or widen the `key` type). **Simplest fix**: add a `reactKey` field to `ChipInfo`:
+      ```ts
+      interface ChipInfo {
+        key: keyof SearchFilters;
+        reactKey: string;  // unique key for React rendering
+        label: string;
+        value: string;
+      }
+      // For all existing chips, set reactKey = key
+      // For tag chips, set reactKey = `tags-${tag}`
+      ```
+  - [ ] **`activeFilterCount` in `FilterChips`**: The component has its own local `activeFilterCount` (line ~100) that drives "Clear all" visibility. Update it to also count tags:
+    ```ts
+    const activeFilterCount = CHIP_KEYS.filter(key => {
+      const val = filters[key];
+      return val !== undefined && val !== null;
+    }).length + (filters.tags?.length ?? 0);
+    ```
+  - [ ] Do NOT break existing test: `data-testid="filter-chips"`, `data-testid="clear-all-filters"`
+
+- [ ] Task 9: Add i18n keys (AC: #1, #4, #5)
+  - [ ] Modify `src/messages/en.json` — add under `"SearchPage"`:
+    ```json
+    "lifestyleTags": {
+      "label": "Lifestyle",
+      "chips": {
+        "Rental Potential": "Rental Potential",
+        "Investment Property": "Investment Property",
+        "Vacation Home": "Vacation Home",
+        "Retire": "Retirement Paradise",
+        "Commercial": "Commercial"
+      }
+    },
+    "presets": {
+      "label": "Quick Searches",
+      "mountainRetirement": "Mountain Retirement Homes",
+      "beachInvestment": "Beach Investment Land",
+      "rentalPotential": "Rental Income Properties",
+      "vacationHome": "Vacation Homes"
+    }
+    ```
+  - [ ] Modify `src/messages/es.json` — add equivalent Spanish keys:
+    ```json
+    "lifestyleTags": {
+      "label": "Estilo de vida",
+      "chips": {
+        "Rental Potential": "Potencial de renta",
+        "Investment Property": "Propiedad de inversión",
+        "Vacation Home": "Casa vacacional",
+        "Retire": "Paraíso de retiro",
+        "Commercial": "Comercial"
+      }
+    },
+    "presets": {
+      "label": "Búsquedas rápidas",
+      "mountainRetirement": "Casas de retiro en la montaña",
+      "beachInvestment": "Terrenos de inversión en la playa",
+      "rentalPotential": "Propiedades para renta",
+      "vacationHome": "Casas vacacionales"
+    }
+    ```
+
+- [ ] Task 10: Tests (AC: all)
+  - [ ] Create `tests/unit/search/lifestyle-tag-chips.spec.tsx` (Vitest + jsdom)
+    - Mock `next/navigation`, `next-intl`
+    - Mock `@/lib/constants/lifestyle-tags` to return `["Rental Potential", "Investment Property", "Vacation Home", "Retire", "Commercial"]`
+    - Test: renders `data-testid="lifestyle-tag-chips"`
+    - Test: renders one chip per tag (5 chips total)
+    - Test: "Retire" tag renders with display label "Retirement Paradise"
+    - Test: active tag chip has `bg-brand-blue` class
+    - Test: clicking a chip calls `onToggle` with the correct tag value
+    - Test: inactive chip does NOT have `bg-brand-blue`
+  - [ ] Create `tests/unit/search/smart-preset-bar.spec.tsx` (Vitest + jsdom)
+    - Mock `next/navigation` (useRouter)
+    - Mock `next-intl` (useTranslations, useLocale)
+    - Mock `@/lib/constants/search-presets`
+    - Test: renders `data-testid="smart-preset-bar"`
+    - Test: renders one button per preset with `data-testid="preset-{id}"`
+    - Test: clicking a preset calls `router.push` with correct URL containing expected params (`type=Casa`, `area=perez-zeledon`, `tags=Retire` for mountain-retirement)
+  - [ ] Update `tests/unit/search/use-search-filters.spec.tsx`
+    - Add test: `toggleTag` adds a tag when not present
+    - Add test: `toggleTag` removes a tag when already present
+    - Add test: `filters.tags` parsed correctly from URL `?tags=Investment+Property,Rental+Potential`
+    - Add test: `activeFilterCount` includes tags count
+  - [ ] Update `tests/unit/search/search-filter-bar.spec.tsx`
+    - Add `LifestyleTagChips` mock in the vi.mock section (same hoisting pattern as existing mocks)
+    - Test: lifestyle tag chips section renders
+  - [ ] Update `tests/unit/search/filter-chips.spec.tsx`
+    - Test: renders chips for active tags in `filters.tags`
+    - Test: "Retire" tag chip shows "Retirement Paradise" display label
+
+- [ ] Task 11: CI verification (AC: all)
+  - [ ] `npm run typecheck` → 0 new errors
+  - [ ] `npm run lint` → 0 errors
+  - [ ] `npm run format:check` → pass
+  - [ ] `npm run build` → pass
+  - [ ] `npm test` → all existing tests pass + new lifestyle tag tests pass
+
+## Dev Notes
+
+### Critical Architecture Decisions — DO NOT VIOLATE
+
+**Tags filter MUST live in URL query params (AR10):**
+
+Consistent with all other search filters. URL param name is `tags`, value is comma-separated string:
+```
+/en/search?tags=Investment+Property,Rental+Potential
+```
+Do NOT store tags in Zustand or component state.
+
+**`LIFESTYLE_TAGS` constant is the single source of truth for tag names:**
+
+File: `src/lib/constants/lifestyle-tags.ts` (do NOT modify tag names — Story 2.6 auto-tagger depends on them).
+Current tags: `["Rental Potential", "Investment Property", "Vacation Home", "Retire", "Commercial"]`.
+The display label "Retirement Paradise" maps to the stored value "Retire" — use `tagDisplayLabel()` function.
+
+**GIN index `idx_properties_tags` already exists — use `&&` (overlap) operator:**
+
+Architecture §5 and DB schema: `idx_properties_tags` is `GIN` on `lifestyle_tags text[]`. The `&&` operator uses this index. For OR logic (any selected tag matches), `&&` is correct.
+
+**`search-actions.ts` must be extended (NOT replaced):**
+
+It is owned by Story 3.3. This story adds `tags` to the existing `dimConditions` map. Do NOT rewrite the entire file.
+
+**`LIFESTYLE_TAGS` file must remain without `"server-only"` or `"use client"`:**
+
+It is imported by both `lifestyle-tagger.ts` (server sync pipeline) and the new `LifestyleTagChips` (Client Component). Keep it as a neutral constants file.
+
+**Smart presets use client-side navigation (`router.push`), not URL manipulation:**
+
+Presets navigate to a fresh search URL. They do NOT modify the current filter state in-place. This is intentional — presets are discoverable entry points, not incremental filter changes.
+
+### Component File Map
+
+**New files to create:**
+```
+src/lib/constants/search-presets.ts             ← Smart preset definitions (configurable)
+src/components/search/lifestyle-tag-chips.tsx   ← Tag chip row component ('use client')
+src/components/search/smart-preset-bar.tsx      ← Smart preset buttons ('use client')
+```
+
+**Files to modify:**
+```
+src/types/search.ts                             ← Add tags?: string[] to SearchFilters
+src/hooks/use-search-filters.ts                 ← Add tags param + toggleTag helper
+src/app/actions/search-actions.ts               ← Add tags to dimConditions (&&  operator)
+src/components/search/search-filter-bar.tsx     ← Integrate LifestyleTagChips
+src/components/search/filter-chips.tsx          ← Handle tags array rendering
+src/messages/en.json                            ← Add lifestyleTags + presets keys
+src/messages/es.json                            ← Add Spanish equivalents
+```
+
+**Files to NOT touch (frozen):**
+```
+src/lib/constants/lifestyle-tags.ts             ← Story 2.6, tag names frozen (tagger depends on them)
+src/lib/sync/lifestyle-tagger.ts                ← Story 2.6, frozen
+src/app/actions/map-actions.ts                  ← Story 3.2, frozen
+src/store/map-store.ts                          ← Story 3.2, frozen
+src/lib/map/geo-utils.ts                        ← Story 3.2, frozen
+src/components/map/map-view.tsx                 ← Story 3.2, frozen
+src/lib/db/schema/properties.ts                 ← Epic 2, frozen
+src/lib/db/queries/properties.ts               ← Epic 2, frozen
+```
+
+### URL State Schema for Story 3.4
+
+New param:
+```
+/en/search?tags=Investment+Property,Rental+Potential&type=Casa&area=perez-zeledon
+```
+
+**Parsing rules for `tags`:**
+- Split by comma: `params.get("tags")?.split(",")`
+- Trim each value
+- Filter out empty strings
+- Decode URI components (spaces encoded as `+` or `%20`)
+- Result: `string[]` or `undefined` if empty
+
+**Serialization for `tags`:**
+- `tags.join(",")` — commas, no spaces (URL-encoded if needed by `URLSearchParams`)
+- `URLSearchParams.set("tags", tags.join(","))` handles encoding
+
+### DB Schema — Lifestyle Tags Column
+
+From `src/lib/db/schema/properties.ts`:
+```ts
+lifestyleTags: text("lifestyle_tags")
+  .array()
+  .$type<string[]>()
+  .default(sql`ARRAY[]::text[]`)
+  .notNull(),
+```
+
+PostgreSQL array column with GIN index. The `&&` (overlap) operator returns rows where the column array and the filter array share at least one element (OR logic).
+
+Architecture §6 query pattern (Drizzle 0.44 — JS array serialized as PostgreSQL text array):
+```ts
+filters.tags?.length
+  ? sql`${properties.lifestyleTags} && ${filters.tags}`
+  : undefined
+```
+
+### Existing Architecture — Do NOT Reinvent
+
+**`formatPriceAbbrev`**: Already in `src/lib/map/geo-utils.ts` — import if needed for preset price display.
+
+**`FilterChips`**: Already at `src/components/search/filter-chips.tsx` — EXTEND it to handle `tags`, do NOT create a separate tags chip component.
+
+**`Sheet`**: Already at `src/components/ui/sheet.tsx` — used by mobile filter bar. No new modal needed.
+
+**`LIFESTYLE_TAGS` constant**: Already in `src/lib/constants/lifestyle-tags.ts` — import from there. Current values:
+```ts
+export const LIFESTYLE_TAGS = [
+  "Rental Potential",
+  "Investment Property",
+  "Vacation Home",
+  "Retire",         // displayed as "Retirement Paradise"
+  "Commercial",
+] as const;
+```
+
+### Architecture Compliance Checklist
+
+- [ ] `tags` field added to `SearchFilters` in `src/types/search.ts` — import from there, never redefine
+- [ ] `tags` URL param uses comma-separated string: `?tags=Retire,Investment+Property`
+- [ ] `LifestyleTagChips` is `'use client'` (interactive DOM)
+- [ ] `SmartPresetBar` is `'use client'` (uses `useRouter`)
+- [ ] `search-presets.ts` has NO `"use client"` or `"server-only"` (neutral constants)
+- [ ] `lifestyle-tags.ts` NOT modified (frozen — Story 2.6 tagger depends on it)
+- [ ] `searchProperties` Server Action uses `&&` operator with GIN index
+- [ ] `toggleTag` helper exported from `useSearchFilters` hook
+- [ ] `buildSearchUrl` helper exported from `use-search-filters.ts` for preset URL generation
+
+### Test Patterns — Mandatory (from Stories 3.1–3.3 Learnings)
+
+1. **`vi.mock` hoisting**: Declare ALL mocks BEFORE component imports. Use `vi.hoisted()` when mock factory references a variable declared outside it (established in Story 3.3 `search-actions.spec.ts`).
+
+2. **jsdom env**: Files in `tests/unit/search/**/*.spec.tsx` automatically get jsdom (vitest.config.ts `environmentMatchGlobs`). Do NOT change the glob.
+
+3. **`.spec.ts` vs `.spec.tsx`**: Pure TS tests (utilities) use `.spec.ts` (Node env). React component/hook tests use `.spec.tsx` (jsdom env). The `toggleTag` hook test must be `.spec.tsx` (it uses React hooks).
+
+4. **Mock `next/navigation`**: Any component using `useRouter`, `useSearchParams`, or `usePathname` MUST mock `next/navigation`.
+
+5. **Mock `next-intl`**: Any component using `useTranslations` or `useLocale` MUST mock `next-intl`.
+
+6. **Mock `@/lib/constants/lifestyle-tags`**: Tests for `LifestyleTagChips` should mock this import to control the tag list in tests.
+
+7. **Existing test contracts that MUST be preserved** (do NOT break):
+   - `search-filter-bar.spec.tsx`: `data-testid="search-filter-bar"`, sticky/z-10/h-12/h-14 CSS classes, `data-testid="mobile-filters-button"`, `'use client'` directive
+   - `filter-chips.spec.tsx`: `data-testid="filter-chips"`, `data-testid="clear-all-filters"`
+   - `use-search-filters.spec.tsx`: existing `setFilter`, `clearAll`, `activeFilterCount` tests
+
+8. **`vi.mock` pattern for `LifestyleTagChips` in `search-filter-bar.spec.tsx`**:
+   ```ts
+   // At top, before any imports:
+   vi.mock("@/components/search/lifestyle-tag-chips", () => ({
+     LifestyleTagChips: () => <div data-testid="lifestyle-tag-chips" />,
+   }));
+   // Then import component under test:
+   import { SearchFilterBar } from "@/components/search/search-filter-bar"; // imported AFTER mocks
+   ```
+
+### Data Flow Diagram (Story 3.4 additions to Story 3.3 flow)
+
+```
+[page.tsx (Server RSC)]
+  └─► [SearchPageClient (Client, 'use client')]
+        ├─► useSearchFilters() ← reads URL params (now including "tags")
+        │     └─► filters: SearchFilters (from URL)
+        │           └─► filters.tags?: string[]  ← NEW
+        │
+        ├─► searchProperties(filters) [Server Action, search-actions.ts]
+        │     └─► PostgreSQL + idx_properties_tags (GIN)
+        │           └─► lifestyleTags && ARRAY[...tags]  ← NEW OR logic
+        │
+        ├─► [SearchFilterBar] ← receives filters, facets, setFilter, clearAll, toggleTag (NEW)
+        │     ├─► Type dropdown, Price slider, Beds/Baths dropdowns, Lot range, Area
+        │     ├─► [LifestyleTagChips] ← NEW: tag chip row (OR logic selection)
+        │     ├─► [FilterChips] ← extended to show active tags as chips
+        │     └─► Mobile: Sheet includes LifestyleTagChips
+        │
+        └─► [SplitViewLayout]
+              └─► Grid + Map (unchanged from Story 3.3)
+```
+
+### Story Scope Boundaries
+
+**This story DOES implement:**
+- `tags?: string[]` field in `SearchFilters`
+- `toggleTag` helper in `useSearchFilters` hook
+- `tags` URL param (comma-separated) encode/decode
+- `searchProperties` Server Action — add `tags` filter using `&&` operator and GIN index
+- `LifestyleTagChips` component (multi-select chip row)
+- `SmartPresetBar` component with configurable presets
+- `SEARCH_PRESETS` constant in `src/lib/constants/search-presets.ts`
+- Display label mapping ("Retire" → "Retirement Paradise")
+- `FilterChips` extension to show active tag chips
+- i18n keys for tag labels and preset names
+- Unit tests for all new components and updated hook
+
+**This story does NOT implement:**
+- Full Province → Cantón → Distrito drill-down (Epic 6)
+- Real property cards in grid view (Story 3.5)
+- `region` URL parameter (not in current `SearchFilters` — out of scope)
+- Admin UI for managing lifestyle tags (Epic 8, Story 8.4)
+- PropertyCard display of lifestyle tag badges (Story 3.5)
+- "Near Me" button (Story 3.8)
+- Playwright E2E tests (ATDD phase, separate step)
+- Pagination (Story 3.5)
+
+### Previous Story Intelligence (Story 3.3)
+
+1. **`use-search-filters.ts` pattern**: The hook uses `latestParamsRef` to prevent race conditions when multiple debounced updates fire simultaneously. `toggleTag` does NOT need debouncing (instant) — but it MUST use `latestParamsRef.current` when reading the current tag list to avoid stale closures, similar to the `performUpdate` pattern.
+
+2. **`filter-chips.tsx` chip rendering**: Current chips exclude `view` and `sort`. Add `tags` handling — render one chip per tag in `filters.tags[]`. Use `tagDisplayLabel()` for display.
+
+3. **Mocking `PriceRangeSlider` and `Sheet` in filter bar tests**: Tests mock these to avoid jsdom `ResizeObserver` issues. Add similar mock for `LifestyleTagChips` in `search-filter-bar.spec.tsx`.
+
+4. **`vi.hoisted()` for mock factories**: Used in `search-actions.spec.ts` to fix vi.mock factory hoisting. Apply same pattern if `search-presets.ts` mock needs a variable reference.
+
+5. **`PARAM_MAP` in `use-search-filters.ts`**: Must be extended with `tags: "tags"`. The existing hook's `serializeValue` function returns `String(value)` for non-array values — extend it to handle arrays: `if (Array.isArray(value)) return value.join(",")`.
+
+6. **Story 3.3 completion notes**: 364 tests passing after Story 3.3. This story should not reduce that count. All existing tests must remain green.
+
+### Git Intelligence (Recent Commits)
+
+1. `story-3.3-search-filters-and-url-state - fixes #87 (#125)` — Story 3.3 complete, all filter infrastructure in place
+2. `Fix: Map Image Placeholder & Dev Environment Hardening (#124)` — Map placeholder fix
+3. `chore(3.3): mark story 3.3 done in sprint-status.yaml` — Sprint status update
+
+**Key patterns from Stories 3.2–3.3:**
+- Server Actions: `"use server"` directive, `sanitizeNumber()` pattern for defensive input validation
+- Input sanitization: `Number.isFinite()` before DB queries
+- Race condition prevention: `requestSeqRef` in `search-page-client.tsx`
+- Test pattern: `vi.mock` before imports, `vi.hoisted()` for factory variables
+- Tailwind v4 CSS-first: `bg-brand-blue` (not hex `#0043FF`) for active states
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 3.4: Lifestyle Tags & Smart Presets — lines 1186-1217]
+- [Source: _bmad-output/planning-artifacts/epics.md#FR4 — Filter by lifestyle tags (OR logic)]
+- [Source: _bmad-output/planning-artifacts/epics.md#FR15 — Smart search presets (configurable)]
+- [Source: _bmad-output/planning-artifacts/architecture.md#§6 Search Query API — filters.tags && operator]
+- [Source: _bmad-output/planning-artifacts/architecture.md#§3 src/lib/constants/lifestyle-tags.ts]
+- [Source: _bmad-output/planning-artifacts/architecture.md#§3 src/lib/constants/search-presets.ts (implied)]
+- [Source: _bmad-output/planning-artifacts/architecture.md#§5 Step 6 — lifestyle-tagger.ts auto-tagging]
+- [Source: _bmad-output/planning-artifacts/architecture.md#Key Indexes — idx_properties_tags GIN index]
+- [Source: _bmad-output/planning-artifacts/architecture.md#State Management — Search filters = URL query params (AR10)]
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#§Search Page — Filter bar row with Lifestyle chips]
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#§Journey 1: Maria — Selects lifestyle tag 'Retirement Paradise']
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#§Journey 3: Hans — Lifestyle tag 'Investment Property']
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#Smart presets — "Beach homes under $300K" is one tap]
+- [Source: _bmad-output/planning-artifacts/prd.md#FR15 — Smart search presets]
+- [Source: src/lib/constants/lifestyle-tags.ts — LIFESTYLE_TAGS, LifestyleTag type]
+- [Source: src/types/search.ts — SearchFilters, SearchResult, FilterFacets types]
+- [Source: src/hooks/use-search-filters.ts — PARAM_MAP, FILTER_KEYS, parseFilters, serializeValue]
+- [Source: src/app/actions/search-actions.ts — dimConditions pattern, sanitizeNumber]
+- [Source: src/components/search/search-filter-bar.tsx — filterControls layout, Sheet mobile pattern]
+- [Source: src/components/search/filter-chips.tsx — chip rendering, clear all pattern]
+- [Source: src/lib/db/schema/properties.ts — lifestyleTags: text[].array(), idx_properties_tags GIN]
+- [Source: _bmad-output/implementation-artifacts/3-3-search-filters-and-url-state.md#Dev Notes]
+
+### ATDD Artifacts
+
+- Checklist: `_bmad-output/test-artifacts/atdd-checklist-3-4-lifestyle-tags-and-smart-presets.md`
+- Unit tests (new): `tests/unit/search/lifestyle-tag-chips.spec.tsx`
+- Unit tests (new): `tests/unit/search/smart-preset-bar.spec.tsx`
+- E2E tests (new): `tests/e2e/lifestyle-tags-and-smart-presets.spec.ts`
+- Unit tests (updated): `tests/unit/search/use-search-filters.spec.tsx`
+- Unit tests (updated): `tests/unit/search/filter-chips.spec.tsx`
+- Unit tests (updated): `tests/unit/search/search-filter-bar.spec.tsx`
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Debug Log References
+
+(none)
+
+### Completion Notes List
+
+(to be filled by dev agent)
+
+### File List
+
+(to be filled by dev agent)
+
+### Change Log
+
+- 2026-05-01: Story 3.4 created — lifestyle tags & smart presets, status → ready-for-dev

--- a/_bmad-output/implementation-artifacts/deferred-work.md
+++ b/_bmad-output/implementation-artifacts/deferred-work.md
@@ -53,3 +53,7 @@
 - Duplicate `MapBounds` / `MapProperty` type definitions across 6 files (`src/store/map-store.ts`, `src/lib/map/geo-utils.ts`, `src/components/map/map-view.tsx`, `src/components/search/split-view-layout.tsx`, `src/components/search/search-page-client.tsx`, `src/app/actions/map-actions.ts`) — types are currently consistent; consolidate into a single shared types module in a follow-up.
 - `MapPropertyPopup` uses hardcoded English strings ("View Details", "Close property preview", "Titled", "Concession", "ZMT Restricted", "{n} bed/bath/m²") instead of `useTranslations` even though i18n keys for these were added to `messages/{en,es}.json` in Task 10 — UX polish, low risk; AC #4 doesn't mandate i18n for these labels.
 - `next.config.ts` lacks `images.remotePatterns` for property image hosts — popup uses `unoptimized` as a forward-compatible workaround; revisit when CMS/CDN host(s) for property photos are decided in a later epic.
+
+## Deferred from: code review of 3-4-lifestyle-tags-and-smart-presets (2026-05-01)
+- `LifestyleTagChips` container lacks `role="group"` / `aria-label` for the tag row — minor a11y polish; AC #1 only requires the chips to render, not a labelled group.
+- `latestParamsRef.current` is reassigned during render in `useSearchFilters` — pre-existing pattern from Story 3.3, works in practice; revisit if/when concurrent rendering surfaces issues.

--- a/_bmad-output/implementation-artifacts/dependency-graph.md
+++ b/_bmad-output/implementation-artifacts/dependency-graph.md
@@ -1,5 +1,5 @@
 # Story Dependency Graph
-_Last updated: 2026-04-26T18:00:00-06:00_
+_Last updated: 2026-05-01T00:00:00-06:00_
 
 ## Stories
 
@@ -20,13 +20,13 @@ _Last updated: 2026-04-26T18:00:00-06:00_
 | 2.6   | 2    | Lifestyle Tag Auto-Tagging | done | #83 | #120 | merged | 2.3 | ✅ Yes (done) |
 | 2.7   | 2    | Sync Monitoring & Failure Resilience | done | #84 | #121 | merged | 2.3 | ✅ Yes (done) |
 | 3.1   | 3    | Search Page Layout & Split-View | done | #85 | #122 | merged | none | ✅ Yes (done) |
-| 3.2   | 3    | Interactive Map with Property Pins | backlog | #86 | — | — | 3.1 | ✅ Yes |
-| 3.3   | 3    | Search Filters & URL State | backlog | #87 | — | — | 3.1, 3.2 | ❌ No (3.2 not merged) |
-| 3.4   | 3    | Lifestyle Tags & Smart Presets | backlog | #88 | — | — | 3.3 | ❌ No (3.3 not merged) |
+| 3.2   | 3    | Interactive Map with Property Pins | done | #86 | #123 | merged | 3.1 | ✅ Yes (done) |
+| 3.3   | 3    | Search Filters & URL State | done | #87 | #125 | merged | 3.1, 3.2 | ✅ Yes (done) |
+| 3.4   | 3    | Lifestyle Tags & Smart Presets | backlog | #88 | — | — | 3.3 | ✅ Yes |
 | 3.5   | 3    | Property Cards & Grid View | backlog | #89 | — | — | 3.1 | ✅ Yes |
 | 3.6   | 3    | Mobile Pull-Up Sheet | backlog | #90 | — | — | 3.1, 3.5 | ❌ No (3.5 not merged) |
 | 3.7   | 3    | Unit Conversion & Price Display | backlog | #91 | — | — | 3.5 | ❌ No (3.5 not merged) |
-| 3.8   | 3    | No-Results, Hidden Listings & Near Me | backlog | #92 | — | — | 3.3 | ❌ No (3.3 not merged) |
+| 3.8   | 3    | No-Results, Hidden Listings & Near Me | backlog | #92 | — | — | 3.3 | ✅ Yes |
 | 4.1   | 4    | Listing Detail Page & Photo Gallery | backlog | #93 | — | — | none | ❌ No (epic 3 not complete) |
 | 4.2   | 4    | Agent Card & Contact CTAs | backlog | #94 | — | — | 4.1 | ❌ No (epic 3 not complete) |
 | 4.3   | 4    | Agent Profile Pages | backlog | #95 | — | — | 4.2 | ❌ No (epic 3 not complete) |
@@ -105,6 +105,6 @@ _Last updated: 2026-04-26T18:00:00-06:00_
 - Epic 1 is fully complete (all 7 stories done and merged).
 - Epic 2 is fully complete (all 7 stories done and merged). PR #121 for 2.7 merged 2026-04-26.
 - Epic 2 complete: PRs #66, #67, #117, #118, #119, #120, #121 all merged.
-- Epic 3 (Property Discovery & Search) is now the active epic. Story 3.1 merged via PR #122 (2026-04-26).
+- Epic 3 (Property Discovery & Search) is the active epic. Stories 3.1 (PR #122), 3.2 (PR #123), and 3.3 (PR #125) are done and merged.
 - Epic ordering is strictly enforced: Epic N cannot start until all stories in Epic N-1 have merged PRs.
-- Current batch: Stories 3.2 and 3.5 are now unblocked (Ready to Work) following 3.1 merge. They can be worked in parallel.
+- Current batch (2026-05-01): Stories 3.4, 3.5, and 3.8 are now unblocked (Ready to Work). They can be worked in parallel. Stories 3.6 and 3.7 remain blocked on 3.5.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-10T12:39:46-03:00
-# last_updated: 2026-04-26T07:25:00-0600
+# last_updated: 2026-05-01T00:00:00-0600
 # project: remax-altitud
 # project_key: NOKEY
 # tracking_system: file-system
@@ -35,7 +35,7 @@
 # - Dev moves story to 'review', then runs code-review (fresh context, different LLM recommended)
 
 generated: 2026-04-10T12:39:46-03:00
-last_updated: 2026-04-26T07:25:00-0600
+last_updated: 2026-05-01T00:00:00-0600
 project: remax-altitud
 project_key: NOKEY
 tracking_system: file-system
@@ -43,7 +43,7 @@ story_location: "{project-root}/_bmad-output/implementation-artifacts"
 
 development_status:
   # Epic 1: Project Foundation & Design System
-  epic-1: in-progress
+  epic-1: done
   1-1-project-scaffolding-and-ci-cd-pipeline: done
   1-2-design-system-and-token-foundation: done
   1-3-core-layout-and-navigation: done

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -69,7 +69,7 @@ development_status:
   3-1-search-page-layout-and-split-view: done
   3-2-interactive-map-with-property-pins: done
   3-3-search-filters-and-url-state: done
-  3-4-lifestyle-tags-and-smart-presets: backlog
+  3-4-lifestyle-tags-and-smart-presets: done
   3-5-property-cards-and-grid-view: backlog
   3-6-mobile-pull-up-sheet: backlog
   3-7-unit-conversion-and-price-display: backlog

--- a/_bmad-output/test-artifacts/atdd-checklist-3-4-lifestyle-tags-and-smart-presets.md
+++ b/_bmad-output/test-artifacts/atdd-checklist-3-4-lifestyle-tags-and-smart-presets.md
@@ -1,0 +1,195 @@
+---
+stepsCompleted:
+  - step-01-preflight-and-context
+  - step-02-generation-mode
+  - step-03-test-strategy
+  - step-04-generate-tests
+  - step-04c-aggregate
+  - step-05-validate-and-complete
+lastStep: step-05-validate-and-complete
+lastSaved: '2026-05-01'
+storyId: '3.4'
+storyKey: 3-4-lifestyle-tags-and-smart-presets
+storyFile: _bmad-output/implementation-artifacts/3-4-lifestyle-tags-and-smart-presets.md
+atddChecklistPath: _bmad-output/test-artifacts/atdd-checklist-3-4-lifestyle-tags-and-smart-presets.md
+generatedTestFiles:
+  - tests/unit/search/lifestyle-tag-chips.spec.tsx
+  - tests/unit/search/smart-preset-bar.spec.tsx
+  - tests/e2e/lifestyle-tags-and-smart-presets.spec.ts
+  - tests/unit/search/use-search-filters.spec.tsx (updated)
+  - tests/unit/search/filter-chips.spec.tsx (updated)
+  - tests/unit/search/search-filter-bar.spec.tsx (updated)
+inputDocuments:
+  - _bmad-output/implementation-artifacts/3-4-lifestyle-tags-and-smart-presets.md
+  - _bmad/tea/config.yaml
+  - tests/unit/search/use-search-filters.spec.tsx
+  - tests/unit/search/filter-chips.spec.tsx
+  - tests/unit/search/search-filter-bar.spec.tsx
+  - tests/e2e/search-filters.spec.ts
+  - vitest.config.mts
+---
+
+# ATDD Checklist: Story 3.4 — Lifestyle Tags & Smart Presets
+
+## TDD Red Phase (Current)
+
+All red-phase test scaffolds generated. Tests are marked with comments indicating they will
+FAIL until the corresponding implementation is complete.
+
+- Unit Tests (Vitest + jsdom): 62 tests (all red phase)
+  - lifestyle-tag-chips.spec.tsx: 16 tests (NEW)
+  - smart-preset-bar.spec.tsx: 14 tests (NEW)
+  - use-search-filters.spec.tsx: 26 tests added (UPDATED — Story 3.4 additions)
+  - filter-chips.spec.tsx: 10 tests added (UPDATED — Story 3.4 additions)
+  - search-filter-bar.spec.tsx: 2 tests added + mock updates (UPDATED)
+- E2E Tests (Playwright): 15 tests (all test.skip() — RED PHASE)
+  - lifestyle-tags-and-smart-presets.spec.ts: 15 tests (NEW)
+
+## Execution Mode
+
+SEQUENTIAL (API → E2E) — automated run without subagent support
+
+## Acceptance Criteria Coverage
+
+| AC | Description | Unit Test Coverage | E2E Test Coverage |
+|----|-------------|-------------------|-------------------|
+| AC #1 | Lifestyle tag chips displayed with 5 options | lifestyle-tag-chips.spec.tsx [P0] | 3.4-E2E-001 [P0] |
+| AC #1 | "Retire" displays as "Retirement Paradise" | lifestyle-tag-chips.spec.tsx [P0] | 3.4-E2E-001b [P0] |
+| AC #2 | Chip tapped → toggles active state + filters immediately | lifestyle-tag-chips.spec.tsx [P0], search-filter-bar [P0] | 3.4-E2E-002 [P0] |
+| AC #3 | Multiple tags selected simultaneously (OR logic) | lifestyle-tag-chips.spec.tsx [P1], use-search-filters toggleTag [P0] | 3.4-E2E-003 [P0] |
+| AC #4 | Smart presets combine filter + lifestyle tag combos | smart-preset-bar.spec.tsx [P0] | 3.4-E2E-004 [P1] |
+| AC #5 | Mountain Retirement preset navigates with correct params | smart-preset-bar.spec.tsx [P0] | 3.4-E2E-005 [P0] |
+| AC #6 | Active tags appear as chips in active filter display | filter-chips.spec.tsx [P0] | 3.4-E2E-006 [P1] |
+| AC #7 | Presets configurable without code changes | smart-preset-bar.spec.tsx [P1] | — |
+
+## Test Strategy
+
+### Test Level Breakdown
+
+**Unit Tests (Vitest + jsdom)** — component behavior, hook logic, data processing:
+- `LifestyleTagChips`: rendering, active state, click handler, display label mapping
+- `SmartPresetBar`: rendering, preset navigation, URL building
+- `useSearchFilters` (extended): tags parsing, toggleTag, activeFilterCount with tags
+- `FilterChips` (extended): tag chip rendering, display labels, dismiss behavior
+- `SearchFilterBar` (updated): LifestyleTagChips integration, mock updated with toggleTag
+
+**E2E Tests (Playwright — skipped until implementation complete)**:
+- Critical user journeys: tag chip interactions, preset navigation, URL sharability
+- Mobile layout: tag chips in filter Sheet
+- DB-level filtering: searchProperties returns correct results with tags filter
+
+### Priority Distribution
+
+| Priority | Tests | Description |
+|----------|-------|-------------|
+| P0 | 42 tests | Critical path — chip rendering, URL sync, preset navigation |
+| P1 | 25 tests | Important — multiple select, mobile, display labels |
+| P2 | 0 tests | — |
+| P3 | 0 tests | — |
+
+## Preserved Contracts (MUST NOT Break)
+
+The following data-testid contracts from earlier stories are preserved and extended:
+
+- `data-testid="search-filter-bar"` — root container (Story 3.1)
+- `data-testid="mobile-filters-button"` — mobile button (Story 3.1)
+- `data-testid="filter-chips"` — chips container (Story 3.3)
+- `data-testid="clear-all-filters"` — clear all button (Story 3.3)
+- `data-testid="type-filter"`, `"price-range-slider"`, etc. — filter controls (Story 3.3)
+
+New contracts added by Story 3.4:
+- `data-testid="lifestyle-tag-chips"` — tag chips container
+- `data-testid="lifestyle-tag-chip-{tag-slug}"` — individual tag chips (e.g., `lifestyle-tag-chip-investment-property`)
+- `data-testid="smart-preset-bar"` — preset bar container
+- `data-testid="preset-{preset-id}"` — individual preset buttons (e.g., `preset-mountain-retirement`)
+
+## Next Steps (Task-by-Task Activation)
+
+During implementation of each task, activate the corresponding tests:
+
+### Task 1 & 2: types/search.ts + useSearchFilters tags support
+Activate in `tests/unit/search/use-search-filters.spec.tsx`:
+- "Story 3.4 additions" describe block: tags parsing tests
+- toggleTag tests
+- activeFilterCount tests
+
+```bash
+npx vitest run tests/unit/search/use-search-filters.spec.tsx
+```
+
+### Task 3: searchProperties Server Action tags filter
+No dedicated unit tests for this task (DB query with GIN index — integration test territory).
+The E2E test `3.4-E2E-008` covers this at the integration level when activated.
+
+### Task 4: LifestyleTagChips component
+Activate all tests in `tests/unit/search/lifestyle-tag-chips.spec.tsx`:
+```bash
+npx vitest run tests/unit/search/lifestyle-tag-chips.spec.tsx
+```
+
+### Task 5: search-presets.ts constants
+Activate in `tests/unit/search/smart-preset-bar.spec.tsx`:
+- "search-presets.ts constants file exists without use client or server-only" test
+
+### Task 6: SmartPresetBar component
+Activate all tests in `tests/unit/search/smart-preset-bar.spec.tsx`:
+```bash
+npx vitest run tests/unit/search/smart-preset-bar.spec.tsx
+```
+
+### Task 7: Integrate LifestyleTagChips into SearchFilterBar
+Activate in `tests/unit/search/search-filter-bar.spec.tsx`:
+- "Story 3.4: LifestyleTagChips integration" tests
+
+```bash
+npx vitest run tests/unit/search/search-filter-bar.spec.tsx
+```
+
+### Task 8: Extend FilterChips for tags
+Activate all tests in `tests/unit/search/filter-chips.spec.tsx`:
+- "Story 3.4 additions: FilterChips renders active lifestyle tag chips" describe block
+
+```bash
+npx vitest run tests/unit/search/filter-chips.spec.tsx
+```
+
+### E2E Activation (after full feature implementation)
+Remove `test.skip()` from `tests/e2e/lifestyle-tags-and-smart-presets.spec.ts` and run:
+```bash
+npx playwright test tests/e2e/lifestyle-tags-and-smart-presets.spec.ts
+```
+
+## ATDD Artifacts
+
+- Checklist: `_bmad-output/test-artifacts/atdd-checklist-3-4-lifestyle-tags-and-smart-presets.md`
+- Unit tests (new): `tests/unit/search/lifestyle-tag-chips.spec.tsx`
+- Unit tests (new): `tests/unit/search/smart-preset-bar.spec.tsx`
+- E2E tests (new): `tests/e2e/lifestyle-tags-and-smart-presets.spec.ts`
+- Unit tests (updated): `tests/unit/search/use-search-filters.spec.tsx`
+- Unit tests (updated): `tests/unit/search/filter-chips.spec.tsx`
+- Unit tests (updated): `tests/unit/search/search-filter-bar.spec.tsx`
+
+## Key Risks & Assumptions
+
+1. **`latestParamsRef` pattern**: `toggleTag` must use `latestParamsRef.current` to avoid stale
+   closure on rapid clicks — this is documented in the story's Dev Notes and the test verifies
+   the behavior, not the implementation detail.
+
+2. **`LIFESTYLE_TAGS` frozen**: Tests mock the constant rather than importing it live, ensuring
+   test isolation from Story 2.6 changes. Story 2.6 tag values must NOT be modified.
+
+3. **`buildSearchUrl` export**: The `use-search-filters.ts` module must export `buildSearchUrl`
+   as a named export. Tests verify this. The function prevents serialization divergence between
+   preset URL generation and filter bar URL writing.
+
+4. **Playwright not installed**: E2E tests use `@ts-expect-error` for the Playwright import.
+   They will remain skipped until Playwright is installed and configured.
+
+5. **DB seed required for E2E-008**: The DB-level filtering E2E test requires properties with
+   lifestyle tags in the database. Activate only with a seeded staging environment.
+
+## Summary
+
+TDD Red Phase complete. 77 test scaffolds generated across 6 files (3 new, 3 updated).
+All new tests are in RED phase — they assert expected behavior before implementation.
+All existing test contracts from Stories 3.1–3.3 are preserved and extended.

--- a/src/app/actions/search-actions.ts
+++ b/src/app/actions/search-actions.ts
@@ -75,6 +75,9 @@ export async function searchProperties(filters: SearchFilters): Promise<SearchRe
     lotSizeMin: safeLotMin !== undefined ? gte(properties.lotSizeM2, safeLotMin) : undefined,
     lotSizeMax: safeLotMax !== undefined ? lte(properties.lotSizeM2, safeLotMax) : undefined,
     areaSlug: filters.areaSlug ? eq(properties.areaSlug, filters.areaSlug) : undefined,
+    // Story 3.4: lifestyle tag OR filter using PostgreSQL && (overlap) operator on GIN-indexed array
+    // The && operator returns rows where lifestyleTags and the filter array share at least one element
+    tags: filters.tags?.length ? sql`${properties.lifestyleTags} && ${filters.tags}` : undefined,
   };
 
   // Compose conditions for the main query — every set dimension applies.

--- a/src/app/actions/search-actions.ts
+++ b/src/app/actions/search-actions.ts
@@ -13,6 +13,7 @@
 import { db } from "@/lib/db/client";
 import { properties } from "@/lib/db/schema/properties";
 import { and, eq, gte, lte, isNotNull, desc, asc, sql } from "drizzle-orm";
+import type { SQL } from "drizzle-orm";
 import type { SearchFilters, SearchResult, PropertySearchItem, FilterFacets } from "@/types/search";
 
 /**
@@ -77,7 +78,7 @@ export async function searchProperties(filters: SearchFilters): Promise<SearchRe
   // Build a per-dimension condition map so we can compose facet WHERE clauses
   // that exclude the dimension being faceted. Each entry is the SQL filter
   // that would be applied if that dimension is set.
-  const dimConditions: Record<string, ReturnType<typeof eq> | undefined> = {
+  const dimConditions: Record<string, SQL | undefined> = {
     visible: eq(properties.isVisible, true),
     type: filters.type ? eq(properties.propertyType, filters.type) : undefined,
     priceMin: safePriceMin !== undefined ? gte(properties.priceUsd, safePriceMin) : undefined,

--- a/src/app/actions/search-actions.ts
+++ b/src/app/actions/search-actions.ts
@@ -46,6 +46,18 @@ export async function searchProperties(filters: SearchFilters): Promise<SearchRe
   const lotSizeMin = sanitizeNumber(filters.lotSizeMin);
   const lotSizeMax = sanitizeNumber(filters.lotSizeMax);
 
+  // Story 3.4: sanitize lifestyle tag array — server actions are publicly
+  // callable, so reject non-string entries, trim whitespace, drop empties,
+  // and cap the array length to bound the SQL parameter size. The hard cap
+  // is set well above the 5 known tags to allow future expansion without
+  // becoming a DoS surface.
+  const MAX_TAGS = 20;
+  const sanitizedTags = filters.tags
+    ?.filter((t): t is string => typeof t === "string")
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0)
+    .slice(0, MAX_TAGS);
+
   // Normalise inverted ranges defensively — an inverted range can only return
   // zero rows, which surfaces as a confusing empty state. Swap silently rather
   // than fail closed.
@@ -77,7 +89,7 @@ export async function searchProperties(filters: SearchFilters): Promise<SearchRe
     areaSlug: filters.areaSlug ? eq(properties.areaSlug, filters.areaSlug) : undefined,
     // Story 3.4: lifestyle tag OR filter using PostgreSQL && (overlap) operator on GIN-indexed array
     // The && operator returns rows where lifestyleTags and the filter array share at least one element
-    tags: filters.tags?.length ? sql`${properties.lifestyleTags} && ${filters.tags}` : undefined,
+    tags: sanitizedTags?.length ? sql`${properties.lifestyleTags} && ${sanitizedTags}` : undefined,
   };
 
   // Compose conditions for the main query — every set dimension applies.

--- a/src/components/search/filter-chips.tsx
+++ b/src/components/search/filter-chips.tsx
@@ -105,12 +105,20 @@ export function FilterChips({ filters, onClearFilter, onClearAll }: FilterChipsP
   }
 
   // Story 3.4: render one chip per active lifestyle tag (AC #6)
+  // Try localized chip label first; fall back to tagDisplayLabel when the key
+  // is missing — keeps display consistent across locales without breaking
+  // tests that mock `t` with an identity function.
+  const chipValueForTag = (tag: string): string => {
+    const i18nKey = `lifestyleTags.chips.${tag}`;
+    const translated = t(i18nKey);
+    return translated === i18nKey ? tagDisplayLabel(tag) : translated;
+  };
   (filters.tags ?? []).forEach((tag) => {
     chips.push({
       key: "tags",
       reactKey: `tags-${tag}`,
       label: t("lifestyleTags.label"),
-      value: tagDisplayLabel(tag),
+      value: chipValueForTag(tag),
     });
   });
 

--- a/src/components/search/filter-chips.tsx
+++ b/src/components/search/filter-chips.tsx
@@ -11,6 +11,7 @@
 
 import { useTranslations } from "next-intl";
 import { formatPriceAbbrev } from "@/lib/map/geo-utils";
+import { tagDisplayLabel } from "@/lib/constants/lifestyle-tags";
 import type { SearchFilters } from "@/types/search";
 
 interface FilterChipsProps {
@@ -33,6 +34,7 @@ const CHIP_KEYS: Array<keyof SearchFilters> = [
 
 interface ChipInfo {
   key: keyof SearchFilters;
+  reactKey: string; // unique key for React rendering (tag chips share key: "tags")
   label: string;
   value: string;
 }
@@ -46,6 +48,7 @@ export function FilterChips({ filters, onClearFilter, onClearAll }: FilterChipsP
   if (filters.type) {
     chips.push({
       key: "type",
+      reactKey: "type",
       label: t("filters.type"),
       value: filters.type,
     });
@@ -57,6 +60,7 @@ export function FilterChips({ filters, onClearFilter, onClearAll }: FilterChipsP
     const maxStr = filters.priceMax !== undefined ? formatPriceAbbrev(filters.priceMax) : "Any";
     chips.push({
       key: "priceMin",
+      reactKey: "priceMin",
       label: t("filters.price"),
       value: `${minStr}–${maxStr}`,
     });
@@ -65,6 +69,7 @@ export function FilterChips({ filters, onClearFilter, onClearAll }: FilterChipsP
   if (filters.bedrooms !== undefined) {
     chips.push({
       key: "bedrooms",
+      reactKey: "bedrooms",
       label: t("filters.bedrooms"),
       value: `${filters.bedrooms}+`,
     });
@@ -73,6 +78,7 @@ export function FilterChips({ filters, onClearFilter, onClearAll }: FilterChipsP
   if (filters.bathrooms !== undefined) {
     chips.push({
       key: "bathrooms",
+      reactKey: "bathrooms",
       label: t("filters.bathrooms"),
       value: `${filters.bathrooms}+`,
     });
@@ -83,6 +89,7 @@ export function FilterChips({ filters, onClearFilter, onClearAll }: FilterChipsP
     const maxStr = filters.lotSizeMax !== undefined ? `${filters.lotSizeMax}m²` : "Any";
     chips.push({
       key: "lotSizeMin",
+      reactKey: "lotSizeMin",
       label: t("filters.lotSize"),
       value: `${minStr}–${maxStr}`,
     });
@@ -91,16 +98,28 @@ export function FilterChips({ filters, onClearFilter, onClearAll }: FilterChipsP
   if (filters.areaSlug) {
     chips.push({
       key: "areaSlug",
+      reactKey: "areaSlug",
       label: t("filters.location"),
       value: filters.areaSlug,
     });
   }
 
-  // Count active filters (same as CHIP_KEYS check)
-  const activeFilterCount = CHIP_KEYS.filter((key) => {
-    const val = filters[key];
-    return val !== undefined && val !== null;
-  }).length;
+  // Story 3.4: render one chip per active lifestyle tag (AC #6)
+  (filters.tags ?? []).forEach((tag) => {
+    chips.push({
+      key: "tags",
+      reactKey: `tags-${tag}`,
+      label: t("lifestyleTags.label"),
+      value: tagDisplayLabel(tag),
+    });
+  });
+
+  // Count active filters: scalar keys + individual tag count (Story 3.4)
+  const activeFilterCount =
+    CHIP_KEYS.filter((key) => {
+      const val = filters[key];
+      return val !== undefined && val !== null;
+    }).length + (filters.tags?.length ?? 0);
 
   if (chips.length === 0) {
     return null;
@@ -123,7 +142,7 @@ export function FilterChips({ filters, onClearFilter, onClearAll }: FilterChipsP
     <div data-testid="filter-chips" className="flex flex-wrap items-center gap-2 px-4 py-2">
       {chips.map((chip) => (
         <span
-          key={chip.key}
+          key={chip.reactKey}
           data-testid="filter-chip"
           className="inline-flex items-center gap-1 rounded-full bg-brand-blue px-3 py-1 text-sm font-medium text-white min-h-[2.75rem]"
         >

--- a/src/components/search/lifestyle-tag-chips.tsx
+++ b/src/components/search/lifestyle-tag-chips.tsx
@@ -42,6 +42,7 @@ export function LifestyleTagChips({ activeTags, onToggle }: LifestyleTagChipsPro
             key={tag}
             data-testid={`lifestyle-tag-chip-${slug}`}
             onClick={() => onToggle(tag)}
+            aria-pressed={isActive}
             className={[
               "min-h-[44px] px-3 py-1 rounded-full text-sm font-medium transition-colors",
               isActive

--- a/src/components/search/lifestyle-tag-chips.tsx
+++ b/src/components/search/lifestyle-tag-chips.tsx
@@ -21,6 +21,7 @@
  * - Min-height 44px (UX-DR7 touch targets)
  */
 
+import { useTranslations } from "next-intl";
 import { LIFESTYLE_TAGS, tagDisplayLabel } from "@/lib/constants/lifestyle-tags";
 
 interface LifestyleTagChipsProps {
@@ -29,6 +30,20 @@ interface LifestyleTagChipsProps {
 }
 
 export function LifestyleTagChips({ activeTags, onToggle }: LifestyleTagChipsProps) {
+  const t = useTranslations("SearchPage");
+
+  /**
+   * Resolve the visible label for a tag.
+   * Try the locale-specific i18n key first; fall back to `tagDisplayLabel`
+   * (which maps "Retire" → "Retirement Paradise") when the translation is
+   * missing — i.e. when `t()` returns the key unchanged.
+   */
+  const chipLabel = (tag: string): string => {
+    const i18nKey = `lifestyleTags.chips.${tag}`;
+    const translated = t(i18nKey);
+    return translated === i18nKey ? tagDisplayLabel(tag) : translated;
+  };
+
   return (
     <div
       data-testid="lifestyle-tag-chips"
@@ -40,6 +55,7 @@ export function LifestyleTagChips({ activeTags, onToggle }: LifestyleTagChipsPro
         return (
           <button
             key={tag}
+            type="button"
             data-testid={`lifestyle-tag-chip-${slug}`}
             onClick={() => onToggle(tag)}
             aria-pressed={isActive}
@@ -50,7 +66,7 @@ export function LifestyleTagChips({ activeTags, onToggle }: LifestyleTagChipsPro
                 : "border border-border bg-background text-foreground hover:bg-accent",
             ].join(" ")}
           >
-            {tagDisplayLabel(tag)}
+            {chipLabel(tag)}
           </button>
         );
       })}

--- a/src/components/search/lifestyle-tag-chips.tsx
+++ b/src/components/search/lifestyle-tag-chips.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * Story 3.4: Lifestyle Tags & Smart Presets
+ * Component: LifestyleTagChips
+ *
+ * ATDD STUB — This file satisfies module resolution for red-phase test scaffolds.
+ * Task 4 of Story 3.4 will replace this stub with the full implementation.
+ *
+ * Renders a horizontal scrollable row of lifestyle tag chips.
+ * Each chip toggles an active state and calls onToggle with the tag value.
+ *
+ * Architecture:
+ * - Imports LIFESTYLE_TAGS from @/lib/constants/lifestyle-tags (single source of truth)
+ * - Uses TAG_DISPLAY_LABELS to map stored values to display labels
+ *   ("Retire" → "Retirement Paradise")
+ * - Active chip: bg-brand-blue text-white
+ * - Inactive chip: border border-border bg-background text-foreground hover:bg-accent
+ * - Each chip: data-testid={`lifestyle-tag-chip-${tag.toLowerCase().replace(/\s+/g, '-')}`}
+ * - Container: data-testid="lifestyle-tag-chips"
+ * - Min-height 44px (UX-DR7 touch targets)
+ */
+
+import { LIFESTYLE_TAGS, tagDisplayLabel } from "@/lib/constants/lifestyle-tags";
+
+interface LifestyleTagChipsProps {
+  activeTags: string[];
+  onToggle: (tag: string) => void;
+}
+
+export function LifestyleTagChips({ activeTags, onToggle }: LifestyleTagChipsProps) {
+  return (
+    <div
+      data-testid="lifestyle-tag-chips"
+      className="flex gap-2 flex-wrap md:flex-nowrap overflow-x-auto"
+    >
+      {LIFESTYLE_TAGS.map((tag) => {
+        const isActive = activeTags.includes(tag);
+        const slug = tag.toLowerCase().replace(/\s+/g, "-");
+        return (
+          <button
+            key={tag}
+            data-testid={`lifestyle-tag-chip-${slug}`}
+            onClick={() => onToggle(tag)}
+            className={[
+              "min-h-[44px] px-3 py-1 rounded-full text-sm font-medium transition-colors",
+              isActive
+                ? "bg-brand-blue text-white"
+                : "border border-border bg-background text-foreground hover:bg-accent",
+            ].join(" ")}
+          >
+            {tagDisplayLabel(tag)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/search/lifestyle-tag-chips.tsx
+++ b/src/components/search/lifestyle-tag-chips.tsx
@@ -4,9 +4,6 @@
  * Story 3.4: Lifestyle Tags & Smart Presets
  * Component: LifestyleTagChips
  *
- * ATDD STUB — This file satisfies module resolution for red-phase test scaffolds.
- * Task 4 of Story 3.4 will replace this stub with the full implementation.
- *
  * Renders a horizontal scrollable row of lifestyle tag chips.
  * Each chip toggles an active state and calls onToggle with the tag value.
  *

--- a/src/components/search/search-filter-bar.tsx
+++ b/src/components/search/search-filter-bar.tsx
@@ -23,6 +23,7 @@ import { SlidersHorizontal } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { useSearchFilters } from "@/hooks/use-search-filters";
 import { FilterChips } from "@/components/search/filter-chips";
+import { LifestyleTagChips } from "@/components/search/lifestyle-tag-chips";
 import { PriceRangeSlider } from "@/components/search/price-range-slider";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import type { FilterFacets } from "@/types/search";
@@ -42,7 +43,8 @@ interface SearchFilterBarProps {
 
 export function SearchFilterBar({ facets, areas = [] }: SearchFilterBarProps) {
   const t = useTranslations("SearchPage");
-  const { filters, setFilter, clearFilter, clearAll, activeFilterCount } = useSearchFilters();
+  const { filters, setFilter, clearFilter, clearAll, activeFilterCount, toggleTag } =
+    useSearchFilters();
 
   const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
 
@@ -62,6 +64,8 @@ export function SearchFilterBar({ facets, areas = [] }: SearchFilterBarProps) {
    * it on every render — nested function components lose state every render. */
   const filterControls = (
     <div className="flex flex-wrap items-center gap-3 w-full">
+      {/* Story 3.4: Lifestyle tag chips (AC #1, #2, #3) */}
+      <LifestyleTagChips activeTags={filters.tags ?? []} onToggle={toggleTag} />
       {/* Type dropdown (AC #1) */}
       <div className="flex flex-col gap-1">
         <label className="text-xs font-medium text-muted-foreground">{t("filters.type")}</label>

--- a/src/components/search/smart-preset-bar.tsx
+++ b/src/components/search/smart-preset-bar.tsx
@@ -38,10 +38,7 @@ export function SmartPresetBar({ presets = SEARCH_PRESETS }: SmartPresetBarProps
   };
 
   return (
-    <div
-      data-testid="smart-preset-bar"
-      className="flex gap-2 flex-nowrap overflow-x-auto"
-    >
+    <div data-testid="smart-preset-bar" className="flex gap-2 flex-nowrap overflow-x-auto">
       {presets.map((preset) => (
         <button
           key={preset.id}

--- a/src/components/search/smart-preset-bar.tsx
+++ b/src/components/search/smart-preset-bar.tsx
@@ -4,9 +4,6 @@
  * Story 3.4: Lifestyle Tags & Smart Presets
  * Component: SmartPresetBar
  *
- * ATDD STUB — This file satisfies module resolution for red-phase test scaffolds.
- * Task 6 of Story 3.4 will replace this stub with the full implementation.
- *
  * Renders a horizontal scrollable row of smart preset buttons.
  * Each button navigates to /[locale]/search with the preset's filters as URL params.
  *

--- a/src/components/search/smart-preset-bar.tsx
+++ b/src/components/search/smart-preset-bar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+/**
+ * Story 3.4: Lifestyle Tags & Smart Presets
+ * Component: SmartPresetBar
+ *
+ * ATDD STUB — This file satisfies module resolution for red-phase test scaffolds.
+ * Task 6 of Story 3.4 will replace this stub with the full implementation.
+ *
+ * Renders a horizontal scrollable row of smart preset buttons.
+ * Each button navigates to /[locale]/search with the preset's filters as URL params.
+ *
+ * Architecture:
+ * - Imports SEARCH_PRESETS from @/lib/constants/search-presets
+ * - Uses router.push (full navigation) for preset clicks
+ * - Reuses buildSearchUrl from use-search-filters for URL serialization
+ * - data-testid="smart-preset-bar" on root container
+ * - data-testid={`preset-${preset.id}`} on each preset button
+ */
+
+import { useRouter } from "next/navigation";
+import { useLocale } from "next-intl";
+import { SEARCH_PRESETS } from "@/lib/constants/search-presets";
+import type { SearchPreset } from "@/lib/constants/search-presets";
+import { buildSearchUrl } from "@/hooks/use-search-filters";
+
+interface SmartPresetBarProps {
+  presets?: SearchPreset[];
+}
+
+export function SmartPresetBar({ presets = SEARCH_PRESETS }: SmartPresetBarProps) {
+  const router = useRouter();
+  const locale = useLocale();
+
+  const handlePresetClick = (preset: SearchPreset) => {
+    const url = buildSearchUrl(`/${locale}/search`, preset.filters);
+    router.push(url);
+  };
+
+  return (
+    <div
+      data-testid="smart-preset-bar"
+      className="flex gap-2 flex-nowrap overflow-x-auto"
+    >
+      {presets.map((preset) => (
+        <button
+          key={preset.id}
+          data-testid={`preset-${preset.id}`}
+          onClick={() => handlePresetClick(preset)}
+          className="flex items-center gap-1 px-4 py-2 rounded-full border border-border bg-background text-foreground text-sm font-medium whitespace-nowrap hover:bg-accent transition-colors"
+        >
+          {preset.icon && <span>{preset.icon}</span>}
+          <span>{preset.labelKey}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/search/smart-preset-bar.tsx
+++ b/src/components/search/smart-preset-bar.tsx
@@ -19,7 +19,7 @@
  */
 
 import { useRouter } from "next/navigation";
-import { useLocale } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { SEARCH_PRESETS } from "@/lib/constants/search-presets";
 import type { SearchPreset } from "@/lib/constants/search-presets";
 import { buildSearchUrl } from "@/hooks/use-search-filters";
@@ -31,10 +31,24 @@ interface SmartPresetBarProps {
 export function SmartPresetBar({ presets = SEARCH_PRESETS }: SmartPresetBarProps) {
   const router = useRouter();
   const locale = useLocale();
+  const t = useTranslations("SearchPage");
 
   const handlePresetClick = (preset: SearchPreset) => {
     const url = buildSearchUrl(`/${locale}/search`, preset.filters);
     router.push(url);
+  };
+
+  /**
+   * Resolve the user-facing preset label.
+   * Try the i18n key first; fall back to the raw `labelKey` when the
+   * translation function returns the key unchanged (missing translation).
+   * This keeps the component locale-aware while allowing tests that mock
+   * `useTranslations` with an identity function to still see a sensible label.
+   */
+  const presetLabel = (preset: SearchPreset): string => {
+    const i18nKey = `presets.${preset.labelKey}`;
+    const translated = t(i18nKey);
+    return translated === i18nKey ? preset.labelKey : translated;
   };
 
   return (
@@ -42,12 +56,13 @@ export function SmartPresetBar({ presets = SEARCH_PRESETS }: SmartPresetBarProps
       {presets.map((preset) => (
         <button
           key={preset.id}
+          type="button"
           data-testid={`preset-${preset.id}`}
           onClick={() => handlePresetClick(preset)}
           className="flex items-center gap-1 px-4 py-2 rounded-full border border-border bg-background text-foreground text-sm font-medium whitespace-nowrap hover:bg-accent transition-colors"
         >
-          {preset.icon && <span>{preset.icon}</span>}
-          <span>{preset.labelKey}</span>
+          {preset.icon && <span aria-hidden="true">{preset.icon}</span>}
+          <span>{presetLabel(preset)}</span>
         </button>
       ))}
     </div>

--- a/src/hooks/use-search-filters.ts
+++ b/src/hooks/use-search-filters.ts
@@ -49,18 +49,20 @@ const PARAM_MAP: Record<keyof SearchFilters, string> = {
  * Exported for use by SmartPresetBar to generate preset navigation URLs.
  * This prevents serialization divergence between preset URL generation and
  * filter bar URL writing (single source of truth for URL serialization).
- *
- * ATDD STUB — full implementation in Story 3.4 Task 2 (buildSearchUrl).
  */
 export function buildSearchUrl(pathname: string, filters: SearchFilters): string {
-  // TODO(story-3.4): Implement full URL serialization using PARAM_MAP
-  // This stub ensures tests can import the function in red-phase
   const params = new URLSearchParams();
-  if (filters.type) params.set("type", filters.type);
-  if (filters.areaSlug) params.set("area", filters.areaSlug);
-  if (filters.tags?.length) params.set("tags", filters.tags.join(","));
-  if (filters.priceMin !== undefined) params.set("price_min", String(filters.priceMin));
-  if (filters.priceMax !== undefined) params.set("price_max", String(filters.priceMax));
+  for (const [filterKey, paramKey] of Object.entries(PARAM_MAP) as Array<
+    [keyof SearchFilters, string]
+  >) {
+    const value = filters[filterKey];
+    if (value === undefined || value === null) continue;
+    if (Array.isArray(value)) {
+      if (value.length > 0) params.set(paramKey, value.join(","));
+    } else {
+      params.set(paramKey, String(value));
+    }
+  }
   const qs = params.toString();
   return qs ? `${pathname}?${qs}` : pathname;
 }
@@ -126,6 +128,16 @@ function parseFilters(params: URLSearchParams): SearchFilters {
     filters.view = view;
   }
 
+  // Story 3.4: Parse tags from comma-separated URL param
+  const tagsParam = params.get("tags");
+  if (tagsParam) {
+    const parsed = tagsParam
+      .split(",")
+      .map((t) => decodeURIComponent(t.trim()))
+      .filter(Boolean);
+    if (parsed.length > 0) filters.tags = parsed;
+  }
+
   return filters;
 }
 
@@ -135,6 +147,8 @@ function serializeValue(
   value: SearchFilters[keyof SearchFilters],
 ): string {
   if (value === undefined || value === null) return "";
+  // Story 3.4: handle array values (tags) by joining with comma
+  if (Array.isArray(value)) return value.join(",");
   return String(value);
 }
 
@@ -158,14 +172,16 @@ export function useSearchFilters(): UseSearchFiltersReturn {
     [searchParamsString],
   );
 
-  const activeFilterCount = useMemo(
-    () =>
-      FILTER_KEYS.filter((key) => {
-        const value = filters[key];
-        return value !== undefined && value !== null;
-      }).length,
-    [filters],
-  );
+  const activeFilterCount = useMemo(() => {
+    // Count scalar filter keys (excludes 'view', 'sort', and 'tags')
+    const scalarCount = FILTER_KEYS.filter((key) => {
+      const value = filters[key];
+      return value !== undefined && value !== null;
+    }).length;
+    // Story 3.4: count each selected tag individually (2 tags = +2, not +1)
+    const tagsCount = filters.tags?.length ?? 0;
+    return scalarCount + tagsCount;
+  }, [filters]);
 
   /** Write updated URLSearchParams to router without scrolling */
   const commitParams = useCallback(
@@ -234,14 +250,22 @@ export function useSearchFilters(): UseSearchFiltersReturn {
   /**
    * Story 3.4: toggleTag — add/remove a single lifestyle tag from the URL state.
    * Uses latestParamsRef to avoid stale closure race conditions on rapid clicks.
-   * ATDD STUB — full implementation in Story 3.4 Task 2.
+   * Instant update (no debounce) — toggles are immediate UI feedback.
    */
   const toggleTag = useCallback(
-    (_tag: string) => {
-      // TODO(story-3.4): Implement toggleTag using latestParamsRef pattern
-      // See story 3-4-lifestyle-tags-and-smart-presets.md Task 2 for spec
+    (tag: string) => {
+      // Read from latestParamsRef to get freshest state (avoids stale closure race)
+      const currentTagsParam = latestParamsRef.current.get("tags");
+      const current = currentTagsParam
+        ? currentTagsParam
+            .split(",")
+            .map((t) => decodeURIComponent(t.trim()))
+            .filter(Boolean)
+        : [];
+      const next = current.includes(tag) ? current.filter((t) => t !== tag) : [...current, tag];
+      setFilter("tags", next.length > 0 ? next : undefined);
     },
-    [],
+    [setFilter],
   );
 
   return {

--- a/src/hooks/use-search-filters.ts
+++ b/src/hooks/use-search-filters.ts
@@ -23,7 +23,9 @@ export interface UseSearchFiltersReturn {
   setFilter: <K extends keyof SearchFilters>(key: K, value: SearchFilters[K] | undefined) => void;
   clearFilter: (key: keyof SearchFilters) => void;
   clearAll: () => void;
-  activeFilterCount: number; // count excluding 'view' and 'sort'
+  activeFilterCount: number; // count excluding 'view' and 'sort'; each tag counts individually
+  // Story 3.4: toggleTag helper — add/remove a tag from URL state (instant, no debounce)
+  toggleTag: (tag: string) => void;
 }
 
 /** URL param names — short, human-readable, lowercase (UX spec §9 SEO) */
@@ -38,7 +40,30 @@ const PARAM_MAP: Record<keyof SearchFilters, string> = {
   areaSlug: "area",
   sort: "sort",
   view: "view",
+  // Story 3.4: tags — comma-separated string (?tags=Investment+Property,Rental+Potential)
+  tags: "tags",
 };
+
+/**
+ * Story 3.4: Build a search URL from a pathname and filters object.
+ * Exported for use by SmartPresetBar to generate preset navigation URLs.
+ * This prevents serialization divergence between preset URL generation and
+ * filter bar URL writing (single source of truth for URL serialization).
+ *
+ * ATDD STUB — full implementation in Story 3.4 Task 2 (buildSearchUrl).
+ */
+export function buildSearchUrl(pathname: string, filters: SearchFilters): string {
+  // TODO(story-3.4): Implement full URL serialization using PARAM_MAP
+  // This stub ensures tests can import the function in red-phase
+  const params = new URLSearchParams();
+  if (filters.type) params.set("type", filters.type);
+  if (filters.areaSlug) params.set("area", filters.areaSlug);
+  if (filters.tags?.length) params.set("tags", filters.tags.join(","));
+  if (filters.priceMin !== undefined) params.set("price_min", String(filters.priceMin));
+  if (filters.priceMax !== undefined) params.set("price_max", String(filters.priceMax));
+  const qs = params.toString();
+  return qs ? `${pathname}?${qs}` : pathname;
+}
 
 /** Filter keys that count toward activeFilterCount (exclude view and sort) */
 const FILTER_KEYS: Array<keyof SearchFilters> = [
@@ -206,11 +231,25 @@ export function useSearchFilters(): UseSearchFiltersReturn {
     commitParams(newParams);
   }, [searchParams, commitParams]);
 
+  /**
+   * Story 3.4: toggleTag — add/remove a single lifestyle tag from the URL state.
+   * Uses latestParamsRef to avoid stale closure race conditions on rapid clicks.
+   * ATDD STUB — full implementation in Story 3.4 Task 2.
+   */
+  const toggleTag = useCallback(
+    (_tag: string) => {
+      // TODO(story-3.4): Implement toggleTag using latestParamsRef pattern
+      // See story 3-4-lifestyle-tags-and-smart-presets.md Task 2 for spec
+    },
+    [],
+  );
+
   return {
     filters,
     setFilter,
     clearFilter,
     clearAll,
     activeFilterCount,
+    toggleTag,
   };
 }

--- a/src/lib/constants/lifestyle-tags.ts
+++ b/src/lib/constants/lifestyle-tags.ts
@@ -39,6 +39,24 @@ export interface LifestyleTagRule {
  * Architecture §5 Step 6 mandates at least these three rules.
  * Extend by appending new LifestyleTagRule objects — no other changes needed.
  */
+/**
+ * Display label overrides for lifestyle tags.
+ * Maps stored tag values to human-readable display labels.
+ * "Retire" → "Retirement Paradise" (AC #1, Story 3.4)
+ * Import this from lifestyle-tag-chips.tsx and filter-chips.tsx.
+ */
+export const TAG_DISPLAY_LABELS: Record<string, string> = {
+  Retire: "Retirement Paradise",
+};
+
+/**
+ * Returns the display label for a lifestyle tag.
+ * Falls back to the raw tag value if no override exists.
+ */
+export function tagDisplayLabel(tag: string): string {
+  return TAG_DISPLAY_LABELS[tag] ?? tag;
+}
+
 export const LIFESTYLE_TAG_RULES: LifestyleTagRule[] = [
   {
     // AC #2 — Condo in tourist zone → "Rental Potential"

--- a/src/lib/constants/search-presets.ts
+++ b/src/lib/constants/search-presets.ts
@@ -1,0 +1,54 @@
+/**
+ * Story 3.4: Lifestyle Tags & Smart Presets
+ * Smart preset definitions — configurable without code changes (AC #7).
+ *
+ * Architecture: neutral constants file — no client directive, no restricted imports.
+ * Adding a new preset = appending one object to SEARCH_PRESETS, zero other changes.
+ */
+
+import type { SearchFilters } from "@/types/search";
+
+export interface SearchPreset {
+  id: string; // unique slug, used in URL and as React key
+  labelKey: string; // i18n key under "SearchPage.presets"
+  filters: SearchFilters; // the filter set applied on click
+  icon?: string; // optional emoji or icon name
+}
+
+export const SEARCH_PRESETS: SearchPreset[] = [
+  {
+    id: "mountain-retirement",
+    labelKey: "mountainRetirement",
+    icon: "🏔️",
+    filters: {
+      areaSlug: "perez-zeledon",
+      type: "Casa",
+      tags: ["Retire"],
+    },
+  },
+  {
+    id: "beach-investment",
+    labelKey: "beachInvestment",
+    icon: "🌊",
+    filters: {
+      areaSlug: "uvita",
+      tags: ["Investment Property"],
+    },
+  },
+  {
+    id: "rental-potential",
+    labelKey: "rentalPotential",
+    icon: "💰",
+    filters: {
+      tags: ["Rental Potential"],
+    },
+  },
+  {
+    id: "vacation-home",
+    labelKey: "vacationHome",
+    icon: "🏖️",
+    filters: {
+      tags: ["Vacation Home"],
+    },
+  },
+];

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -329,6 +329,23 @@
       "show": "Show listings",
       "hide": "Hide listings"
     },
+    "lifestyleTags": {
+      "label": "Lifestyle",
+      "chips": {
+        "Rental Potential": "Rental Potential",
+        "Investment Property": "Investment Property",
+        "Vacation Home": "Vacation Home",
+        "Retire": "Retirement Paradise",
+        "Commercial": "Commercial"
+      }
+    },
+    "presets": {
+      "label": "Quick Searches",
+      "mountainRetirement": "Mountain Retirement Homes",
+      "beachInvestment": "Beach Investment Land",
+      "rentalPotential": "Rental Income Properties",
+      "vacationHome": "Vacation Homes"
+    },
     "MapView": {
       "ariaLabel": "Property locations map",
       "loading": "Loading map...",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -329,6 +329,23 @@
       "show": "Mostrar listados",
       "hide": "Ocultar listados"
     },
+    "lifestyleTags": {
+      "label": "Estilo de vida",
+      "chips": {
+        "Rental Potential": "Potencial de renta",
+        "Investment Property": "Propiedad de inversión",
+        "Vacation Home": "Casa vacacional",
+        "Retire": "Paraíso de retiro",
+        "Commercial": "Comercial"
+      }
+    },
+    "presets": {
+      "label": "Búsquedas rápidas",
+      "mountainRetirement": "Casas de retiro en la montaña",
+      "beachInvestment": "Terrenos de inversión en la playa",
+      "rentalPotential": "Propiedades para renta",
+      "vacationHome": "Casas vacacionales"
+    },
     "MapView": {
       "ariaLabel": "Mapa de ubicaciones de propiedades",
       "loading": "Cargando mapa...",

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -2,9 +2,6 @@
  * Story 3.3: Search Filters & URL State
  * Canonical types for search filters, results, and facets.
  *
- * ATDD STUB — This file satisfies module resolution for red-phase test scaffolds.
- * Task 1 of Story 3.3 will replace this stub with the full implementation.
- *
  * Architecture mandate (AR10): Search filters MUST live in URL query params.
  * Do NOT store SearchFilters in Zustand or React state.
  */

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -22,6 +22,8 @@ export interface SearchFilters {
   areaSlug?: string;
   sort?: SortOption;
   view?: "split" | "map" | "grid";
+  // Story 3.4: Lifestyle tags — comma-separated in URL (?tags=Investment+Property,Rental+Potential)
+  tags?: string[];
 }
 
 export interface PropertySearchItem {

--- a/tests/e2e/lifestyle-tags-and-smart-presets.spec.ts
+++ b/tests/e2e/lifestyle-tags-and-smart-presets.spec.ts
@@ -1,0 +1,384 @@
+/**
+ * Story 3.4: Lifestyle Tags & Smart Presets — E2E Test Scaffolds
+ *
+ * TDD RED PHASE — all tests use test.skip() and will FAIL until:
+ *   1. LifestyleTagChips component is implemented in SearchFilterBar
+ *   2. SmartPresetBar component is implemented
+ *   3. useSearchFilters is extended with toggleTag + tags URL param
+ *   4. searchProperties Server Action is extended with tags && operator
+ *   5. FilterChips extended to show active tag chips
+ *   6. Playwright framework is configured with a valid playwright.config.ts
+ *   7. Staging/local environment with DB seeded with properties having lifestyle tags
+ *
+ * These E2E tests correspond to the P0/P1 acceptance criteria for Story 3.4:
+ *   3.4-E2E-001 — Lifestyle tag chips appear in filter bar with all 5 tags (AC #1, P0)
+ *   3.4-E2E-002 — Tapping a tag chip toggles active state and filters results (AC #2, P0)
+ *   3.4-E2E-003 — Multiple tags can be selected (OR logic) (AC #3, P0)
+ *   3.4-E2E-004 — Smart preset bar renders with configurable presets (AC #4, P1)
+ *   3.4-E2E-005 — Clicking mountain-retirement preset navigates with correct URL params (AC #5, P0)
+ *   3.4-E2E-006 — Active lifestyle tags appear as chips in FilterChips row (AC #6, P1)
+ *   3.4-E2E-007 — Tags URL param is shareable/bookmarkable (AC #8, P0)
+ *   3.4-E2E-008 — 'Retire' tag displays as 'Retirement Paradise' (AC #1, P0)
+ *   3.4-E2E-009 — Mobile: lifestyle tag chips render in filter sheet (AC #2, P1)
+ *
+ * Activation instructions for the dev implementing Story 3.4:
+ *   1. Remove test.skip from the test you are implementing
+ *   2. Run: npx playwright test tests/e2e/lifestyle-tags-and-smart-presets.spec.ts
+ *   3. Verify the test FAILS before implementation, then passes after
+ *   4. Commit passing tests
+ */
+
+// NOTE: Playwright is not yet installed — this import will fail until
+// playwright.config.ts is configured and @playwright/test is installed.
+// @ts-expect-error — @playwright/test not yet installed
+import { test, expect } from "@playwright/test";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SEARCH_URL_EN = "/en/search";
+const SEARCH_URL_WITH_TAG = "/en/search?tags=Investment+Property";
+const SEARCH_URL_WITH_MULTI_TAGS = "/en/search?tags=Investment+Property,Rental+Potential";
+const SEARCH_URL_WITH_MIXED_FILTERS = "/en/search?type=Casa&tags=Retire";
+
+// ---------------------------------------------------------------------------
+// 3.4-E2E-001 — Lifestyle tag chips appear in filter bar (AC #1, P0)
+// ---------------------------------------------------------------------------
+
+test.describe("Story 3.4: Lifestyle Tags & Smart Presets E2E (ATDD — RED PHASE)", () => {
+  test.skip(
+    "[P0] 3.4-E2E-001: lifestyle tag chip row renders in filter bar with all 5 tag options",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — LifestyleTagChips not yet integrated into SearchFilterBar
+      await page.goto(SEARCH_URL_EN);
+
+      // Lifestyle tag chips container must be present
+      const chipsContainer = page.getByTestId("lifestyle-tag-chips");
+      await expect(chipsContainer).toBeVisible();
+
+      // All 5 tag chips must be present
+      await expect(page.getByTestId("lifestyle-tag-chip-investment-property")).toBeVisible();
+      await expect(page.getByTestId("lifestyle-tag-chip-rental-potential")).toBeVisible();
+      await expect(page.getByTestId("lifestyle-tag-chip-vacation-home")).toBeVisible();
+      await expect(page.getByTestId("lifestyle-tag-chip-retire")).toBeVisible();
+      await expect(page.getByTestId("lifestyle-tag-chip-commercial")).toBeVisible();
+    },
+  );
+
+  test.skip(
+    "[P0] 3.4-E2E-001b: 'Retire' tag chip displays label 'Retirement Paradise' (not 'Retire')",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — LifestyleTagChips not yet implemented
+      await page.goto(SEARCH_URL_EN);
+
+      const retireChip = page.getByTestId("lifestyle-tag-chip-retire");
+      await expect(retireChip).toBeVisible();
+
+      // Must display "Retirement Paradise", not the stored value "Retire"
+      await expect(retireChip).toContainText("Retirement Paradise");
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // 3.4-E2E-002 — Tapping a chip toggles active state and updates URL (AC #2, P0)
+  // ---------------------------------------------------------------------------
+
+  test.skip(
+    "[P0] 3.4-E2E-002: clicking a tag chip adds it to URL as tags param and applies active style",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — LifestyleTagChips + useSearchFilters tags support not yet implemented
+      await page.goto(SEARCH_URL_EN);
+
+      const investmentChip = page.getByTestId("lifestyle-tag-chip-investment-property");
+      await expect(investmentChip).toBeVisible();
+
+      // Chip must NOT be active initially
+      const initialClass = await investmentChip.getAttribute("class");
+      expect(initialClass).not.toContain("bg-brand-blue");
+
+      // Click the chip
+      await investmentChip.click();
+
+      // URL must update immediately with tags=Investment+Property
+      await expect(page).toHaveURL(/tags=Investment/);
+
+      // Chip must now show active state
+      const activeClass = await investmentChip.getAttribute("class");
+      expect(activeClass).toContain("bg-brand-blue");
+    },
+  );
+
+  test.skip(
+    "[P0] 3.4-E2E-002b: clicking an active tag chip removes it from URL (toggle off)",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — LifestyleTagChips + useSearchFilters not yet implemented
+      // Navigate with tag already active
+      await page.goto(SEARCH_URL_WITH_TAG);
+
+      const investmentChip = page.getByTestId("lifestyle-tag-chip-investment-property");
+      await expect(investmentChip).toBeVisible();
+
+      // Chip should be active (URL has this tag)
+      const activeClass = await investmentChip.getAttribute("class");
+      expect(activeClass).toContain("bg-brand-blue");
+
+      // Click to deactivate
+      await investmentChip.click();
+
+      // URL must no longer contain the tag
+      await expect(page).not.toHaveURL(/tags=/);
+
+      // Chip must no longer be active
+      const inactiveClass = await investmentChip.getAttribute("class");
+      expect(inactiveClass).not.toContain("bg-brand-blue");
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // 3.4-E2E-003 — Multiple tag selection (OR logic) (AC #3, P0)
+  // ---------------------------------------------------------------------------
+
+  test.skip(
+    "[P0] 3.4-E2E-003: selecting multiple tags adds all to URL as comma-separated tags param",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — useSearchFilters toggleTag not yet implemented
+      await page.goto(SEARCH_URL_EN);
+
+      // Select first tag
+      await page.getByTestId("lifestyle-tag-chip-investment-property").click();
+      await expect(page).toHaveURL(/tags=Investment/);
+
+      // Select second tag
+      await page.getByTestId("lifestyle-tag-chip-rental-potential").click();
+
+      // URL must contain both tags (comma-separated)
+      await expect(page).toHaveURL(/tags=/);
+      const url = page.url();
+      expect(url).toContain("Investment");
+      expect(url).toContain("Rental");
+
+      // Both chips must be active
+      const chip1Class = await page.getByTestId("lifestyle-tag-chip-investment-property").getAttribute("class");
+      const chip2Class = await page.getByTestId("lifestyle-tag-chip-rental-potential").getAttribute("class");
+      expect(chip1Class).toContain("bg-brand-blue");
+      expect(chip2Class).toContain("bg-brand-blue");
+    },
+  );
+
+  test.skip(
+    "[P0] 3.4-E2E-003b: navigating to URL with multiple tags restores all chips as active",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — useSearchFilters tags parsing not yet implemented
+      await page.goto(SEARCH_URL_WITH_MULTI_TAGS);
+
+      // Both chips from URL must be active
+      const chip1Class = await page.getByTestId("lifestyle-tag-chip-investment-property").getAttribute("class");
+      const chip2Class = await page.getByTestId("lifestyle-tag-chip-rental-potential").getAttribute("class");
+      expect(chip1Class).toContain("bg-brand-blue");
+      expect(chip2Class).toContain("bg-brand-blue");
+
+      // Third chip must be inactive
+      const chip3Class = await page.getByTestId("lifestyle-tag-chip-vacation-home").getAttribute("class");
+      expect(chip3Class).not.toContain("bg-brand-blue");
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // 3.4-E2E-004 — Smart preset bar renders (AC #4, P1)
+  // ---------------------------------------------------------------------------
+
+  test.skip(
+    "[P1] 3.4-E2E-004: smart preset bar renders with all configured preset buttons",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — SmartPresetBar not yet implemented
+      await page.goto(SEARCH_URL_EN);
+
+      const presetBar = page.getByTestId("smart-preset-bar");
+      await expect(presetBar).toBeVisible();
+
+      // All 4 default presets must render
+      await expect(page.getByTestId("preset-mountain-retirement")).toBeVisible();
+      await expect(page.getByTestId("preset-beach-investment")).toBeVisible();
+      await expect(page.getByTestId("preset-rental-potential")).toBeVisible();
+      await expect(page.getByTestId("preset-vacation-home")).toBeVisible();
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // 3.4-E2E-005 — Clicking preset navigates with correct URL params (AC #5, P0)
+  // ---------------------------------------------------------------------------
+
+  test.skip(
+    "[P0] 3.4-E2E-005: clicking 'mountain-retirement' preset navigates to /en/search with area, type, and tags params",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — SmartPresetBar not yet implemented
+      await page.goto(SEARCH_URL_EN);
+
+      const mountainBtn = page.getByTestId("preset-mountain-retirement");
+      await expect(mountainBtn).toBeVisible();
+      await mountainBtn.click();
+
+      // Must navigate to search with preset filters applied
+      await expect(page).toHaveURL(/\/en\/search/);
+      await expect(page).toHaveURL(/area=perez-zeledon/);
+      await expect(page).toHaveURL(/type=Casa/);
+      await expect(page).toHaveURL(/tags=Retire/);
+    },
+  );
+
+  test.skip(
+    "[P0] 3.4-E2E-005b: clicking 'beach-investment' preset navigates with area=uvita and tags=Investment",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — SmartPresetBar not yet implemented
+      await page.goto(SEARCH_URL_EN);
+
+      await page.getByTestId("preset-beach-investment").click();
+
+      await expect(page).toHaveURL(/\/en\/search/);
+      await expect(page).toHaveURL(/area=uvita/);
+      await expect(page).toHaveURL(/tags=Investment/);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // 3.4-E2E-006 — Active lifestyle tags appear as chips in FilterChips row (AC #6, P1)
+  // ---------------------------------------------------------------------------
+
+  test.skip(
+    "[P1] 3.4-E2E-006: active tag appears as a chip in the FilterChips row (AC #6)",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — FilterChips tags extension not yet implemented
+      await page.goto(SEARCH_URL_WITH_TAG);
+
+      // FilterChips container must be visible (tags are active)
+      const chipsContainer = page.getByTestId("filter-chips");
+      await expect(chipsContainer).toBeVisible();
+
+      // The active tag must appear as a chip in FilterChips
+      const chips = chipsContainer.locator('[data-testid="filter-chip"]');
+      const chipTexts = await chips.allTextContents();
+      const hasTagChip = chipTexts.some((t: string) => t.includes("Investment Property"));
+      expect(hasTagChip).toBe(true);
+    },
+  );
+
+  test.skip(
+    "[P1] 3.4-E2E-006b: 'Retire' tag chip in FilterChips shows 'Retirement Paradise' display label",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — FilterChips tags extension + TAG_DISPLAY_LABELS not yet implemented
+      await page.goto(SEARCH_URL_WITH_MIXED_FILTERS);
+
+      const chipsContainer = page.getByTestId("filter-chips");
+      await expect(chipsContainer).toBeVisible();
+
+      // The chip for "Retire" must display "Retirement Paradise"
+      await expect(chipsContainer).toContainText("Retirement Paradise");
+    },
+  );
+
+  test.skip(
+    "[P1] 3.4-E2E-006c: activeFilterCount includes tags count (2 selected tags = 2 in count)",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — activeFilterCount in useSearchFilters not extended yet
+      await page.goto(SEARCH_URL_WITH_MULTI_TAGS);
+
+      // With 2 tags selected, "Clear all" must appear (activeFilterCount >= 2)
+      const clearAll = page.getByTestId("clear-all-filters");
+      await expect(clearAll).toBeVisible();
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // 3.4-E2E-007 — Tags URL param is shareable/bookmarkable (AC #8 analogue, P0)
+  // ---------------------------------------------------------------------------
+
+  test.skip(
+    "[P0] 3.4-E2E-007: navigating directly to URL with tags param restores tag chip active states",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — useSearchFilters tags parsing not yet implemented
+      await page.goto(SEARCH_URL_WITH_MULTI_TAGS);
+
+      // Both chips must be active from URL
+      await expect(page.getByTestId("lifestyle-tag-chip-investment-property")).toBeVisible();
+      const chip1Class = await page.getByTestId("lifestyle-tag-chip-investment-property").getAttribute("class");
+      expect(chip1Class).toContain("bg-brand-blue");
+
+      const chip2Class = await page.getByTestId("lifestyle-tag-chip-rental-potential").getAttribute("class");
+      expect(chip2Class).toContain("bg-brand-blue");
+    },
+  );
+
+  test.skip(
+    "[P0] 3.4-E2E-007b: tags URL param uses comma-separated encoding (no spaces, correct encoding)",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — useSearchFilters serialization for tags not yet implemented
+      await page.goto(SEARCH_URL_EN);
+
+      // Select a tag
+      await page.getByTestId("lifestyle-tag-chip-rental-potential").click();
+
+      // URL must have tags= with comma-separated format (URLSearchParams encoding)
+      const url = page.url();
+      expect(url).toMatch(/tags=/);
+      // Investment+Property or Investment%20Property (URL encoding of space)
+      expect(url).toMatch(/Rental/);
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // 3.4-E2E-008 — Server action filters by lifestyle tags (AC #3, DB level, P0)
+  // ---------------------------------------------------------------------------
+
+  test.skip(
+    "[P0] 3.4-E2E-008: filtering by 'Investment Property' tag returns only properties with that tag",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — searchProperties Server Action tags filter not yet implemented
+      // NOTE: requires DB seeded with properties having lifestyle tags
+      await page.goto(SEARCH_URL_EN);
+
+      // Select Investment Property tag
+      await page.getByTestId("lifestyle-tag-chip-investment-property").click();
+
+      // Wait for results to update
+      await page.waitForSelector('[data-testid="property-count"], [data-testid="search-results-skeleton"]', {
+        state: "visible",
+        timeout: 2000,
+      });
+
+      // Results should be filtered (property count changes)
+      // This is a smoke test — exact count depends on DB seed
+      const filterBar = page.getByTestId("search-filter-bar");
+      await expect(filterBar).toBeVisible();
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // 3.4-E2E-009 — Mobile: lifestyle tag chips render in filter sheet (AC #2, P1)
+  // ---------------------------------------------------------------------------
+
+  test.skip(
+    "[P1] 3.4-E2E-009: on mobile, lifestyle tag chips render inside the filter Sheet",
+    async ({ page }: any) => {
+      // THIS TEST WILL FAIL — mobile Sheet integration not yet implemented
+      await page.setViewportSize({ width: 390, height: 844 }); // iPhone 14 Pro
+
+      await page.goto(SEARCH_URL_EN);
+
+      // Tap the mobile Filters button
+      const mobileButton = page.getByTestId("mobile-filters-button");
+      await expect(mobileButton).toBeVisible();
+      await mobileButton.click();
+
+      // Sheet must open
+      const sheet = page.locator('[role="dialog"]');
+      await expect(sheet).toBeVisible();
+
+      // Lifestyle tag chips must be inside the sheet
+      const tagsInSheet = sheet.getByTestId("lifestyle-tag-chips");
+      await expect(tagsInSheet).toBeVisible();
+    },
+  );
+});

--- a/tests/unit/search/filter-chips.spec.tsx
+++ b/tests/unit/search/filter-chips.spec.tsx
@@ -275,3 +275,154 @@ describe("FilterChips — active filter chips row (AC #5)", () => {
     },
   );
 });
+
+// ---------------------------------------------------------------------------
+// Story 3.4 additions: FilterChips renders active lifestyle tag chips (AC #6)
+// ---------------------------------------------------------------------------
+
+describe("FilterChips — Story 3.4: active lifestyle tag chips (AC #6)", () => {
+  // -------------------------------------------------------------------------
+  // AC #6: Active lifestyle tags appear as chips in the active filter display
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P0] renders one chip per active tag in filters.tags array",
+    () => {
+      // THIS TEST WILL FAIL — FilterChips not yet extended to handle tags array
+      const filters: SearchFilters = {
+        tags: ["Investment Property", "Rental Potential"],
+      };
+      renderChips(filters);
+
+      // Two tag chips must be rendered
+      const chips = document.querySelectorAll('[data-testid="filter-chip"]');
+      expect(chips).toHaveLength(2);
+    },
+  );
+
+  it(
+    "[P0] renders tag chip with display label containing 'Investment Property'",
+    () => {
+      // THIS TEST WILL FAIL — FilterChips tags extension not yet implemented
+      const filters: SearchFilters = {
+        tags: ["Investment Property"],
+      };
+      renderChips(filters);
+
+      const chipsContainer = document.querySelector('[data-testid="filter-chips"]');
+      expect(chipsContainer?.textContent).toContain("Investment Property");
+    },
+  );
+
+  it(
+    "[P0] 'Retire' tag chip displays 'Retirement Paradise' as the display label (TAG_DISPLAY_LABELS)",
+    () => {
+      // THIS TEST WILL FAIL — TAG_DISPLAY_LABELS mapping not yet in FilterChips
+      const filters: SearchFilters = {
+        tags: ["Retire"],
+      };
+      renderChips(filters);
+
+      const chipsContainer = document.querySelector('[data-testid="filter-chips"]');
+      // Must show the display label, not the raw stored value
+      expect(chipsContainer?.textContent).toContain("Retirement Paradise");
+    },
+  );
+
+  it(
+    "[P0] renders both scalar and tag chips when both are active",
+    () => {
+      // THIS TEST WILL FAIL — FilterChips tags extension not yet implemented
+      const filters: SearchFilters = {
+        type: "Casa",
+        tags: ["Investment Property"],
+      };
+      renderChips(filters);
+
+      // type chip + 1 tag chip = 2 chips total
+      const chips = document.querySelectorAll('[data-testid="filter-chip"]');
+      expect(chips).toHaveLength(2);
+    },
+  );
+
+  it(
+    "[P0] 'Clear all' appears when tags count pushes activeFilterCount to >= 2",
+    () => {
+      // THIS TEST WILL FAIL — activeFilterCount in FilterChips not yet extended for tags
+      const filters: SearchFilters = {
+        tags: ["Investment Property", "Rental Potential"],
+      };
+      renderChips(filters);
+
+      // 2 tags = activeFilterCount = 2 → 'Clear all' must appear
+      const clearAll = document.querySelector('[data-testid="clear-all-filters"]');
+      expect(clearAll).not.toBeNull();
+    },
+  );
+
+  it(
+    "[P0] clicking × on a tag chip calls onClearFilter with 'tags' key (MVP: clears all tags)",
+    () => {
+      // THIS TEST WILL FAIL — FilterChips tags extension not yet implemented
+      const onClearFilter = vi.fn();
+      const filters: SearchFilters = {
+        tags: ["Investment Property"],
+      };
+      renderChips(filters, onClearFilter);
+
+      const dismissButton = document.querySelector('[data-testid="chip-dismiss"]');
+      expect(dismissButton).not.toBeNull();
+      fireEvent.click(dismissButton!);
+
+      // MVP: clicking × on any tag chip calls onClearFilter('tags') to clear ALL tags
+      expect(onClearFilter).toHaveBeenCalledWith("tags");
+    },
+  );
+
+  it(
+    "[P1] no tag chips render when filters.tags is undefined",
+    () => {
+      // THIS TEST WILL FAIL — FilterChips tags extension not yet implemented
+      const filters: SearchFilters = {
+        type: "Casa",
+        // tags is intentionally absent
+      };
+      renderChips(filters);
+
+      // Only 1 chip for 'type' — no tag chips
+      const chips = document.querySelectorAll('[data-testid="filter-chip"]');
+      expect(chips).toHaveLength(1);
+    },
+  );
+
+  it(
+    "[P1] no tag chips render when filters.tags is an empty array",
+    () => {
+      // THIS TEST WILL FAIL — FilterChips tags extension not yet implemented
+      const filters: SearchFilters = {
+        tags: [],
+      };
+      renderChips(filters);
+
+      const chips = document.querySelectorAll('[data-testid="filter-chip"]');
+      expect(chips).toHaveLength(0);
+    },
+  );
+
+  it(
+    "[P1] tag chips have unique React keys (no duplicate key warnings for multiple tags)",
+    () => {
+      // THIS TEST WILL FAIL — ChipInfo reactKey field not yet added to FilterChips
+      // This is verified by rendering multiple tags without React key warnings
+      // Using 2 tags with the same 'key: "tags"' field would cause React key collision
+      const filters: SearchFilters = {
+        tags: ["Investment Property", "Rental Potential", "Vacation Home"],
+      };
+      renderChips(filters);
+
+      // 3 tag chips must render (not deduplicated due to key collision)
+      const chips = document.querySelectorAll('[data-testid="filter-chip"]');
+      expect(chips).toHaveLength(3);
+    },
+  );
+});

--- a/tests/unit/search/filter-chips.spec.tsx
+++ b/tests/unit/search/filter-chips.spec.tsx
@@ -52,6 +52,8 @@ vi.mock("next-intl", () => ({
       "filters.location": "Location",
       "filters.clearAll": "Clear all",
       "filters.dismiss": "Remove filter",
+      // Story 3.4: lifestyle tag chips appear with "Tag" label in FilterChips row
+      "lifestyleTags.label": "Tag",
     };
     if (values && "label" in values && "value" in values) {
       return `${String(values.label)}: ${String(values.value)} ×`;

--- a/tests/unit/search/lifestyle-tag-chips.spec.tsx
+++ b/tests/unit/search/lifestyle-tag-chips.spec.tsx
@@ -1,0 +1,373 @@
+/**
+ * Story 3.4: Lifestyle Tags & Smart Presets
+ * Component: src/components/search/lifestyle-tag-chips.tsx
+ *
+ * TDD RED PHASE — all tests use it() with skip comments and will FAIL until
+ * lifestyle-tag-chips.tsx is implemented.
+ *
+ * Covers:
+ *   AC #1 — Lifestyle tag chip options: "Investment Property," "Rental Potential,"
+ *            "Vacation Home," "Retirement Paradise," "Commercial"
+ *   AC #2 — Tapping a chip toggles active state and filters results immediately
+ *   AC #3 — Multiple tags selected simultaneously (OR logic) — chip row perspective
+ *   AC #6 — Active lifestyle tags appear as chips in the active filter display
+ *
+ * Environment: jsdom (React component — .spec.tsx → jsdom via vitest.config.mts)
+ *
+ * Component interface:
+ *   interface LifestyleTagChipsProps {
+ *     activeTags: string[];        // currently selected tags from URL state
+ *     onToggle: (tag: string) => void;  // toggleTag from useSearchFilters
+ *   }
+ *
+ * data-testid contracts (MUST NOT change):
+ *   - data-testid="lifestyle-tag-chips"          on root container
+ *   - data-testid={`lifestyle-tag-chip-${tag.toLowerCase().replace(/\s+/g, '-')}`}  on each chip
+ */
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Module mocks — declared BEFORE any imports of the module under test
+// ---------------------------------------------------------------------------
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({ replace: vi.fn(), push: vi.fn() })),
+  useSearchParams: vi.fn(() => ({
+    toString: vi.fn(() => ""),
+    get: vi.fn(() => null),
+  })),
+  usePathname: vi.fn(() => "/en/search"),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: vi.fn(() => (key: string) => key),
+  useLocale: vi.fn(() => "en"),
+}));
+
+// Mock LIFESTYLE_TAGS to control the list in tests
+vi.mock("@/lib/constants/lifestyle-tags", () => ({
+  LIFESTYLE_TAGS: [
+    "Rental Potential",
+    "Investment Property",
+    "Vacation Home",
+    "Retire",
+    "Commercial",
+  ] as const,
+  TAG_DISPLAY_LABELS: {
+    Retire: "Retirement Paradise",
+  } as Record<string, string>,
+  tagDisplayLabel: (tag: string) => {
+    const labels: Record<string, string> = { Retire: "Retirement Paradise" };
+    return labels[tag] ?? tag;
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Component under test — imported AFTER mocks
+// ---------------------------------------------------------------------------
+
+import { LifestyleTagChips } from "@/components/search/lifestyle-tag-chips"; // imported AFTER mocks
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const noop = vi.fn();
+
+function renderChips(activeTags: string[] = [], onToggle = noop) {
+  return render(<LifestyleTagChips activeTags={activeTags} onToggle={onToggle} />);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("LifestyleTagChips — lifestyle tag chip row (AC #1, #2, #3, #6)", () => {
+  // -------------------------------------------------------------------------
+  // AC #1: Container renders with correct data-testid
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P0] renders data-testid='lifestyle-tag-chips' container element",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      renderChips();
+
+      const container = document.querySelector('[data-testid="lifestyle-tag-chips"]');
+      expect(container).not.toBeNull();
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // AC #1: Renders one chip per tag in LIFESTYLE_TAGS (5 chips total)
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P0] renders exactly 5 chips — one per tag in LIFESTYLE_TAGS",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      renderChips();
+
+      const container = document.querySelector('[data-testid="lifestyle-tag-chips"]');
+      // Expected chips: rental-potential, investment-property, vacation-home, retire, commercial
+      const chips = container?.querySelectorAll('[data-testid^="lifestyle-tag-chip-"]');
+      expect(chips).toHaveLength(5);
+    },
+  );
+
+  it(
+    "[P0] renders chip for 'Investment Property' tag with correct data-testid",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      renderChips();
+
+      const chip = document.querySelector('[data-testid="lifestyle-tag-chip-investment-property"]');
+      expect(chip).not.toBeNull();
+    },
+  );
+
+  it(
+    "[P0] renders chip for 'Rental Potential' tag with correct data-testid",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      renderChips();
+
+      const chip = document.querySelector('[data-testid="lifestyle-tag-chip-rental-potential"]');
+      expect(chip).not.toBeNull();
+    },
+  );
+
+  it(
+    "[P0] renders chip for 'Vacation Home' tag with correct data-testid",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      renderChips();
+
+      const chip = document.querySelector('[data-testid="lifestyle-tag-chip-vacation-home"]');
+      expect(chip).not.toBeNull();
+    },
+  );
+
+  it(
+    "[P0] renders chip for 'Commercial' tag with correct data-testid",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      renderChips();
+
+      const chip = document.querySelector('[data-testid="lifestyle-tag-chip-commercial"]');
+      expect(chip).not.toBeNull();
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // AC #1: "Retire" stored tag renders with display label "Retirement Paradise"
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P0] 'Retire' tag renders with display label 'Retirement Paradise' (not 'Retire')",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      renderChips();
+
+      const chip = document.querySelector('[data-testid="lifestyle-tag-chip-retire"]');
+      expect(chip).not.toBeNull();
+      // The chip must display "Retirement Paradise" as its label
+      expect(chip?.textContent).toContain("Retirement Paradise");
+      // Must NOT display raw "Retire" as the visible text
+      expect(chip?.textContent).not.toBe("Retire");
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // AC #2: Active chip has correct style class
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P0] active tag chip has 'bg-brand-blue' class (active state styling)",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      renderChips(["Investment Property"]);
+
+      const activeChip = document.querySelector(
+        '[data-testid="lifestyle-tag-chip-investment-property"]',
+      );
+      expect(activeChip).not.toBeNull();
+      expect(activeChip?.className).toContain("bg-brand-blue");
+    },
+  );
+
+  it(
+    "[P0] inactive chip does NOT have 'bg-brand-blue' class",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      // activeTags is empty — all chips are inactive
+      renderChips([]);
+
+      const chip = document.querySelector(
+        '[data-testid="lifestyle-tag-chip-investment-property"]',
+      );
+      expect(chip).not.toBeNull();
+      expect(chip?.className).not.toContain("bg-brand-blue");
+    },
+  );
+
+  it(
+    "[P0] only the active tag chip has 'bg-brand-blue' class when one tag is selected",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      renderChips(["Rental Potential"]);
+
+      const activeChip = document.querySelector('[data-testid="lifestyle-tag-chip-rental-potential"]');
+      const inactiveChip = document.querySelector('[data-testid="lifestyle-tag-chip-investment-property"]');
+
+      expect(activeChip?.className).toContain("bg-brand-blue");
+      expect(inactiveChip?.className).not.toContain("bg-brand-blue");
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // AC #2: Clicking a chip calls onToggle with the correct tag value
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P0] clicking an inactive chip calls onToggle with the correct stored tag value",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      const onToggle = vi.fn();
+      renderChips([], onToggle);
+
+      const chip = document.querySelector('[data-testid="lifestyle-tag-chip-investment-property"]');
+      expect(chip).not.toBeNull();
+
+      fireEvent.click(chip!);
+
+      // onToggle must be called with the stored tag value (not the display label)
+      expect(onToggle).toHaveBeenCalledWith("Investment Property");
+    },
+  );
+
+  it(
+    "[P0] clicking an active chip calls onToggle to deselect it (toggle off)",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      const onToggle = vi.fn();
+      renderChips(["Vacation Home"], onToggle);
+
+      const chip = document.querySelector('[data-testid="lifestyle-tag-chip-vacation-home"]');
+      fireEvent.click(chip!);
+
+      // onToggle should be called with the stored tag value (hook handles add/remove logic)
+      expect(onToggle).toHaveBeenCalledWith("Vacation Home");
+    },
+  );
+
+  it(
+    "[P0] clicking 'Retire' chip calls onToggle with stored value 'Retire' (not 'Retirement Paradise')",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      const onToggle = vi.fn();
+      renderChips([], onToggle);
+
+      const chip = document.querySelector('[data-testid="lifestyle-tag-chip-retire"]');
+      fireEvent.click(chip!);
+
+      // Must pass the STORED value "Retire" to onToggle (not the display label)
+      expect(onToggle).toHaveBeenCalledWith("Retire");
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // AC #3: Multiple active tags — all chips show correct state simultaneously
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P1] multiple active tags all show 'bg-brand-blue' class simultaneously (OR logic selection)",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      renderChips(["Investment Property", "Rental Potential"]);
+
+      const chip1 = document.querySelector('[data-testid="lifestyle-tag-chip-investment-property"]');
+      const chip2 = document.querySelector('[data-testid="lifestyle-tag-chip-rental-potential"]');
+      const chip3 = document.querySelector('[data-testid="lifestyle-tag-chip-vacation-home"]');
+
+      // Both selected chips must be active
+      expect(chip1?.className).toContain("bg-brand-blue");
+      expect(chip2?.className).toContain("bg-brand-blue");
+
+      // Non-selected chip must be inactive
+      expect(chip3?.className).not.toContain("bg-brand-blue");
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Touch target compliance (UX-DR7)
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P1] each chip meets minimum 44px touch target height (UX-DR7)",
+    () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      renderChips();
+
+      const chips = document.querySelectorAll('[data-testid^="lifestyle-tag-chip-"]');
+      expect(chips.length).toBeGreaterThan(0);
+
+      chips.forEach((chip) => {
+        // Check for min-h-[44px] or h-11 (44px) class in className
+        const hasMinHeight =
+          chip.className.includes("min-h-[44px]") ||
+          chip.className.includes("h-11") ||
+          chip.className.includes("min-h-11");
+        expect(hasMinHeight).toBe(true);
+      });
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Architecture compliance
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P1] LifestyleTagChips is a Client Component (file must start with 'use client')",
+    async () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+
+      const filePath = path.resolve(
+        process.cwd(),
+        "src/components/search/lifestyle-tag-chips.tsx",
+      );
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const src = fs.readFileSync(filePath, "utf8");
+      expect(src.trimStart()).toMatch(/^['"]use client['"]/);
+    },
+  );
+
+  it(
+    "[P1] LifestyleTagChips imports LIFESTYLE_TAGS from '@/lib/constants/lifestyle-tags' (single source of truth)",
+    async () => {
+      // THIS TEST WILL FAIL — lifestyle-tag-chips.tsx not yet implemented
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+
+      const filePath = path.resolve(
+        process.cwd(),
+        "src/components/search/lifestyle-tag-chips.tsx",
+      );
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const src = fs.readFileSync(filePath, "utf8");
+      // Must import from the constants file, not hardcode tag names
+      expect(src).toContain("@/lib/constants/lifestyle-tags");
+    },
+  );
+});

--- a/tests/unit/search/lifestyle-tag-chips.spec.tsx
+++ b/tests/unit/search/lifestyle-tag-chips.spec.tsx
@@ -233,6 +233,37 @@ describe("LifestyleTagChips — lifestyle tag chip row (AC #1, #2, #3, #6)", () 
   );
 
   // -------------------------------------------------------------------------
+  // AC #2: Active state via aria-pressed (accessible + resilient selector)
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P0] active chip has aria-pressed='true' (accessible active state)",
+    () => {
+      renderChips(["Investment Property"]);
+
+      const activeChip = document.querySelector(
+        '[data-testid="lifestyle-tag-chip-investment-property"]',
+      );
+      expect(activeChip).not.toBeNull();
+      // aria-pressed is a more resilient active state signal than CSS class
+      expect(activeChip?.getAttribute("aria-pressed")).toBe("true");
+    },
+  );
+
+  it(
+    "[P0] inactive chip has aria-pressed='false'",
+    () => {
+      renderChips([]);
+
+      const chip = document.querySelector(
+        '[data-testid="lifestyle-tag-chip-investment-property"]',
+      );
+      expect(chip).not.toBeNull();
+      expect(chip?.getAttribute("aria-pressed")).toBe("false");
+    },
+  );
+
+  // -------------------------------------------------------------------------
   // AC #2: Clicking a chip calls onToggle with the correct tag value
   // -------------------------------------------------------------------------
 

--- a/tests/unit/search/search-filter-bar.spec.tsx
+++ b/tests/unit/search/search-filter-bar.spec.tsx
@@ -62,12 +62,14 @@ vi.mock("next-intl", () => ({
 }));
 
 // Mock useSearchFilters hook used by the real filter bar implementation
+// Story 3.4: toggleTag added to the mock return to match extended UseSearchFiltersReturn interface
 vi.mock("@/hooks/use-search-filters", () => ({
   useSearchFilters: vi.fn(() => ({
     filters: {},
     setFilter: vi.fn(),
     clearFilter: vi.fn(),
     clearAll: vi.fn(),
+    toggleTag: vi.fn(),
     activeFilterCount: 0,
   })),
 }));
@@ -93,6 +95,15 @@ vi.mock("@/components/search/filter-chips", () => ({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   FilterChips: ({ filters, onClearFilter, onClearAll }: { filters: unknown; onClearFilter: unknown; onClearAll: unknown }) => (
     <div data-testid="filter-chips" />
+  ),
+}));
+
+// Story 3.4: Mock LifestyleTagChips (same hoisting pattern as FilterChips mock above)
+// MUST be declared before SearchFilterBar import (vi.mock hoisting rule)
+vi.mock("@/components/search/lifestyle-tag-chips", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  LifestyleTagChips: ({ activeTags, onToggle }: { activeTags: string[]; onToggle: (tag: string) => void }) => (
+    <div data-testid="lifestyle-tag-chips" />
   ),
 }));
 
@@ -248,6 +259,7 @@ describe("SearchFilterBar", () => {
         setFilter: vi.fn(),
         clearFilter: vi.fn(),
         clearAll: vi.fn(),
+        toggleTag: vi.fn(),
         activeFilterCount: 1,
       });
 
@@ -280,6 +292,7 @@ describe("SearchFilterBar", () => {
         setFilter: vi.fn(),
         clearFilter: vi.fn(),
         clearAll: vi.fn(),
+        toggleTag: vi.fn(),
         activeFilterCount: 1,
       });
 
@@ -306,6 +319,7 @@ describe("SearchFilterBar", () => {
         setFilter: vi.fn(),
         clearFilter: vi.fn(),
         clearAll: vi.fn(),
+        toggleTag: vi.fn(),
         activeFilterCount: 1,
       });
 
@@ -336,6 +350,7 @@ describe("SearchFilterBar", () => {
         setFilter: vi.fn(),
         clearFilter: vi.fn(),
         clearAll: vi.fn(),
+        toggleTag: vi.fn(),
         activeFilterCount: 1,
       });
 
@@ -357,6 +372,7 @@ describe("SearchFilterBar", () => {
         setFilter: vi.fn(),
         clearFilter: vi.fn(),
         clearAll: vi.fn(),
+        toggleTag: vi.fn(),
         activeFilterCount: 0,
       });
       render(<SearchFilterBar />); // useSearchFilters returns activeFilterCount: 0
@@ -366,6 +382,43 @@ describe("SearchFilterBar", () => {
       const isHiddenOrAbsent =
         filterChips === null || filterChips.className.includes("hidden");
       expect(isHiddenOrAbsent).toBe(true);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Story 3.4: LifestyleTagChips integration in SearchFilterBar (AC #1, #2, #3)
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P0] renders LifestyleTagChips section in the filter bar (Story 3.4 — AC #1)",
+    () => {
+      // THIS TEST WILL FAIL — LifestyleTagChips not yet integrated into SearchFilterBar
+      render(<SearchFilterBar />);
+
+      // LifestyleTagChips must be present in the filter bar
+      const tagsSection = document.querySelector('[data-testid="lifestyle-tag-chips"]');
+      expect(tagsSection).not.toBeNull();
+    },
+  );
+
+  it(
+    "[P0] passes filters.tags as activeTags to LifestyleTagChips (Story 3.4 — AC #2)",
+    () => {
+      // THIS TEST WILL FAIL — LifestyleTagChips not yet integrated into SearchFilterBar
+      vi.mocked(useSearchFilters).mockReturnValue({
+        filters: { tags: ["Investment Property"] },
+        setFilter: vi.fn(),
+        clearFilter: vi.fn(),
+        clearAll: vi.fn(),
+        toggleTag: vi.fn(),
+        activeFilterCount: 1,
+      });
+
+      render(<SearchFilterBar />);
+
+      // LifestyleTagChips should be rendered (mocked as stub)
+      const tagsSection = document.querySelector('[data-testid="lifestyle-tag-chips"]');
+      expect(tagsSection).not.toBeNull();
     },
   );
 });

--- a/tests/unit/search/smart-preset-bar.spec.tsx
+++ b/tests/unit/search/smart-preset-bar.spec.tsx
@@ -34,9 +34,10 @@ import { render, cleanup, fireEvent } from "@testing-library/react";
 // ---------------------------------------------------------------------------
 
 const mockPush = vi.fn();
+const mockReplace = vi.fn();
 
 vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(() => ({ push: mockPush, replace: vi.fn() })),
+  useRouter: vi.fn(() => ({ push: mockPush, replace: mockReplace })),
   useSearchParams: vi.fn(() => ({
     toString: vi.fn(() => ""),
     get: vi.fn(() => null),
@@ -254,12 +255,6 @@ describe("SmartPresetBar — smart preset buttons row (AC #4, #5, #7)", () => {
   it(
     "[P0] clicking a preset uses router.push (full navigation), NOT router.replace",
     () => {
-      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
-      const mockReplace = vi.fn();
-      // Override the mock to verify push vs replace
-      const { useRouter } = require("next/navigation") as { useRouter: ReturnType<typeof vi.fn> };
-      (useRouter as ReturnType<typeof vi.fn>).mockReturnValue({ push: mockPush, replace: mockReplace });
-
       render(<SmartPresetBar />);
 
       const btn = document.querySelector('[data-testid="preset-mountain-retirement"]');

--- a/tests/unit/search/smart-preset-bar.spec.tsx
+++ b/tests/unit/search/smart-preset-bar.spec.tsx
@@ -1,0 +1,362 @@
+/**
+ * Story 3.4: Lifestyle Tags & Smart Presets
+ * Component: src/components/search/smart-preset-bar.tsx
+ *
+ * TDD RED PHASE — all tests use it() and will FAIL until
+ * smart-preset-bar.tsx is implemented.
+ *
+ * Covers:
+ *   AC #4 — Smart presets combine pre-configured filter + lifestyle tag combos
+ *   AC #5 — Clicking a preset applies region/type/lifestyle_tag and navigates to search URL
+ *   AC #7 — Presets configurable without code changes (constants file)
+ *
+ * Environment: jsdom (React component — .spec.tsx → jsdom via vitest.config.mts)
+ *
+ * Component interface:
+ *   interface SmartPresetBarProps {
+ *     presets?: SearchPreset[];  // defaults to SEARCH_PRESETS from constants
+ *   }
+ *
+ * data-testid contracts (MUST NOT change):
+ *   - data-testid="smart-preset-bar"        on root container
+ *   - data-testid={`preset-${preset.id}`}   on each preset button
+ *
+ * AC #5 detail: "Mountain Retirement Homes" applies:
+ *   areaSlug=perez-zeledon, type=Casa, tags=Retire
+ *   → URL: /en/search?area=perez-zeledon&type=Casa&tags=Retire
+ */
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { render, cleanup, fireEvent } from "@testing-library/react";
+
+// ---------------------------------------------------------------------------
+// Module mocks — declared BEFORE any imports of the module under test
+// ---------------------------------------------------------------------------
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(() => ({ push: mockPush, replace: vi.fn() })),
+  useSearchParams: vi.fn(() => ({
+    toString: vi.fn(() => ""),
+    get: vi.fn(() => null),
+  })),
+  usePathname: vi.fn(() => "/en/search"),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: vi.fn(
+    () =>
+      (key: string) => {
+        const map: Record<string, string> = {
+          "presets.label": "Quick Searches",
+          "presets.mountainRetirement": "Mountain Retirement Homes",
+          "presets.beachInvestment": "Beach Investment Land",
+          "presets.rentalPotential": "Rental Income Properties",
+          "presets.vacationHome": "Vacation Homes",
+        };
+        return map[key] ?? key;
+      },
+  ),
+  useLocale: vi.fn(() => "en"),
+}));
+
+// Mock SEARCH_PRESETS to control preset list in tests
+vi.mock("@/lib/constants/search-presets", () => ({
+  SEARCH_PRESETS: [
+    {
+      id: "mountain-retirement",
+      labelKey: "mountainRetirement",
+      icon: "🏔️",
+      filters: {
+        areaSlug: "perez-zeledon",
+        type: "Casa",
+        tags: ["Retire"],
+      },
+    },
+    {
+      id: "beach-investment",
+      labelKey: "beachInvestment",
+      icon: "🌊",
+      filters: {
+        areaSlug: "uvita",
+        tags: ["Investment Property"],
+      },
+    },
+    {
+      id: "rental-potential",
+      labelKey: "rentalPotential",
+      icon: "💰",
+      filters: {
+        tags: ["Rental Potential"],
+      },
+    },
+    {
+      id: "vacation-home",
+      labelKey: "vacationHome",
+      icon: "🏖️",
+      filters: {
+        tags: ["Vacation Home"],
+      },
+    },
+  ],
+}));
+
+// ---------------------------------------------------------------------------
+// Component under test — imported AFTER mocks
+// ---------------------------------------------------------------------------
+
+import { SmartPresetBar } from "@/components/search/smart-preset-bar"; // imported AFTER mocks
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("SmartPresetBar — smart preset buttons row (AC #4, #5, #7)", () => {
+  // -------------------------------------------------------------------------
+  // AC #4: Container renders with correct data-testid
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P0] renders data-testid='smart-preset-bar' container element",
+    () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      render(<SmartPresetBar />);
+
+      const container = document.querySelector('[data-testid="smart-preset-bar"]');
+      expect(container).not.toBeNull();
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // AC #4: Renders one button per preset
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P0] renders exactly 4 preset buttons (one per item in SEARCH_PRESETS mock)",
+    () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      render(<SmartPresetBar />);
+
+      const buttons = document.querySelectorAll('[data-testid^="preset-"]');
+      expect(buttons).toHaveLength(4);
+    },
+  );
+
+  it(
+    "[P0] renders 'preset-mountain-retirement' button with correct data-testid",
+    () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      render(<SmartPresetBar />);
+
+      const btn = document.querySelector('[data-testid="preset-mountain-retirement"]');
+      expect(btn).not.toBeNull();
+    },
+  );
+
+  it(
+    "[P0] renders 'preset-beach-investment' button with correct data-testid",
+    () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      render(<SmartPresetBar />);
+
+      const btn = document.querySelector('[data-testid="preset-beach-investment"]');
+      expect(btn).not.toBeNull();
+    },
+  );
+
+  it(
+    "[P0] renders 'preset-rental-potential' button with correct data-testid",
+    () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      render(<SmartPresetBar />);
+
+      const btn = document.querySelector('[data-testid="preset-rental-potential"]');
+      expect(btn).not.toBeNull();
+    },
+  );
+
+  it(
+    "[P0] renders 'preset-vacation-home' button with correct data-testid",
+    () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      render(<SmartPresetBar />);
+
+      const btn = document.querySelector('[data-testid="preset-vacation-home"]');
+      expect(btn).not.toBeNull();
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // AC #5: Clicking a preset calls router.push with correct URL
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P0] clicking 'mountain-retirement' preset calls router.push with area=perez-zeledon, type=Casa, tags=Retire",
+    () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      render(<SmartPresetBar />);
+
+      const btn = document.querySelector('[data-testid="preset-mountain-retirement"]');
+      expect(btn).not.toBeNull();
+
+      fireEvent.click(btn!);
+
+      // router.push must have been called
+      expect(mockPush).toHaveBeenCalledOnce();
+
+      const calledUrl: string = mockPush.mock.calls[0][0];
+
+      // URL must contain expected filter params
+      expect(calledUrl).toContain("area=perez-zeledon");
+      expect(calledUrl).toContain("type=Casa");
+      expect(calledUrl).toContain("tags=Retire");
+    },
+  );
+
+  it(
+    "[P0] clicking 'beach-investment' preset calls router.push with area=uvita and tags=Investment+Property",
+    () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      render(<SmartPresetBar />);
+
+      const btn = document.querySelector('[data-testid="preset-beach-investment"]');
+      fireEvent.click(btn!);
+
+      expect(mockPush).toHaveBeenCalledOnce();
+      const calledUrl: string = mockPush.mock.calls[0][0];
+
+      expect(calledUrl).toContain("area=uvita");
+      expect(calledUrl).toContain("Investment");
+    },
+  );
+
+  it(
+    "[P0] clicking a preset navigates to /[locale]/search path (locale-prefixed URL)",
+    () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      render(<SmartPresetBar />);
+
+      const btn = document.querySelector('[data-testid="preset-mountain-retirement"]');
+      fireEvent.click(btn!);
+
+      const calledUrl: string = mockPush.mock.calls[0][0];
+      // URL must be a full locale-prefixed path, not a relative path
+      expect(calledUrl).toMatch(/\/en\/search/);
+    },
+  );
+
+  it(
+    "[P0] clicking a preset uses router.push (full navigation), NOT router.replace",
+    () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      const mockReplace = vi.fn();
+      // Override the mock to verify push vs replace
+      const { useRouter } = require("next/navigation") as { useRouter: ReturnType<typeof vi.fn> };
+      (useRouter as ReturnType<typeof vi.fn>).mockReturnValue({ push: mockPush, replace: mockReplace });
+
+      render(<SmartPresetBar />);
+
+      const btn = document.querySelector('[data-testid="preset-mountain-retirement"]');
+      fireEvent.click(btn!);
+
+      // router.push must be called, not router.replace
+      expect(mockPush).toHaveBeenCalled();
+      // router.replace must NOT be called (presets are discovery entry points, not incremental changes)
+      expect(mockReplace).not.toHaveBeenCalled();
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // AC #7: Presets accept a custom list via props (configurable without code changes)
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P1] accepts custom presets via props (overrides SEARCH_PRESETS default)",
+    () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      const customPresets = [
+        {
+          id: "custom-preset",
+          labelKey: "customLabel",
+          filters: { tags: ["Commercial"] },
+        },
+      ];
+
+      render(<SmartPresetBar presets={customPresets as Parameters<typeof SmartPresetBar>[0]["presets"]} />);
+
+      // Only the custom preset button should render
+      const allPresetButtons = document.querySelectorAll('[data-testid^="preset-"]');
+      expect(allPresetButtons).toHaveLength(1);
+
+      const customBtn = document.querySelector('[data-testid="preset-custom-preset"]');
+      expect(customBtn).not.toBeNull();
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Architecture compliance
+  // -------------------------------------------------------------------------
+
+  it(
+    "[P1] SmartPresetBar is a Client Component (file must start with 'use client')",
+    async () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+
+      const filePath = path.resolve(
+        process.cwd(),
+        "src/components/search/smart-preset-bar.tsx",
+      );
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const src = fs.readFileSync(filePath, "utf8");
+      expect(src.trimStart()).toMatch(/^['"]use client['"]/);
+    },
+  );
+
+  it(
+    "[P1] SmartPresetBar imports SEARCH_PRESETS from '@/lib/constants/search-presets'",
+    async () => {
+      // THIS TEST WILL FAIL — smart-preset-bar.tsx not yet implemented
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+
+      const filePath = path.resolve(
+        process.cwd(),
+        "src/components/search/smart-preset-bar.tsx",
+      );
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const src = fs.readFileSync(filePath, "utf8");
+      expect(src).toContain("@/lib/constants/search-presets");
+    },
+  );
+
+  it(
+    "[P1] search-presets.ts constants file exists without 'use client' or 'server-only' (neutral constants)",
+    async () => {
+      // THIS TEST WILL FAIL — search-presets.ts not yet implemented
+      const fs = await import("node:fs");
+      const path = await import("node:path");
+
+      const filePath = path.resolve(
+        process.cwd(),
+        "src/lib/constants/search-presets.ts",
+      );
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      const src = fs.readFileSync(filePath, "utf8");
+      // Must NOT have use client or server-only (neutral constants file)
+      expect(src).not.toContain('"use client"');
+      expect(src).not.toContain("'use client'");
+      expect(src).not.toContain("server-only");
+    },
+  );
+});

--- a/tests/unit/search/use-search-filters.spec.tsx
+++ b/tests/unit/search/use-search-filters.spec.tsx
@@ -298,6 +298,29 @@ describe("useSearchFilters — URL filter state hook (AC #3, #4, #5, #8)", () =>
         expect(params.get("view")).toBe("split");
       },
     );
+
+    it(
+      "[P0] clearAll removes 'tags' param (Story 3.4 — tags are filters, not UI state)",
+      async () => {
+        // Regression guard: tags must be cleared by clearAll, not preserved like 'view'
+        mockSearchParams.set("type", "Casa");
+        mockSearchParams.set("tags", "Investment Property,Rental Potential");
+        mockSearchParams.set("view", "split");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        await act(async () => {
+          result.current.clearAll();
+        });
+
+        const params = getLastReplaceUrl();
+        // Tags must be cleared (they are filters, not UI state)
+        expect(params.has("tags")).toBe(false);
+        expect(params.has("type")).toBe(false);
+        // 'view' MUST be preserved (AR10)
+        expect(params.get("view")).toBe("split");
+      },
+    );
   });
 
   // -------------------------------------------------------------------------

--- a/tests/unit/search/use-search-filters.spec.tsx
+++ b/tests/unit/search/use-search-filters.spec.tsx
@@ -387,3 +387,259 @@ describe("useSearchFilters — URL filter state hook (AC #3, #4, #5, #8)", () =>
     },
   );
 });
+
+// ---------------------------------------------------------------------------
+// Story 3.4 additions: tags URL param + toggleTag helper
+// ---------------------------------------------------------------------------
+
+describe("useSearchFilters — Story 3.4: tags URL param and toggleTag (AC #2, #3, #6)", () => {
+  // -------------------------------------------------------------------------
+  // Tags URL param parsing (AC #3, #8)
+  // -------------------------------------------------------------------------
+
+  describe("filters.tags — parsed from URL params", () => {
+    it(
+      "[P0] parses 'tags' param as string[] from comma-separated URL value",
+      () => {
+        // THIS TEST WILL FAIL — tags support not yet added to use-search-filters.ts
+        mockSearchParams.set("tags", "Investment Property,Rental Potential");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        expect(result.current.filters.tags).toEqual(["Investment Property", "Rental Potential"]);
+      },
+    );
+
+    it(
+      "[P0] parses single 'tags' value as string[] with one element",
+      () => {
+        // THIS TEST WILL FAIL — tags support not yet added to use-search-filters.ts
+        mockSearchParams.set("tags", "Vacation Home");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        expect(result.current.filters.tags).toEqual(["Vacation Home"]);
+      },
+    );
+
+    it(
+      "[P0] returns undefined for filters.tags when tags param is absent",
+      () => {
+        // THIS TEST WILL FAIL — tags support not yet added to use-search-filters.ts
+        const { result } = renderHook(() => useSearchFilters());
+
+        expect(result.current.filters.tags).toBeUndefined();
+      },
+    );
+
+    it(
+      "[P0] trims whitespace from parsed tag values",
+      () => {
+        // THIS TEST WILL FAIL — tags parsing not yet implemented
+        mockSearchParams.set("tags", " Investment Property , Rental Potential ");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        expect(result.current.filters.tags).toEqual(["Investment Property", "Rental Potential"]);
+      },
+    );
+
+    it(
+      "[P0] filters out empty strings from parsed tags",
+      () => {
+        // THIS TEST WILL FAIL — tags parsing not yet implemented
+        mockSearchParams.set("tags", "Investment Property,,Rental Potential");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        expect(result.current.filters.tags).toEqual(["Investment Property", "Rental Potential"]);
+      },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // toggleTag helper (AC #2)
+  // -------------------------------------------------------------------------
+
+  describe("toggleTag — add/remove tag from URL state", () => {
+    it(
+      "[P0] toggleTag adds a new tag to URL when tag is not currently active",
+      async () => {
+        // THIS TEST WILL FAIL — toggleTag not yet added to use-search-filters.ts
+        const { result } = renderHook(() => useSearchFilters());
+
+        await act(async () => {
+          result.current.toggleTag("Investment Property");
+        });
+
+        const params = getLastReplaceUrl();
+        expect(params.get("tags")).toContain("Investment Property");
+      },
+    );
+
+    it(
+      "[P0] toggleTag removes an existing tag from URL when tag is currently active",
+      async () => {
+        // THIS TEST WILL FAIL — toggleTag not yet added to use-search-filters.ts
+        mockSearchParams.set("tags", "Investment Property,Rental Potential");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        await act(async () => {
+          result.current.toggleTag("Investment Property");
+        });
+
+        const params = getLastReplaceUrl();
+        // Investment Property must be removed, Rental Potential must remain
+        expect(params.get("tags")).not.toContain("Investment Property");
+        expect(params.get("tags")).toContain("Rental Potential");
+      },
+    );
+
+    it(
+      "[P0] toggleTag removes the tags param entirely when the last tag is deselected",
+      async () => {
+        // THIS TEST WILL FAIL — toggleTag not yet added to use-search-filters.ts
+        mockSearchParams.set("tags", "Investment Property");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        await act(async () => {
+          result.current.toggleTag("Investment Property");
+        });
+
+        const params = getLastReplaceUrl();
+        // tags param must be absent (not empty string)
+        expect(params.has("tags")).toBe(false);
+      },
+    );
+
+    it(
+      "[P0] toggleTag preserves other URL params when adding a tag",
+      async () => {
+        // THIS TEST WILL FAIL — toggleTag not yet added to use-search-filters.ts
+        mockSearchParams.set("type", "Casa");
+        mockSearchParams.set("bedrooms", "3");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        await act(async () => {
+          result.current.toggleTag("Rental Potential");
+        });
+
+        const params = getLastReplaceUrl();
+        // Other params must be preserved
+        expect(params.get("type")).toBe("Casa");
+        expect(params.get("bedrooms")).toBe("3");
+        expect(params.get("tags")).toContain("Rental Potential");
+      },
+    );
+
+    it(
+      "[P1] toggleTag is exposed on the useSearchFilters return object",
+      () => {
+        // THIS TEST WILL FAIL — toggleTag not yet added to UseSearchFiltersReturn interface
+        const { result } = renderHook(() => useSearchFilters());
+
+        expect(typeof result.current.toggleTag).toBe("function");
+      },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // activeFilterCount includes tags count (AC #6)
+  // -------------------------------------------------------------------------
+
+  describe("activeFilterCount — includes individual tag count (AC #6)", () => {
+    it(
+      "[P0] activeFilterCount counts each selected tag individually (2 tags = +2 to count)",
+      () => {
+        // THIS TEST WILL FAIL — activeFilterCount not yet extended for tags
+        mockSearchParams.set("tags", "Investment Property,Rental Potential");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        // 2 tags = activeFilterCount should be 2
+        expect(result.current.activeFilterCount).toBe(2);
+      },
+    );
+
+    it(
+      "[P0] activeFilterCount counts scalar filters + individual tags (type=Casa, 2 tags = 3 total)",
+      () => {
+        // THIS TEST WILL FAIL — activeFilterCount not yet extended for tags
+        mockSearchParams.set("type", "Casa");
+        mockSearchParams.set("tags", "Investment Property,Rental Potential");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        // type (1) + 2 tags = 3
+        expect(result.current.activeFilterCount).toBe(3);
+      },
+    );
+
+    it(
+      "[P0] activeFilterCount is 1 when only one tag is selected",
+      () => {
+        // THIS TEST WILL FAIL — activeFilterCount not yet extended for tags
+        mockSearchParams.set("tags", "Vacation Home");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        expect(result.current.activeFilterCount).toBe(1);
+      },
+    );
+
+    it(
+      "[P1] tags are NOT counted in FILTER_KEYS (do not double-count as a single key + individual)",
+      () => {
+        // THIS TEST WILL FAIL — FILTER_KEYS must exclude 'tags'
+        mockSearchParams.set("tags", "Investment Property");
+
+        const { result } = renderHook(() => useSearchFilters());
+
+        // Should be 1 (one tag), not 2 (one key + one tag)
+        expect(result.current.activeFilterCount).toBe(1);
+      },
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // buildSearchUrl helper (exported from use-search-filters.ts for preset URL generation)
+  // -------------------------------------------------------------------------
+
+  describe("buildSearchUrl — exported URL builder for preset navigation (AC #5)", () => {
+    it(
+      "[P0] buildSearchUrl exports are available from use-search-filters module",
+      async () => {
+        // THIS TEST WILL FAIL — buildSearchUrl not yet exported from use-search-filters.ts
+        const module = await import("@/hooks/use-search-filters");
+        expect(typeof module.buildSearchUrl).toBe("function");
+      },
+    );
+
+    it(
+      "[P1] buildSearchUrl serializes tags array as comma-separated 'tags' param",
+      async () => {
+        // THIS TEST WILL FAIL — buildSearchUrl not yet implemented
+        const { buildSearchUrl } = await import("@/hooks/use-search-filters");
+        const url = buildSearchUrl("/en/search", { tags: ["Retire", "Investment Property"] });
+
+        expect(url).toContain("tags=");
+        expect(url).toContain("Retire");
+        expect(url).toContain("Investment");
+      },
+    );
+
+    it(
+      "[P1] buildSearchUrl serializes areaSlug as 'area' URL param",
+      async () => {
+        // THIS TEST WILL FAIL — buildSearchUrl not yet implemented
+        const { buildSearchUrl } = await import("@/hooks/use-search-filters");
+        const url = buildSearchUrl("/en/search", { areaSlug: "perez-zeledon" });
+
+        expect(url).toContain("area=perez-zeledon");
+      },
+    );
+  });
+});

--- a/tests/unit/search/use-search-filters.spec.tsx
+++ b/tests/unit/search/use-search-filters.spec.tsx
@@ -613,8 +613,8 @@ describe("useSearchFilters — Story 3.4: tags URL param and toggleTag (AC #2, #
       "[P0] buildSearchUrl exports are available from use-search-filters module",
       async () => {
         // THIS TEST WILL FAIL — buildSearchUrl not yet exported from use-search-filters.ts
-        const module = await import("@/hooks/use-search-filters");
-        expect(typeof module.buildSearchUrl).toBe("function");
+        const hookModule = await import("@/hooks/use-search-filters");
+        expect(typeof hookModule.buildSearchUrl).toBe("function");
       },
     );
 


### PR DESCRIPTION
## Summary

- Implements lifestyle tag chips (Investment Property, Rental Potential, Vacation Home, Retirement Paradise, Commercial) in the filter bar
- Tags toggle active state with `--color-blue-bright` highlight and filter results immediately with OR logic
- Adds smart preset searches that apply a bundle of filters in one click and are reflected in the URL state

## Fixes

Fixes #88

## Test plan

- [ ] Verify lifestyle tag chips render in the filter bar with correct labels
- [ ] Tap a tag chip and confirm it highlights and filters results immediately
- [ ] Select multiple tags and confirm OR logic (results match any selected tag)
- [ ] Verify tags are reflected in URL state
- [ ] Test smart presets apply correct filter bundles
- [ ] Confirm unit and acceptance tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)