### PR TITLE
feat: Story 5.2 — CMA Request Form (clean rebased)

### DIFF
--- a/_bmad-output/implementation-artifacts/5-2-cma-request-form.md
+++ b/_bmad-output/implementation-artifacts/5-2-cma-request-form.md
@@ -1,0 +1,538 @@
+# Story 5.2: CMA Request Form
+
+**Status:** ready-for-dev
+**GH Issue:** #99
+**Epic:** 5 — Seller Lead Capture
+**Story Key:** 5-2-cma-request-form
+**Created:** 2026-05-11
+
+---
+
+## Story
+
+As a **seller**,
+I want to request a free Comparative Market Analysis through a dedicated form,
+So that I can learn my property's market value before deciding to list.
+
+---
+
+## Acceptance Criteria
+
+1. **Given** the CMA form entry point **When** accessed from the seller landing page or a direct CTA **Then** a "Request a Free CMA" form loads with a value proposition explaining what a CMA is and why it's free (FR41). `data-testid="cma-form"` on the form wrapper.
+
+2. **Given** the CMA form **When** rendered **Then** it collects: Name (required), Phone/WhatsApp (required), Email (optional), Property Type (dropdown), Location (address text or map pin, reusing the `LocationPicker` component from Story 5.1), Approximate Size (with unit toggle), and Comment/Message (optional) (FR42). `data-testid="cma-form-fields"` on the fields container.
+
+3. **Given** a completed CMA form **When** submitted **Then** the lead is stored with source = "cma_form" and intent = "sell" (distinguishable from seller listing leads). `data-testid="cma-confirmation"` on the confirmation screen.
+
+4. **Given** the CMA form **When** submitted successfully **Then** a confirmation screen displays with the matched agent card (photo, name, languages, WhatsApp + Email CTAs) and message: "Your CMA request has been received. [Agent] will contact you within 24 hours." (FR43). Uses the existing `SellerConfirmation` component (with `source` variant prop for different heading text).
+
+5. **Given** the CMA form **When** a user is on the seller page **Then** it is accessible as a secondary CTA ("Just need a valuation? Request a Free CMA") without navigating away from the seller page context.
+
+6. **And** all form labels, validation messages, and confirmation text display in the selected locale (EN/ES).
+
+7. **And** the CMA form shares form field components (location picker, input styling, validation patterns) with the seller listing form for consistency.
+
+---
+
+## Developer Context
+
+### New Files to Create
+
+| File | Purpose |
+|------|---------|
+| `src/components/seller/cma-form.tsx` | Client Component — single-page CMA request form |
+| `src/components/seller/cma-hero.tsx` | Client Component — CMA value proposition section embedded in the seller page |
+
+### Existing Files to Modify
+
+| File | Change | Reason |
+|------|--------|--------|
+| `src/app/[locale]/sell/page.tsx` | Add CMA form section below the seller form | CMA form is accessible from seller page (AC #5) |
+| `src/components/seller/seller-confirmation.tsx` | Add `source` variant prop ("seller" \| "cma") for different confirmation text | CMA confirmation needs different heading/subheading |
+| `src/messages/en.json` | Add `CmaForm` namespace | All CMA UI strings |
+| `src/messages/es.json` | Add `CmaForm` namespace | Spanish translations |
+
+### Do NOT Modify
+
+- `src/components/seller/seller-form.tsx` — reuse patterns from it but do NOT modify the existing seller form.
+- `src/components/seller/location-picker.tsx` — reuse as-is. It was designed to be shared with Story 5.2.
+- `src/components/agent/agent-card.tsx` — reuse as-is.
+- Any existing `data-testid` values from Stories 5.1 and Epics 3–4 — cannot be renamed or removed.
+- `src/components/layout/unit-toggle.tsx` — do NOT duplicate its unit logic.
+
+---
+
+## Technical Requirements
+
+### CMA Form Architecture
+
+The CMA form is a **simpler, single-page form** compared to the 3-step seller form. It is embedded directly in the seller landing page as a secondary CTA section.
+
+**Design Decision:** The CMA form is NOT a separate page. It lives on the existing `/{locale}/sell` page as a collapsible section below the seller form. This follows AC #5: "accessible as a secondary CTA without navigating away from the seller page context."
+
+### Implementation Approach
+
+#### Option: Inline Accordion/Section on Sell Page
+
+The CMA form appears as a visually distinct section on the sell page:
+1. A CTA banner: "Just need a valuation? Request a Free CMA" with an expand/collapse toggle.
+2. When expanded, the CMA form renders inline with all fields visible at once (no multi-step).
+3. On successful submission, the same confirmation pattern as the seller form is shown.
+
+### CmaForm Component (`src/components/seller/cma-form.tsx`)
+
+```typescript
+'use client';
+
+import { useState, useId, type FormEvent, type ChangeEvent } from 'react';
+import { useTranslations } from 'next-intl';
+import { useLocaleUnits } from '@/hooks/use-locale-units';
+import { LocationPicker, type LocationValue } from '@/components/seller/location-picker';
+import { SellerConfirmation } from '@/components/seller/seller-confirmation';
+import type { Agent } from '@/lib/db/schema/agents';
+
+export interface CmaFormData {
+  name: string;
+  phone: string;
+  email: string;
+  propertyType: 'Casa' | 'Lote/Terreno' | 'Finca' | 'Condominio' | 'Comercial' | '';
+  location: LocationValue;
+  approximateSize: string;
+  sizeUnit: 'sqm' | 'sqft' | 'acres';
+  comment: string;
+}
+
+interface CmaFormProps {
+  locale: string;
+  fallbackAgent: Agent | null;
+  officeName?: string;
+}
+
+export function CmaForm({ locale, fallbackAgent, officeName = 'RE/MAX Altitud' }: CmaFormProps) {
+  // Implementation follows seller-form.tsx patterns
+}
+```
+
+**Key differences from SellerForm:**
+- Single-page (no steps, no progress bar)
+- No photo upload field
+- No "I need help with pricing" checkbox
+- No price expectation field
+- Has a Comment/Message textarea instead of Description
+- `source = "cma_form"` in lead payload (vs "seller_form")
+- Simpler validation (fewer required fields)
+
+### Field Reuse Strategy
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| Name | Same pattern as seller form Step 3 | Required |
+| Phone/WhatsApp | Same pattern as seller form Step 3 | Required, same validation |
+| Email | Same pattern as seller form Step 3 | Optional, same validation |
+| Property Type | Same pattern as seller form Step 1 | Dropdown (select) instead of radio group |
+| Location | `LocationPicker` from Story 5.1 | Reuse directly |
+| Approximate Size | Same pattern as seller form Step 1 | With unit toggle via `useLocaleUnits` |
+| Comment | New textarea | Optional, no character limit |
+
+### SellerConfirmation Enhancement
+
+Add a `source` prop to differentiate confirmation messages:
+
+```typescript
+// src/components/seller/seller-confirmation.tsx
+interface SellerConfirmationProps {
+  agent: Agent;
+  officeName: string;
+  locale: string;
+  source?: 'seller' | 'cma'; // NEW — defaults to 'seller'
+}
+
+export function SellerConfirmation({ agent, officeName, locale, source = 'seller' }: SellerConfirmationProps) {
+  const t = useTranslations(source === 'cma' ? 'CmaForm' : 'SellerPage');
+  // Use t('confirmation.heading'), t('confirmation.subheading') etc.
+  // CmaForm namespace has its own confirmation keys
+}
+```
+
+### Sell Page Modification
+
+```typescript
+// src/app/[locale]/sell/page.tsx
+// Add CmaFormLoader below SellerFormLoader
+import { CmaFormLoader } from '@/components/seller/cma-form-loader';
+
+// In the JSX:
+<main>
+  <SellerHero locale={locale} />
+  <SellerFormLoader locale={locale} fallbackAgent={fallbackAgent} officeName={officeName} />
+  
+  {/* CMA section — secondary CTA */}
+  <section id="cma" className="mx-auto max-w-2xl px-4 py-12">
+    <CmaHero locale={locale} />
+    <CmaFormLoader locale={locale} fallbackAgent={fallbackAgent} officeName={officeName} />
+  </section>
+</main>
+```
+
+**Lazy-loading:** Follow the same `next/dynamic` pattern as SellerFormLoader. Create `src/components/seller/cma-form-loader.tsx`:
+
+```typescript
+'use client';
+
+import dynamic from 'next/dynamic';
+import { SellerFormSkeleton } from '@/components/seller/seller-form-skeleton';
+import type { Agent } from '@/lib/db/schema/agents';
+
+const CmaForm = dynamic(
+  () => import('@/components/seller/cma-form').then((m) => m.CmaForm),
+  { ssr: false, loading: () => <SellerFormSkeleton /> }
+);
+
+interface CmaFormLoaderProps {
+  locale: string;
+  fallbackAgent: Agent | null;
+  officeName: string;
+}
+
+export function CmaFormLoader({ locale, fallbackAgent, officeName }: CmaFormLoaderProps) {
+  return <CmaForm locale={locale} fallbackAgent={fallbackAgent} officeName={officeName} />;
+}
+```
+
+### CMA Lead Payload
+
+```typescript
+export interface CmaLeadPayload {
+  source: 'cma_form';
+  intent: 'sell';
+  name: string;
+  phone: string;
+  email: string;
+  propertyType: string;
+  location: LocationValue;
+  approximateSize: string;
+  sizeUnit: string;
+  comment: string;
+}
+
+export function buildCmaLeadPayload(data: CmaFormData): CmaLeadPayload {
+  return {
+    source: 'cma_form',
+    intent: 'sell',
+    name: data.name,
+    phone: data.phone,
+    email: data.email,
+    propertyType: data.propertyType,
+    location: data.location,
+    approximateSize: data.approximateSize,
+    sizeUnit: data.sizeUnit,
+    comment: data.comment,
+  };
+}
+```
+
+**Stub submission (same pattern as Story 5.1):**
+```typescript
+// 5.2 stub — Story 5.3 replaces with real API call.
+const payload = buildCmaLeadPayload(formData);
+if (process.env.NODE_ENV !== 'production') {
+  console.log('[5.2 stub] CMA form payload:', payload);
+}
+await new Promise((resolve) => setTimeout(resolve, 500));
+```
+
+### Unit Toggle in Size Field
+
+Same pattern as Story 5.1:
+```typescript
+import { useLocaleUnits } from '@/hooks/use-locale-units';
+const { unitSystem, toggleUnits } = useLocaleUnits(locale);
+```
+
+### Validation
+
+Same patterns as Story 5.1:
+- Name: required, non-empty
+- Phone: required, same regex (`/^\+?[\d\s\-()]+$/`, ≥7 digits)
+- Email: optional, same regex (`/^[^@\s]+@[^@\s]+\.[^@\s]+$/`)
+- Property Type: optional (dropdown, not required for CMA)
+- Location: optional (text + map, nice to have for CMA)
+- Size: optional
+- Comment: optional
+
+---
+
+## File Structure Requirements
+
+```
+src/
+├── app/
+│   └── [locale]/
+│       └── sell/
+│           └── page.tsx                  ← MODIFY (add CMA section)
+│
+├── components/
+│   └── seller/
+│       ├── cma-form.tsx                  ← CREATE (Client Component, lazy-loaded)
+│       ├── cma-form-loader.tsx           ← CREATE (Client Component, next/dynamic wrapper)
+│       ├── cma-hero.tsx                  ← CREATE (Client Component, CMA value proposition)
+│       ├── seller-confirmation.tsx       ← MODIFY (add source variant prop)
+│       ├── seller-form.tsx              (no changes)
+│       ├── seller-form-loader.tsx       (no changes)
+│       ├── seller-form-skeleton.tsx     (no changes — reused for CMA loading)
+│       ├── seller-hero.tsx              (no changes)
+│       └── location-picker.tsx          (no changes — shared as designed)
+│
+├── messages/
+│   ├── en.json                           ← MODIFY (add CmaForm namespace)
+│   └── es.json                           ← MODIFY (add CmaForm namespace)
+```
+
+---
+
+## Translatable Surfaces
+
+**CRITICAL — Epic 4 retrospective action item:** Every translatable surface must be listed here.
+
+### `CmaForm` namespace (`src/messages/en.json` / `es.json`)
+
+```json
+{
+  "CmaForm": {
+    "hero": {
+      "heading": "Request a Free CMA",
+      "subheading": "Just need a valuation? Request a Free CMA",
+      "description": "A Comparative Market Analysis (CMA) is a professional assessment of your property's current market value. Our agents analyze recent sales, active listings, and market trends in your area to provide an accurate price estimate — completely free.",
+      "ctaButton": "Request a Free CMA",
+      "ctaButtonAriaLabel": "Open the CMA request form"
+    },
+    "form": {
+      "heading": "Request Your Free CMA",
+      "nameLabel": "Full Name",
+      "namePlaceholder": "Your name",
+      "nameAriaLabel": "Enter your full name",
+      "phoneLabel": "Phone / WhatsApp",
+      "phonePlaceholder": "+506 8888-8888",
+      "phoneAriaLabel": "Enter your phone or WhatsApp number",
+      "phoneDescription": "WhatsApp preferred — your agent will contact you here",
+      "emailLabel": "Email Address (optional)",
+      "emailPlaceholder": "your@email.com",
+      "emailAriaLabel": "Enter your email address (optional)",
+      "emailOptionalBadge": "Optional",
+      "propertyTypeLabel": "Property Type",
+      "propertyTypeAriaLabel": "Select property type (optional)",
+      "propertyTypePlaceholder": "Select type...",
+      "typeCasa": "House / Casa",
+      "typeLote": "Lot / Lote",
+      "typeFinca": "Farm / Finca",
+      "typeCondominio": "Condo / Condominio",
+      "typeCommercial": "Commercial / Comercial",
+      "locationLabel": "Property Location",
+      "locationPlaceholder": "Type address or nearest landmark",
+      "locationAriaLabel": "Enter property location",
+      "sizeLabel": "Approximate Size",
+      "sizePlaceholder": "e.g. 5000",
+      "sizeAriaLabel": "Enter approximate property size",
+      "sizeUnitAriaLabel": "Toggle size unit between square meters, square feet, and acres",
+      "commentLabel": "Comments or Questions (optional)",
+      "commentPlaceholder": "Tell us anything else about your property or what you'd like to know...",
+      "commentAriaLabel": "Additional comments or questions (optional)",
+      "submitButton": "Request My Free CMA",
+      "submitButtonAriaLabel": "Submit your CMA request",
+      "submittingButton": "Submitting...",
+      "validation": {
+        "nameRequired": "Please enter your name",
+        "phoneRequired": "Please enter your phone number",
+        "phoneInvalid": "Please enter a valid phone number",
+        "emailInvalid": "Please enter a valid email address"
+      }
+    },
+    "confirmation": {
+      "heading": "CMA Request Received!",
+      "subheading": "Your agent will prepare your Comparative Market Analysis and contact you within 24 hours.",
+      "agentMatchHeading": "Your Agent Match",
+      "browseWhileWaiting": "While you wait, explore what's selling in your area"
+    }
+  }
+}
+```
+
+**Spanish keys follow the same structure** — all keys translated in `es.json`.
+
+```json
+{
+  "CmaForm": {
+    "hero": {
+      "heading": "Solicita un Avalúo Gratuito",
+      "subheading": "¿Solo necesitas una valoración? Solicita un CMA gratuito",
+      "description": "Un Análisis Comparativo de Mercado (CMA) es una evaluación profesional del valor actual de tu propiedad. Nuestros agentes analizan ventas recientes, listados activos y tendencias del mercado en tu zona para darte un precio estimado preciso — completamente gratis.",
+      "ctaButton": "Solicitar CMA Gratuito",
+      "ctaButtonAriaLabel": "Abrir el formulario de solicitud de CMA"
+    },
+    "form": {
+      "heading": "Solicita tu CMA Gratuito",
+      "nameLabel": "Nombre Completo",
+      "namePlaceholder": "Tu nombre",
+      "nameAriaLabel": "Ingresa tu nombre completo",
+      "phoneLabel": "Teléfono / WhatsApp",
+      "phonePlaceholder": "+506 8888-8888",
+      "phoneAriaLabel": "Ingresa tu número de teléfono o WhatsApp",
+      "phoneDescription": "WhatsApp preferido — tu agente te contactará aquí",
+      "emailLabel": "Correo Electrónico (opcional)",
+      "emailPlaceholder": "tu@correo.com",
+      "emailAriaLabel": "Ingresa tu correo electrónico (opcional)",
+      "emailOptionalBadge": "Opcional",
+      "propertyTypeLabel": "Tipo de Propiedad",
+      "propertyTypeAriaLabel": "Selecciona el tipo de propiedad (opcional)",
+      "propertyTypePlaceholder": "Seleccionar tipo...",
+      "typeCasa": "Casa",
+      "typeLote": "Lote / Terreno",
+      "typeFinca": "Finca",
+      "typeCondominio": "Condominio",
+      "typeCommercial": "Comercial",
+      "locationLabel": "Ubicación de la Propiedad",
+      "locationPlaceholder": "Escribe la dirección o punto de referencia más cercano",
+      "locationAriaLabel": "Ingresa la ubicación de la propiedad",
+      "sizeLabel": "Tamaño Aproximado",
+      "sizePlaceholder": "ej. 5000",
+      "sizeAriaLabel": "Ingresa el tamaño aproximado de la propiedad",
+      "sizeUnitAriaLabel": "Alternar unidad de medida entre metros cuadrados, pies cuadrados y acres",
+      "commentLabel": "Comentarios o Preguntas (opcional)",
+      "commentPlaceholder": "Cuéntanos algo más sobre tu propiedad o qué te gustaría saber...",
+      "commentAriaLabel": "Comentarios o preguntas adicionales (opcional)",
+      "submitButton": "Solicitar Mi CMA Gratuito",
+      "submitButtonAriaLabel": "Enviar tu solicitud de CMA",
+      "submittingButton": "Enviando...",
+      "validation": {
+        "nameRequired": "Por favor ingresa tu nombre",
+        "phoneRequired": "Por favor ingresa tu número de teléfono",
+        "phoneInvalid": "Por favor ingresa un número de teléfono válido",
+        "emailInvalid": "Por favor ingresa un correo electrónico válido"
+      }
+    },
+    "confirmation": {
+      "heading": "¡Solicitud de CMA Recibida!",
+      "subheading": "Tu agente preparará tu Análisis Comparativo de Mercado y te contactará dentro de 24 horas.",
+      "agentMatchHeading": "Tu Agente Asignado",
+      "browseWhileWaiting": "Mientras esperas, explora lo que se vende en tu zona"
+    }
+  }
+}
+```
+
+---
+
+## dangerouslySetInnerHTML Audit
+
+**Epic 4 retrospective requirement:** Any use of `dangerouslySetInnerHTML` must enumerate escape requirements at the output sink.
+
+This story does NOT use `dangerouslySetInnerHTML`. All content is developer-authored static text rendered via i18n keys.
+
+---
+
+## Test Requirements
+
+### Unit Tests (`tests/unit/seller/`)
+
+Per the Epic 5 test design, the following tests cover Story 5.2:
+
+| Test ID | What to test | File |
+|---------|-------------|------|
+| 5.2-COMP-001 | CMA form renders all fields (name, phone, email, type, location, size, comment) | `tests/unit/seller/cma-form.spec.tsx` |
+| 5.2-COMP-002 | CMA form validation — name and phone required, email optional | `tests/unit/seller/cma-form.spec.tsx` |
+| 5.2-COMP-003 | CMA form builds payload with source="cma_form" and intent="sell" | `tests/unit/seller/cma-form.spec.tsx` |
+| 5.2-COMP-004 | CMA confirmation screen shows different heading than seller confirmation | `tests/unit/seller/cma-form.spec.tsx` |
+| 5.2-COMP-005 | LocationPicker reused (not duplicated) for CMA location field | `tests/unit/seller/cma-form.spec.tsx` |
+| 5.2-COMP-006 | CMA form strings in Spanish locale | `tests/unit/seller/cma-form.spec.tsx` |
+| 5.2-COMP-007 | Size unit toggle uses useLocaleUnits hook | `tests/unit/seller/cma-form.spec.tsx` |
+| 5.2-E2E-001 | CMA form accessible from seller page secondary CTA | `tests/unit/seller/cma-form.spec.tsx` |
+
+**Client Component tests use standard RTL `render()`.**
+
+**Mock for `CmaForm` in page-level tests:**
+```typescript
+vi.mock('@/components/seller/cma-form', () => ({
+  CmaForm: () => <div data-testid="cma-form-mock" />,
+}));
+```
+
+### data-testid Contract (CANNOT be renamed)
+
+| `data-testid` | Component | Defined in Story |
+|--------------|-----------|-----------------|
+| `cma-form` | `CmaForm` wrapper | 5.2 |
+| `cma-form-fields` | Form fields container | 5.2 |
+| `cma-confirmation` | CMA confirmation screen | 5.2 |
+| `cma-hero` | CMA value proposition section | 5.2 |
+| `cma-submit-button` | Submit button | 5.2 |
+
+---
+
+## Architecture Compliance Checklist
+
+- [ ] `CmaForm` uses `next/dynamic` with `{ ssr: false }` via `CmaFormLoader` (lazy-load)
+- [ ] `CmaForm` is a Client Component (`'use client'`)
+- [ ] `CmaHero` is a Client Component (uses useTranslations hook for i18n)
+- [ ] `LocationPicker` imported from `@/components/seller/location-picker` — NOT duplicated
+- [ ] `useLocaleUnits` used for size unit toggle (not custom state)
+- [ ] `AgentCard` imported from `@/components/agent/agent-card` via `SellerConfirmation` — NOT duplicated
+- [ ] All translatable strings in `CmaForm` i18n namespace — zero hardcoded EN/ES strings
+- [ ] All aria-labels use i18n keys
+- [ ] `data-testid` contracts applied exactly
+- [ ] Same validation patterns as Story 5.1 (phone regex, email regex)
+- [ ] Lead payload includes `source: "cma_form"` and `intent: "sell"` (R-009 mitigation)
+- [ ] No `dangerouslySetInnerHTML` in new files
+- [ ] `SellerConfirmation` enhanced with `source` prop (backward compatible, defaults to "seller")
+- [ ] `npm run typecheck && npm run lint && npm run format:check && npm run build && npm test` all pass green
+
+---
+
+## Previous Story Intelligence
+
+### From Story 5.1 (critical patterns to follow)
+
+**1. i18n — every string must be in a namespace.**
+CMA form uses a separate `CmaForm` namespace (not `SellerPage`). This keeps the i18n tree clean and allows separate loading.
+
+**2. Validation patterns — reuse, don't reinvent.**
+Phone: `PHONE_RE = /^\+?[\d\s\-()]+$/` + `≥7 digits`
+Email: `EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/`
+These are the project standard (same as contact-form.tsx). Story 5.3 will replace with Zod schemas.
+
+**3. Lazy-loading via `next/dynamic`.**
+Follow the `SellerFormLoader` pattern — a thin `'use client'` wrapper that calls `dynamic()`. Required by Turbopack.
+
+**4. `AgentCard` prop contract.**
+Pass through `SellerConfirmation` — `agent`, `propertyTitle=""`, `propertyRef=""`, `locale`, `officeName`.
+
+**5. Stub submission.**
+CMA form does NOT call `/api/leads`. That's Story 5.3. Use `console.log` + 500ms delay + confirmation screen.
+
+**6. `Link` import pattern.**
+Use `Link` from `@/i18n/navigation` for all internal links.
+
+---
+
+## Risk Mitigation
+
+From `test-design-epic-5.md`:
+
+- **R-009 (BUS, score 3):** CMA source/intent tagging. Mitigated by: `buildCmaLeadPayload()` always sets `source: "cma_form"` + `intent: "sell"`. Test 5.2-COMP-003 verifies this.
+- **R-011 (BUS, score 3):** Form validation errors in wrong locale. Mitigated by: all validation messages via CmaForm i18n namespace. Test 5.2-COMP-006 verifies Spanish locale.
+
+---
+
+## References
+
+- `_bmad-output/planning-artifacts/epics.md` — Epic 5, Story 5.2 (§ "Story 5.2: CMA Request Form")
+- `_bmad-output/planning-artifacts/prd.md` — FR41, FR42, FR43
+- `_bmad-output/implementation-artifacts/5-1-seller-landing-page-and-list-with-us-form.md` — Patterns to reuse
+- `_bmad-output/test-artifacts/test-design-epic-5.md` — Risk register, test scenarios for Story 5.2
+- `_bmad-output/implementation-artifacts/epic-4-retro-2026-05-03.md` — Action items
+- `src/components/seller/seller-form.tsx` — Reference implementation for form patterns
+- `src/components/seller/location-picker.tsx` — Shared component to reuse
+- `src/components/seller/seller-confirmation.tsx` — Confirmation component to enhance
+
+---
+
+*Story context engine analysis completed — comprehensive developer guide created.*

--- a/_bmad-output/test-artifacts/atdd-checklist-5-2-cma-request-form.md
+++ b/_bmad-output/test-artifacts/atdd-checklist-5-2-cma-request-form.md
@@ -1,0 +1,101 @@
+---
+stepsCompleted:
+  - step-01-preflight-and-context
+  - step-02-generation-mode
+  - step-03-test-strategy
+  - step-04-generate-tests
+  - step-04c-aggregate
+  - step-05-validate-and-complete
+lastStep: step-05-validate-and-complete
+lastSaved: '2026-05-11'
+storyId: '5.2'
+storyKey: 5-2-cma-request-form
+storyFile: _bmad-output/implementation-artifacts/5-2-cma-request-form.md
+atddChecklistPath: _bmad-output/test-artifacts/atdd-checklist-5-2-cma-request-form.md
+generatedTestFiles:
+  - tests/unit/seller/cma-form.spec.tsx
+inputDocuments:
+  - _bmad-output/implementation-artifacts/5-2-cma-request-form.md
+  - _bmad-output/test-artifacts/test-design-epic-5.md
+  - _bmad/tea/config.yaml
+  - _bmad-output/test-artifacts/atdd-checklist-5-1-seller-landing-page-and-list-with-us-form.md
+---
+
+# ATDD Checklist: Story 5.2 — CMA Request Form
+
+**Story ID:** 5.2
+**Story Key:** `5-2-cma-request-form`
+**Date:** 2026-05-11
+**Stack:** fullstack (Next.js 14 SSG + React + Vitest)
+**TDD Phase:** RED — all scaffolded tests use `it.skip()`
+
+---
+
+## TDD Red Phase Summary
+
+All scaffolded tests are in **RED phase** (skipped). They assert expected behavior
+that will only pass once the feature is implemented.
+
+| Category | File | Tests (all skipped) |
+|----------|------|---------------------|
+| Unit/Component (Vitest) | `tests/unit/seller/cma-form.spec.tsx` | 12 |
+| **Total** | | **12** |
+
+---
+
+## Acceptance Criteria → Test Coverage
+
+| AC | Description | Test ID | File | Priority |
+|----|-------------|---------|------|----------|
+| AC #1 | CMA form loads with value proposition | 5.2-E2E-001 | unit/seller/cma-form.spec.tsx | P1 |
+| AC #2 | Form collects all required fields (name, phone, email, type, location, size, comment) | 5.2-COMP-001 | unit/seller/cma-form.spec.tsx | P0 |
+| AC #3 | Lead stored with source="cma_form" intent="sell" | 5.2-COMP-003 | unit/seller/cma-form.spec.tsx | P0 |
+| AC #4 | CMA confirmation screen with agent card | 5.2-COMP-004 | unit/seller/cma-form.spec.tsx | P1 |
+| AC #5 | CMA accessible as secondary CTA on seller page | 5.2-E2E-001 | unit/seller/cma-form.spec.tsx | P1 |
+| AC #6 | Form labels/validation in selected locale | 5.2-COMP-006 | unit/seller/cma-form.spec.tsx | P2 |
+| AC #7 | Shares form field components with seller form | 5.2-COMP-005 | unit/seller/cma-form.spec.tsx | P1 |
+
+---
+
+## Risk Mitigations
+
+| Risk | Score | Mitigation Test | Status |
+|------|-------|----------------|--------|
+| R-009: CMA source/intent tagging | 3 | 5.2-COMP-003 (buildCmaLeadPayload) | RED — awaiting implementation |
+| R-011: Validation errors in wrong locale | 3 | 5.2-COMP-006 | RED — awaiting implementation |
+
+---
+
+## data-testid Contract (Frozen — CANNOT Rename)
+
+| `data-testid` | Component | File |
+|--------------|-----------|------|
+| `cma-form` | `CmaForm` wrapper | `src/components/seller/cma-form.tsx` |
+| `cma-form-fields` | Form fields container | `src/components/seller/cma-form.tsx` |
+| `cma-confirmation` | CMA confirmation screen | `src/components/seller/seller-confirmation.tsx` |
+| `cma-hero` | CMA value proposition section | `src/components/seller/cma-hero.tsx` |
+| `cma-submit-button` | Submit button | `src/components/seller/cma-form.tsx` |
+| `location-text-input` | Text address input (reused from 5.1) | `src/components/seller/location-picker.tsx` |
+| `location-map` | Map container (reused from 5.1) | `src/components/seller/location-picker.tsx` |
+
+---
+
+## Recommended Activation Order
+
+| Order | Component | Tests to Activate |
+|-------|-----------|------------------|
+| 1 | `CmaHero` | `cma-form.spec.tsx` — 5.2-E2E-001 |
+| 2 | `CmaForm` fields rendering | `cma-form.spec.tsx` — 5.2-COMP-001 |
+| 3 | `CmaForm` validation | `cma-form.spec.tsx` — 5.2-COMP-002 tests |
+| 4 | `buildCmaLeadPayload` | `cma-form.spec.tsx` — 5.2-COMP-003 |
+| 5 | `CmaForm` confirmation flow | `cma-form.spec.tsx` — 5.2-COMP-004 |
+| 6 | `CmaForm` i18n | `cma-form.spec.tsx` — 5.2-COMP-006 |
+
+---
+
+## ATDD Artifacts
+
+- **Story file:** `_bmad-output/implementation-artifacts/5-2-cma-request-form.md`
+- **This checklist:** `_bmad-output/test-artifacts/atdd-checklist-5-2-cma-request-form.md`
+- **Component tests:** `tests/unit/seller/cma-form.spec.tsx`
+- **Next workflow:** `bmad-dev-story` → implement story 5.2 with these tests guiding the TDD cycle

--- a/src/app/[locale]/sell/page.tsx
+++ b/src/app/[locale]/sell/page.tsx
@@ -76,4 +76,3 @@ export default async function SellPage({ params }: { params: Promise<{ locale: s
     </main>
   );
 }
-

--- a/src/app/[locale]/sell/page.tsx
+++ b/src/app/[locale]/sell/page.tsx
@@ -1,5 +1,5 @@
 /**
- * SellPage — Story 5.1 (AC #1, #12, #13, #14)
+ * SellPage — Story 5.1 (AC #1, #12, #13, #14) + Story 5.2 (AC #5)
  *
  * SSG seller landing page at /{locale}/sell.
  * Follows the exact pattern of src/app/[locale]/about/page.tsx.
@@ -10,6 +10,8 @@
  * (AC #14). SellerFormLoader is a thin 'use client' wrapper following the PropertyGalleryLoader
  * pattern — required by Turbopack which enforces that dynamic(ssr:false) must live in a Client
  * Component.
+ *
+ * Story 5.2 adds the CMA form as a secondary CTA section below the seller form.
  */
 
 import type { Metadata } from "next";
@@ -17,6 +19,8 @@ import { getTranslations, setRequestLocale } from "next-intl/server";
 import { buildAlternatesMetadata } from "@/lib/seo/metadata";
 import { SellerHero } from "@/components/seller/seller-hero";
 import { SellerFormLoader } from "@/components/seller/seller-form-loader";
+import { CmaHero } from "@/components/seller/cma-hero";
+import { CmaFormLoader } from "@/components/seller/cma-form-loader";
 import { getAllAgents } from "@/lib/db/queries/agents";
 import { getOfficeById } from "@/lib/db/queries/offices";
 
@@ -64,6 +68,12 @@ export default async function SellPage({ params }: { params: Promise<{ locale: s
     <main>
       <SellerHero locale={locale} />
       <SellerFormLoader locale={locale} fallbackAgent={fallbackAgent} officeName={officeName} />
+
+      {/* CMA section — secondary CTA (Story 5.2, AC #5) */}
+      <CmaHero locale={locale}>
+        <CmaFormLoader locale={locale} fallbackAgent={fallbackAgent} officeName={officeName} />
+      </CmaHero>
     </main>
   );
 }
+

--- a/src/components/seller/cma-form-loader.tsx
+++ b/src/components/seller/cma-form-loader.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+/**
+ * CmaFormLoader — Client Component wrapper using next/dynamic (ssr: false).
+ *
+ * Thin Client Component wrapper that lazy-loads CmaForm.
+ * The 'use client' directive is required because next/dynamic with ssr: false
+ * can only be called from Client Component context (Turbopack constraint).
+ *
+ * Story 5.2 — pattern mirrors SellerFormLoader (Story 5.1).
+ */
+
+import dynamic from "next/dynamic";
+import { SellerFormSkeleton } from "@/components/seller/seller-form-skeleton";
+import type { Agent } from "@/lib/db/schema/agents";
+
+interface CmaFormLoaderProps {
+  locale: string;
+  fallbackAgent: Agent | null;
+  officeName?: string;
+}
+
+const CmaFormDynamic = dynamic(
+  () => import("@/components/seller/cma-form").then((m) => ({ default: m.CmaForm })),
+  {
+    ssr: false,
+    loading: () => <SellerFormSkeleton />,
+  },
+);
+
+export function CmaFormLoader(props: CmaFormLoaderProps) {
+  return <CmaFormDynamic {...props} />;
+}

--- a/src/components/seller/cma-form.tsx
+++ b/src/components/seller/cma-form.tsx
@@ -139,11 +139,7 @@ interface CmaFormProps {
   officeName?: string;
 }
 
-export function CmaForm({
-  locale,
-  fallbackAgent,
-  officeName = "RE/MAX Altitud",
-}: CmaFormProps) {
+export function CmaForm({ locale, fallbackAgent, officeName = "RE/MAX Altitud" }: CmaFormProps) {
   const t = useTranslations("CmaForm");
   const { unitSystem, toggleUnits } = useLocaleUnits(locale);
 
@@ -221,7 +217,14 @@ export function CmaForm({
 
   // ---- Post-submit: show confirmation screen ----
   if (submitted && fallbackAgent) {
-    return <SellerConfirmation agent={fallbackAgent} officeName={officeName} locale={locale} source="cma" />;
+    return (
+      <SellerConfirmation
+        agent={fallbackAgent}
+        officeName={officeName}
+        locale={locale}
+        source="cma"
+      />
+    );
   }
 
   return (
@@ -313,10 +316,7 @@ export function CmaForm({
                 id={id}
                 value={formData.propertyType}
                 onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-                  updateField(
-                    "propertyType",
-                    e.target.value as CmaFormData["propertyType"],
-                  )
+                  updateField("propertyType", e.target.value as CmaFormData["propertyType"])
                 }
                 aria-label={t("form.propertyTypeAriaLabel")}
                 className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"

--- a/src/components/seller/cma-form.tsx
+++ b/src/components/seller/cma-form.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+/**
+ * CmaForm — Story 5.2 (AC #1–#7)
+ *
+ * Single-page CMA request form for seller lead capture.
+ * Simpler than the 3-step SellerForm — all fields on one page.
+ * Lazy-loaded via next/dynamic in cma-form-loader.tsx.
+ *
+ * Reuses:
+ *   - LocationPicker from Story 5.1 (shared component)
+ *   - SellerConfirmation with source="cma" variant
+ *   - useLocaleUnits for size unit toggle
+ *   - Same validation patterns as seller-form.tsx
+ *
+ * data-testid contract (CANNOT rename):
+ *   cma-form             — root wrapper
+ *   cma-form-fields      — fields container
+ *   cma-submit-button    — submit button
+ *   cma-confirmation     — rendered by SellerConfirmation (source="cma")
+ */
+
+import { useState, useId, type FormEvent, type ChangeEvent } from "react";
+import { useTranslations } from "next-intl";
+import { useLocaleUnits } from "@/hooks/use-locale-units";
+import { LocationPicker, type LocationValue } from "@/components/seller/location-picker";
+import { SellerConfirmation } from "@/components/seller/seller-confirmation";
+import type { Agent } from "@/lib/db/schema/agents";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CmaFormData {
+  name: string;
+  phone: string;
+  email: string;
+  propertyType: "Casa" | "Lote/Terreno" | "Finca" | "Condominio" | "Comercial" | "";
+  location: LocationValue;
+  approximateSize: string;
+  sizeUnit: "sqm" | "sqft" | "acres";
+  comment: string;
+}
+
+type FormErrors = Partial<Record<"name" | "phone" | "email", string>>;
+
+// ---------------------------------------------------------------------------
+// buildCmaLeadPayload — exported for test 5.2-COMP-003
+// ---------------------------------------------------------------------------
+
+export interface CmaLeadPayload {
+  source: "cma_form";
+  intent: "sell";
+  name: string;
+  phone: string;
+  email: string;
+  propertyType: string;
+  location: LocationValue;
+  approximateSize: string;
+  sizeUnit: string;
+  comment: string;
+}
+
+export function buildCmaLeadPayload(data: CmaFormData): CmaLeadPayload {
+  return {
+    source: "cma_form",
+    intent: "sell",
+    name: data.name,
+    phone: data.phone,
+    email: data.email,
+    propertyType: data.propertyType,
+    location: data.location,
+    approximateSize: data.approximateSize,
+    sizeUnit: data.sizeUnit,
+    comment: data.comment,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Field helper (same pattern as seller-form.tsx)
+// ---------------------------------------------------------------------------
+
+interface FieldProps {
+  label: string;
+  error?: string;
+  required?: boolean;
+  optional?: boolean;
+  optionalLabel?: string;
+  children: (params: { id: string; describedBy?: string; invalid: boolean }) => React.ReactNode;
+}
+
+function Field({ label, error, required, optional, optionalLabel, children }: FieldProps) {
+  const reactId = useId();
+  const id = `cma-${reactId}`;
+  const errorId = error ? `${id}-error` : undefined;
+  const invalid = Boolean(error);
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={id} className="text-sm font-semibold text-brand-navy">
+        {label}
+        {required && (
+          <span aria-hidden className="ml-0.5 text-red-500">
+            *
+          </span>
+        )}
+        {optional && optionalLabel && (
+          <span className="ml-1 text-xs font-normal text-text-muted">{optionalLabel}</span>
+        )}
+      </label>
+      {children({ id, describedBy: errorId, invalid })}
+      {error && (
+        <span id={errorId} role="alert" className="text-xs text-[var(--color-error,#dc2626)]">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Property type options
+// ---------------------------------------------------------------------------
+
+const PROPERTY_TYPES = [
+  { value: "Casa", key: "typeCasa" },
+  { value: "Lote/Terreno", key: "typeLote" },
+  { value: "Finca", key: "typeFinca" },
+  { value: "Condominio", key: "typeCondominio" },
+  { value: "Comercial", key: "typeCommercial" },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Main CmaForm component
+// ---------------------------------------------------------------------------
+
+interface CmaFormProps {
+  locale: string;
+  fallbackAgent: Agent | null;
+  officeName?: string;
+}
+
+export function CmaForm({
+  locale,
+  fallbackAgent,
+  officeName = "RE/MAX Altitud",
+}: CmaFormProps) {
+  const t = useTranslations("CmaForm");
+  const { unitSystem, toggleUnits } = useLocaleUnits(locale);
+
+  // ---- Stable IDs for fields not wrapped by Field helper ----
+  const emailFieldReactId = useId();
+  const emailFieldId = `cma-email-${emailFieldReactId}`;
+  const emailErrorId = `${emailFieldId}-error`;
+
+  // ---- Form state ----
+  const [submitted, setSubmitted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const [formData, setFormData] = useState<CmaFormData>({
+    name: "",
+    phone: "",
+    email: "",
+    propertyType: "",
+    location: { text: "", lat: null, lng: null },
+    approximateSize: "",
+    sizeUnit: unitSystem === "metric" ? "sqm" : "sqft",
+    comment: "",
+  });
+
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  // ---- Field update helper ----
+  function updateField<K extends keyof CmaFormData>(key: K, value: CmaFormData[K]) {
+    setFormData((prev) => ({ ...prev, [key]: value }));
+  }
+
+  // ---- Validation (same patterns as seller-form.tsx) ----
+  const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
+  const phoneHasEnoughDigits = (v: string) => v.replace(/\D/g, "").length >= 7;
+  const PHONE_RE = /^\+?[\d\s\-()]+$/;
+
+  function validate(): FormErrors {
+    const errs: FormErrors = {};
+    if (!formData.name.trim()) {
+      errs.name = t("form.validation.nameRequired");
+    }
+    if (!formData.phone.trim()) {
+      errs.phone = t("form.validation.phoneRequired");
+    } else if (!PHONE_RE.test(formData.phone) || !phoneHasEnoughDigits(formData.phone)) {
+      errs.phone = t("form.validation.phoneInvalid");
+    }
+    if (formData.email && !EMAIL_RE.test(formData.email)) {
+      errs.email = t("form.validation.emailInvalid");
+    }
+    return errs;
+  }
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    const errs = validate();
+    if (Object.keys(errs).length > 0) {
+      setErrors(errs);
+      return;
+    }
+    setErrors({});
+    setSubmitting(true);
+
+    // 5.2 stub — Story 5.3 replaces with real API call.
+    const payload = buildCmaLeadPayload(formData);
+    if (process.env.NODE_ENV !== "production") {
+      console.log("[5.2 stub] CMA form payload:", payload);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    setSubmitting(false);
+    setSubmitted(true);
+  }
+
+  // Unit label
+  const sizeUnitLabel = unitSystem === "metric" ? "m²" : "ft²";
+
+  // ---- Post-submit: show confirmation screen ----
+  if (submitted && fallbackAgent) {
+    return <SellerConfirmation agent={fallbackAgent} officeName={officeName} locale={locale} source="cma" />;
+  }
+
+  return (
+    <div data-testid="cma-form" className="mx-auto max-w-2xl">
+      <h3 className="mb-6 text-xl font-bold text-brand-navy">{t("form.heading")}</h3>
+
+      <form onSubmit={handleSubmit} noValidate>
+        <div data-testid="cma-form-fields" className="space-y-5">
+          {/* Name (required) */}
+          <Field label={t("form.nameLabel")} required error={errors.name}>
+            {({ id, describedBy, invalid }) => (
+              <input
+                id={id}
+                type="text"
+                value={formData.name}
+                onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("name", e.target.value)}
+                placeholder={t("form.namePlaceholder")}
+                aria-label={t("form.nameAriaLabel")}
+                aria-describedby={describedBy}
+                aria-invalid={invalid || undefined}
+                required
+                autoComplete="name"
+                className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
+              />
+            )}
+          </Field>
+
+          {/* Phone / WhatsApp (required) */}
+          <div className="space-y-1.5">
+            <Field label={t("form.phoneLabel")} required error={errors.phone}>
+              {({ id, describedBy, invalid }) => (
+                <input
+                  id={id}
+                  type="tel"
+                  value={formData.phone}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    updateField("phone", e.target.value)
+                  }
+                  placeholder={t("form.phonePlaceholder")}
+                  aria-label={t("form.phoneAriaLabel")}
+                  aria-describedby={describedBy}
+                  aria-invalid={invalid || undefined}
+                  required
+                  autoComplete="tel"
+                  className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
+                />
+              )}
+            </Field>
+            <p className="text-xs text-text-muted">{t("form.phoneDescription")}</p>
+          </div>
+
+          {/* Email (optional) */}
+          <div>
+            <div className="mb-1.5 flex items-center gap-2">
+              <label htmlFor={emailFieldId} className="text-sm font-semibold text-brand-navy">
+                {t("form.emailLabel")}
+              </label>
+              <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-text-muted">
+                {t("form.emailOptionalBadge")}
+              </span>
+            </div>
+            <input
+              id={emailFieldId}
+              type="email"
+              value={formData.email}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("email", e.target.value)}
+              placeholder={t("form.emailPlaceholder")}
+              aria-label={t("form.emailAriaLabel")}
+              aria-describedby={errors.email ? emailErrorId : undefined}
+              aria-invalid={errors.email ? true : undefined}
+              autoComplete="email"
+              className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
+            />
+            {errors.email && (
+              <span
+                id={emailErrorId}
+                role="alert"
+                className="mt-1 text-xs text-[var(--color-error,#dc2626)]"
+              >
+                {errors.email}
+              </span>
+            )}
+          </div>
+
+          {/* Property Type (optional dropdown) */}
+          <Field label={t("form.propertyTypeLabel")}>
+            {({ id }) => (
+              <select
+                id={id}
+                value={formData.propertyType}
+                onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+                  updateField(
+                    "propertyType",
+                    e.target.value as CmaFormData["propertyType"],
+                  )
+                }
+                aria-label={t("form.propertyTypeAriaLabel")}
+                className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
+              >
+                <option value="">{t("form.propertyTypePlaceholder")}</option>
+                {PROPERTY_TYPES.map(({ value, key }) => (
+                  <option key={value} value={value}>
+                    {t(`form.${key}` as Parameters<typeof t>[0])}
+                  </option>
+                ))}
+              </select>
+            )}
+          </Field>
+
+          {/* Location (reusing LocationPicker from Story 5.1) */}
+          <div>
+            <span className="mb-2 block text-sm font-semibold text-brand-navy">
+              {t("form.locationLabel")}
+            </span>
+            <LocationPicker
+              value={formData.location}
+              onChange={(val) => updateField("location", val)}
+              locale={locale}
+              placeholder={t("form.locationPlaceholder")}
+            />
+          </div>
+
+          {/* Approximate Size + unit toggle */}
+          <Field label={t("form.sizeLabel")}>
+            {({ id }) => (
+              <div className="flex gap-2">
+                <input
+                  id={id}
+                  type="number"
+                  value={formData.approximateSize}
+                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                    updateField("approximateSize", e.target.value)
+                  }
+                  placeholder={t("form.sizePlaceholder")}
+                  aria-label={t("form.sizeAriaLabel")}
+                  min="0"
+                  className="flex-1 rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
+                />
+                <button
+                  type="button"
+                  data-testid="cma-size-unit-toggle"
+                  onClick={toggleUnits}
+                  aria-label={t("form.sizeUnitAriaLabel")}
+                  className="rounded-lg border border-border px-4 py-3 text-sm font-semibold text-brand-navy hover:bg-gray-50"
+                >
+                  {sizeUnitLabel}
+                </button>
+              </div>
+            )}
+          </Field>
+
+          {/* Comment / Message (optional) */}
+          <Field label={t("form.commentLabel")}>
+            {({ id }) => (
+              <textarea
+                id={id}
+                value={formData.comment}
+                onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                  updateField("comment", e.target.value)
+                }
+                placeholder={t("form.commentPlaceholder")}
+                aria-label={t("form.commentAriaLabel")}
+                rows={3}
+                className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy resize-none"
+              />
+            )}
+          </Field>
+        </div>
+
+        {/* Submit button */}
+        <div className="mt-8">
+          <button
+            type="submit"
+            data-testid="cma-submit-button"
+            disabled={submitting}
+            aria-label={t("form.submitButtonAriaLabel")}
+            className="w-full rounded-lg bg-brand-navy px-8 py-3.5 text-sm font-semibold text-white transition-colors hover:bg-brand-navy/90 disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {submitting ? t("form.submittingButton") : t("form.submitButton")}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/seller/cma-hero.tsx
+++ b/src/components/seller/cma-hero.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+/**
+ * CmaHero — Story 5.2 (AC #1, #5)
+ *
+ * Value proposition section for the CMA request form.
+ * Renders as a secondary CTA on the seller page, below the main seller form.
+ * Explains what a CMA is and why it's free.
+ *
+ * Client Component because it uses useTranslations (client-side hook).
+ * data-testid="cma-hero" on the root section (AC #5 contract).
+ */
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+
+interface CmaHeroProps {
+  locale: string;
+  /** When true, the CMA form section starts expanded. */
+  defaultExpanded?: boolean;
+  children?: React.ReactNode;
+}
+
+export function CmaHero({ locale: _locale, defaultExpanded = false, children }: CmaHeroProps) { // eslint-disable-line @typescript-eslint/no-unused-vars
+  const t = useTranslations("CmaForm");
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  return (
+    <section
+      data-testid="cma-hero"
+      className="mx-auto max-w-2xl px-4 py-12"
+      aria-labelledby="cma-hero-heading"
+    >
+      {/* Divider */}
+      <div className="mb-8 flex items-center gap-4">
+        <div className="h-px flex-1 bg-border" />
+        <span className="text-xs font-semibold uppercase tracking-widest text-text-muted">
+          {t("hero.subheading")}
+        </span>
+        <div className="h-px flex-1 bg-border" />
+      </div>
+
+      {/* CMA value proposition card */}
+      <div className="rounded-xl border border-brand-gold/30 bg-gradient-to-br from-brand-gold/5 to-transparent p-6 md:p-8">
+        <h2
+          id="cma-hero-heading"
+          className="text-2xl font-bold text-brand-navy md:text-3xl"
+        >
+          {t("hero.heading")}
+        </h2>
+
+        <p className="mt-3 text-sm text-text-muted leading-relaxed md:text-base">
+          {t("hero.description")}
+        </p>
+
+        {!expanded && (
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            aria-label={t("hero.ctaButtonAriaLabel")}
+            className="mt-6 inline-flex h-11 items-center rounded-lg border-2 border-brand-gold bg-brand-gold/10 px-6 text-sm font-bold text-brand-navy transition-colors hover:bg-brand-gold/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-gold"
+          >
+            {t("hero.ctaButton")}
+          </button>
+        )}
+      </div>
+
+      {/* Expanded CMA form (children = CmaFormLoader) */}
+      {expanded && <div className="mt-8">{children}</div>}
+    </section>
+  );
+}

--- a/src/components/seller/cma-hero.tsx
+++ b/src/components/seller/cma-hero.tsx
@@ -21,7 +21,8 @@ interface CmaHeroProps {
   children?: React.ReactNode;
 }
 
-export function CmaHero({ locale: _locale, defaultExpanded = false, children }: CmaHeroProps) { // eslint-disable-line @typescript-eslint/no-unused-vars
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function CmaHero({ locale: _locale, defaultExpanded = false, children }: CmaHeroProps) {
   const t = useTranslations("CmaForm");
   const [expanded, setExpanded] = useState(defaultExpanded);
 
@@ -42,10 +43,7 @@ export function CmaHero({ locale: _locale, defaultExpanded = false, children }: 
 
       {/* CMA value proposition card */}
       <div className="rounded-xl border border-brand-gold/30 bg-gradient-to-br from-brand-gold/5 to-transparent p-6 md:p-8">
-        <h2
-          id="cma-hero-heading"
-          className="text-2xl font-bold text-brand-navy md:text-3xl"
-        >
+        <h2 id="cma-hero-heading" className="text-2xl font-bold text-brand-navy md:text-3xl">
           {t("hero.heading")}
         </h2>
 

--- a/src/components/seller/seller-confirmation.tsx
+++ b/src/components/seller/seller-confirmation.tsx
@@ -23,15 +23,17 @@ interface SellerConfirmationProps {
   source?: "seller" | "cma";
 }
 
-export function SellerConfirmation({ agent, officeName, locale, source = "seller" }: SellerConfirmationProps) {
+export function SellerConfirmation({
+  agent,
+  officeName,
+  locale,
+  source = "seller",
+}: SellerConfirmationProps) {
   const t = useTranslations(source === "cma" ? "CmaForm" : "SellerPage");
   const testId = source === "cma" ? "cma-confirmation" : "seller-confirmation";
 
   return (
-    <div
-      data-testid={testId}
-      className="mx-auto max-w-lg space-y-6 py-8 px-4 text-center"
-    >
+    <div data-testid={testId} className="mx-auto max-w-lg space-y-6 py-8 px-4 text-center">
       {/* Success heading */}
       <div className="space-y-2">
         <div

--- a/src/components/seller/seller-confirmation.tsx
+++ b/src/components/seller/seller-confirmation.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 /**
- * SellerConfirmation — Story 5.1 (AC #11)
+ * SellerConfirmation — Story 5.1 (AC #11) + Story 5.2 (AC #4)
  *
  * Success screen shown after form submission.
  * Displays an agent match card using the existing AgentCard component (Story 4.2).
  *
- * data-testid="seller-confirmation" on the root container (AC #11 contract).
+ * Supports two variants via `source` prop:
+ *   - "seller" (default) — uses SellerPage i18n namespace, data-testid="seller-confirmation"
+ *   - "cma" — uses CmaForm i18n namespace, data-testid="cma-confirmation"
  */
 
 import { useTranslations } from "next-intl";
@@ -17,14 +19,17 @@ interface SellerConfirmationProps {
   agent: Agent;
   officeName: string;
   locale: string;
+  /** Confirmation variant — determines i18n namespace and testid. Defaults to "seller". */
+  source?: "seller" | "cma";
 }
 
-export function SellerConfirmation({ agent, officeName, locale }: SellerConfirmationProps) {
-  const t = useTranslations("SellerPage");
+export function SellerConfirmation({ agent, officeName, locale, source = "seller" }: SellerConfirmationProps) {
+  const t = useTranslations(source === "cma" ? "CmaForm" : "SellerPage");
+  const testId = source === "cma" ? "cma-confirmation" : "seller-confirmation";
 
   return (
     <div
-      data-testid="seller-confirmation"
+      data-testid={testId}
       className="mx-auto max-w-lg space-y-6 py-8 px-4 text-center"
     >
       {/* Success heading */}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -649,5 +649,61 @@
       "emailButtonAriaLabel": "Contact {agentName} via email",
       "browseWhileWaiting": "While you wait, explore what's selling in your area"
     }
+  },
+  "CmaForm": {
+    "hero": {
+      "heading": "Request a Free CMA",
+      "subheading": "Just need a valuation?",
+      "description": "A Comparative Market Analysis (CMA) is a professional assessment of your property's current market value. Our agents analyze recent sales, active listings, and market trends in your area to provide an accurate price estimate — completely free.",
+      "ctaButton": "Request a Free CMA",
+      "ctaButtonAriaLabel": "Open the CMA request form"
+    },
+    "form": {
+      "heading": "Request Your Free CMA",
+      "nameLabel": "Full Name",
+      "namePlaceholder": "Your name",
+      "nameAriaLabel": "Enter your full name",
+      "phoneLabel": "Phone / WhatsApp",
+      "phonePlaceholder": "+506 8888-8888",
+      "phoneAriaLabel": "Enter your phone or WhatsApp number",
+      "phoneDescription": "WhatsApp preferred — your agent will contact you here",
+      "emailLabel": "Email Address (optional)",
+      "emailPlaceholder": "your@email.com",
+      "emailAriaLabel": "Enter your email address (optional)",
+      "emailOptionalBadge": "Optional",
+      "propertyTypeLabel": "Property Type",
+      "propertyTypeAriaLabel": "Select property type (optional)",
+      "propertyTypePlaceholder": "Select type...",
+      "typeCasa": "House / Casa",
+      "typeLote": "Lot / Lote",
+      "typeFinca": "Farm / Finca",
+      "typeCondominio": "Condo / Condominio",
+      "typeCommercial": "Commercial / Comercial",
+      "locationLabel": "Property Location",
+      "locationPlaceholder": "Type address or nearest landmark",
+      "locationAriaLabel": "Enter property location",
+      "sizeLabel": "Approximate Size",
+      "sizePlaceholder": "e.g. 5000",
+      "sizeAriaLabel": "Enter approximate property size",
+      "sizeUnitAriaLabel": "Toggle size unit between square meters, square feet, and acres",
+      "commentLabel": "Comments or Questions (optional)",
+      "commentPlaceholder": "Tell us anything else about your property or what you'd like to know...",
+      "commentAriaLabel": "Additional comments or questions (optional)",
+      "submitButton": "Request My Free CMA",
+      "submitButtonAriaLabel": "Submit your CMA request",
+      "submittingButton": "Submitting...",
+      "validation": {
+        "nameRequired": "Please enter your name",
+        "phoneRequired": "Please enter your phone number",
+        "phoneInvalid": "Please enter a valid phone number",
+        "emailInvalid": "Please enter a valid email address"
+      }
+    },
+    "confirmation": {
+      "heading": "CMA Request Received!",
+      "subheading": "Your agent will prepare your Comparative Market Analysis and contact you within 24 hours.",
+      "agentMatchHeading": "Your Agent Match",
+      "browseWhileWaiting": "While you wait, explore what's selling in your area"
+    }
   }
 }

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -649,5 +649,61 @@
       "emailButtonAriaLabel": "Contactar a {agentName} por correo electrónico",
       "browseWhileWaiting": "Mientras espera, explore lo que se vende en su área"
     }
+  },
+  "CmaForm": {
+    "hero": {
+      "heading": "Solicita un Avalúo Gratuito",
+      "subheading": "¿Solo necesitas una valoración?",
+      "description": "Un Análisis Comparativo de Mercado (CMA) es una evaluación profesional del valor actual de tu propiedad. Nuestros agentes analizan ventas recientes, listados activos y tendencias del mercado en tu zona para darte un precio estimado preciso — completamente gratis.",
+      "ctaButton": "Solicitar CMA Gratuito",
+      "ctaButtonAriaLabel": "Abrir el formulario de solicitud de CMA"
+    },
+    "form": {
+      "heading": "Solicita tu CMA Gratuito",
+      "nameLabel": "Nombre Completo",
+      "namePlaceholder": "Tu nombre",
+      "nameAriaLabel": "Ingresa tu nombre completo",
+      "phoneLabel": "Teléfono / WhatsApp",
+      "phonePlaceholder": "+506 8888-8888",
+      "phoneAriaLabel": "Ingresa tu número de teléfono o WhatsApp",
+      "phoneDescription": "WhatsApp preferido — tu agente te contactará aquí",
+      "emailLabel": "Correo Electrónico (opcional)",
+      "emailPlaceholder": "tu@correo.com",
+      "emailAriaLabel": "Ingresa tu correo electrónico (opcional)",
+      "emailOptionalBadge": "Opcional",
+      "propertyTypeLabel": "Tipo de Propiedad",
+      "propertyTypeAriaLabel": "Selecciona el tipo de propiedad (opcional)",
+      "propertyTypePlaceholder": "Seleccionar tipo...",
+      "typeCasa": "Casa",
+      "typeLote": "Lote / Terreno",
+      "typeFinca": "Finca",
+      "typeCondominio": "Condominio",
+      "typeCommercial": "Comercial",
+      "locationLabel": "Ubicación de la Propiedad",
+      "locationPlaceholder": "Escribe la dirección o punto de referencia más cercano",
+      "locationAriaLabel": "Ingresa la ubicación de la propiedad",
+      "sizeLabel": "Tamaño Aproximado",
+      "sizePlaceholder": "ej. 5000",
+      "sizeAriaLabel": "Ingresa el tamaño aproximado de la propiedad",
+      "sizeUnitAriaLabel": "Alternar unidad de medida entre metros cuadrados, pies cuadrados y acres",
+      "commentLabel": "Comentarios o Preguntas (opcional)",
+      "commentPlaceholder": "Cuéntanos algo más sobre tu propiedad o qué te gustaría saber...",
+      "commentAriaLabel": "Comentarios o preguntas adicionales (opcional)",
+      "submitButton": "Solicitar Mi CMA Gratuito",
+      "submitButtonAriaLabel": "Enviar tu solicitud de CMA",
+      "submittingButton": "Enviando...",
+      "validation": {
+        "nameRequired": "Por favor ingresa tu nombre",
+        "phoneRequired": "Por favor ingresa tu número de teléfono",
+        "phoneInvalid": "Por favor ingresa un número de teléfono válido",
+        "emailInvalid": "Por favor ingresa un correo electrónico válido"
+      }
+    },
+    "confirmation": {
+      "heading": "¡Solicitud de CMA Recibida!",
+      "subheading": "Tu agente preparará tu Análisis Comparativo de Mercado y te contactará dentro de 24 horas.",
+      "agentMatchHeading": "Tu Agente Asignado",
+      "browseWhileWaiting": "Mientras esperas, explora lo que se vende en tu zona"
+    }
   }
 }

--- a/tests/unit/seller/cma-form.spec.tsx
+++ b/tests/unit/seller/cma-form.spec.tsx
@@ -1,0 +1,356 @@
+/**
+ * Tests: Story 5.2 — CMA Request Form
+ *
+ * data-testid contracts:
+ *   cma-form             — CmaForm wrapper
+ *   cma-form-fields      — form fields container
+ *   cma-confirmation     — CMA confirmation screen (rendered by SellerConfirmation source="cma")
+ *   cma-hero             — CMA value proposition section
+ *   cma-submit-button    — submit button
+ *
+ * Test IDs:
+ *   5.2-COMP-001  CMA form renders all fields
+ *   5.2-COMP-002  Validation (name + phone required, email optional)
+ *   5.2-COMP-003  Lead payload has source="cma_form" intent="sell"
+ *   5.2-COMP-004  CMA confirmation heading differs from seller confirmation
+ *   5.2-COMP-005  LocationPicker reused (not duplicated)
+ *   5.2-COMP-006  CMA form strings use CmaForm i18n namespace
+ *   5.2-COMP-007  Size unit toggle uses useLocaleUnits hook
+ *   5.2-E2E-001   CMA hero section renders with CTA
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const { mockToggleUnits } = vi.hoisted(() => ({
+  mockToggleUnits: vi.fn(),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: vi.fn().mockReturnValue((key: string) => key),
+}));
+
+vi.mock("@/hooks/use-locale-units", () => ({
+  useLocaleUnits: vi.fn().mockReturnValue({
+    unitSystem: "metric",
+    toggleUnits: mockToggleUnits,
+  }),
+}));
+
+vi.mock("@/components/seller/location-picker", () => ({
+  LocationPicker: ({
+    value,
+    onChange,
+    placeholder,
+  }: Record<string, unknown>) => (
+    <div data-testid="location-picker-mock">
+      <input
+        data-testid="location-text-input"
+        value={(value as { text: string }).text}
+        onChange={(e) =>
+          (
+            onChange as (val: {
+              text: string;
+              lat: number | null;
+              lng: number | null;
+            }) => void
+          )({
+            text: e.target.value,
+            lat: null,
+            lng: null,
+          })
+        }
+        placeholder={placeholder as string}
+      />
+    </div>
+  ),
+}));
+
+vi.mock("@/components/seller/seller-confirmation", () => ({
+  SellerConfirmation: ({ source }: { source?: string }) => (
+    <div
+      data-testid={source === "cma" ? "cma-confirmation" : "seller-confirmation"}
+    >
+      {`confirmation-${source ?? "seller"}`}
+    </div>
+  ),
+}));
+
+// imported AFTER mocks
+import { CmaForm, buildCmaLeadPayload } from "@/components/seller/cma-form";
+import { CmaHero } from "@/components/seller/cma-hero";
+import { useLocaleUnits } from "@/hooks/use-locale-units";
+
+const MOCK_AGENT = {
+  id: "agent-1",
+  remaxId: "A001",
+  firstName: "Test",
+  lastName: "Agent",
+  email: "test@agent.com",
+  phone: "+50688881234",
+  bio: null,
+  bioEs: null,
+  photoUrl: null,
+  languages: ["en", "es"],
+  officeId: "office-1",
+  slug: "test-agent",
+  isActive: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as const;
+
+function renderCmaForm() {
+  return render(
+    <CmaForm locale="en" fallbackAgent={MOCK_AGENT as never} officeName="RE/MAX Altitud" />,
+  );
+}
+
+describe("CmaForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 5.2-COMP-001: CMA form renders all fields
+  // ──────────────────────────────────────────────────────────────────────────
+  it("renders all CMA form fields (name, phone, email, type, location, size, comment)", () => {
+    renderCmaForm();
+
+    expect(screen.getByTestId("cma-form")).not.toBeNull();
+    expect(screen.getByTestId("cma-form-fields")).not.toBeNull();
+
+    // Name, phone, email inputs
+    expect(screen.getByPlaceholderText("form.namePlaceholder")).not.toBeNull();
+    expect(screen.getByPlaceholderText("form.phonePlaceholder")).not.toBeNull();
+    expect(screen.getByPlaceholderText("form.emailPlaceholder")).not.toBeNull();
+
+    // Property type dropdown
+    expect(screen.getByText("form.propertyTypePlaceholder")).not.toBeNull();
+
+    // LocationPicker (mock)
+    expect(screen.getByTestId("location-picker-mock")).not.toBeNull();
+
+    // Size input
+    expect(screen.getByPlaceholderText("form.sizePlaceholder")).not.toBeNull();
+
+    // Comment textarea
+    expect(screen.getByPlaceholderText("form.commentPlaceholder")).not.toBeNull();
+
+    // Submit button
+    expect(screen.getByTestId("cma-submit-button")).not.toBeNull();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 5.2-COMP-002: Validation — name and phone required, email optional
+  // ──────────────────────────────────────────────────────────────────────────
+  it("shows validation errors when name is empty on submit", async () => {
+    const user = userEvent.setup();
+    renderCmaForm();
+
+    await user.click(screen.getByTestId("cma-submit-button"));
+
+    expect(screen.getByText("form.validation.nameRequired")).not.toBeNull();
+  });
+
+  it("shows validation errors when phone is empty on submit", async () => {
+    const user = userEvent.setup();
+    renderCmaForm();
+
+    // Fill name but leave phone empty
+    await user.type(
+      screen.getByPlaceholderText("form.namePlaceholder"),
+      "John Doe",
+    );
+    await user.click(screen.getByTestId("cma-submit-button"));
+
+    expect(screen.getByText("form.validation.phoneRequired")).not.toBeNull();
+  });
+
+  it("does NOT require email — form submits without email", async () => {
+    const user = userEvent.setup();
+    renderCmaForm();
+
+    await user.type(
+      screen.getByPlaceholderText("form.namePlaceholder"),
+      "John Doe",
+    );
+    await user.type(
+      screen.getByPlaceholderText("form.phonePlaceholder"),
+      "+50688881234",
+    );
+    await user.click(screen.getByTestId("cma-submit-button"));
+
+    // No email error should appear
+    expect(screen.queryByText("form.validation.emailInvalid")).toBeNull();
+  });
+
+  it("shows email validation error for invalid email format", async () => {
+    const user = userEvent.setup();
+    renderCmaForm();
+
+    await user.type(
+      screen.getByPlaceholderText("form.namePlaceholder"),
+      "John Doe",
+    );
+    await user.type(
+      screen.getByPlaceholderText("form.phonePlaceholder"),
+      "+50688881234",
+    );
+    await user.type(
+      screen.getByPlaceholderText("form.emailPlaceholder"),
+      "not-an-email",
+    );
+    await user.click(screen.getByTestId("cma-submit-button"));
+
+    expect(screen.getByText("form.validation.emailInvalid")).not.toBeNull();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 5.2-COMP-003: Lead payload has source="cma_form" and intent="sell"
+  // ──────────────────────────────────────────────────────────────────────────
+  it("buildCmaLeadPayload sets source to 'cma_form' and intent to 'sell'", () => {
+    const payload = buildCmaLeadPayload({
+      name: "Test",
+      phone: "+50688881234",
+      email: "",
+      propertyType: "Casa",
+      location: { text: "Test location", lat: null, lng: null },
+      approximateSize: "500",
+      sizeUnit: "sqm",
+      comment: "Test comment",
+    });
+
+    expect(payload.source).toBe("cma_form");
+    expect(payload.intent).toBe("sell");
+    expect(payload.name).toBe("Test");
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 5.2-COMP-004: CMA confirmation screen after submission
+  // ──────────────────────────────────────────────────────────────────────────
+  it("shows CMA-specific confirmation screen after successful submission", async () => {
+    const user = userEvent.setup();
+    renderCmaForm();
+
+    await user.type(
+      screen.getByPlaceholderText("form.namePlaceholder"),
+      "John Doe",
+    );
+    await user.type(
+      screen.getByPlaceholderText("form.phonePlaceholder"),
+      "+50688881234",
+    );
+    await user.click(screen.getByTestId("cma-submit-button"));
+
+    // Wait for the 500ms stub delay + state update
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("cma-confirmation")).not.toBeNull();
+      },
+      { timeout: 2000 },
+    );
+
+    // Confirm it's the CMA variant, not seller
+    expect(screen.queryByTestId("seller-confirmation")).toBeNull();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 5.2-COMP-005: LocationPicker reused (not duplicated)
+  // ──────────────────────────────────────────────────────────────────────────
+  it("uses LocationPicker from seller/location-picker (shared component)", () => {
+    renderCmaForm();
+
+    // The mock LocationPicker renders data-testid="location-picker-mock"
+    // Confirms CmaForm imports LocationPicker rather than duplicating it
+    expect(screen.getByTestId("location-picker-mock")).not.toBeNull();
+    expect(screen.getByTestId("location-text-input")).not.toBeNull();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 5.2-COMP-006: CMA form strings use CmaForm i18n namespace
+  // ──────────────────────────────────────────────────────────────────────────
+  it("renders all form labels using CmaForm i18n namespace", () => {
+    renderCmaForm();
+
+    // The mock useTranslations returns the key itself.
+    // Verify the keys come from CmaForm namespace (form.* keys).
+    expect(screen.getByText("form.heading")).not.toBeNull();
+    expect(screen.getByText("form.nameLabel")).not.toBeNull();
+    expect(screen.getByText("form.phoneLabel")).not.toBeNull();
+    expect(screen.getByText("form.propertyTypeLabel")).not.toBeNull();
+    expect(screen.getByText("form.sizeLabel")).not.toBeNull();
+    expect(screen.getByText("form.commentLabel")).not.toBeNull();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // 5.2-COMP-007: Size unit toggle uses useLocaleUnits hook
+  // ──────────────────────────────────────────────────────────────────────────
+  it("size field uses useLocaleUnits for unit toggle", async () => {
+    const user = userEvent.setup();
+    renderCmaForm();
+
+    expect(useLocaleUnits).toHaveBeenCalledWith("en");
+
+    // Unit toggle button shows m² (metric mock)
+    const toggleButton = screen.getByTestId("cma-size-unit-toggle");
+    expect(toggleButton.textContent).toContain("m²");
+
+    // Click triggers toggleUnits
+    await user.click(toggleButton);
+    expect(mockToggleUnits).toHaveBeenCalledTimes(1);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // Lazy-load contract
+  // ──────────────────────────────────────────────────────────────────────────
+  it("CmaForm is exported from cma-form.tsx (lazy-load contract)", async () => {
+    const mod = await import("@/components/seller/cma-form");
+    expect(typeof mod.CmaForm).toBe("function");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 5.2-E2E-001: CMA hero section renders
+// ──────────────────────────────────────────────────────────────────────────────
+describe("CmaHero", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("renders CMA hero section with CTA button", () => {
+    render(
+      <CmaHero locale="en">
+        <div data-testid="cma-form-mock" />
+      </CmaHero>,
+    );
+
+    expect(screen.getByTestId("cma-hero")).not.toBeNull();
+    // CTA button should be visible (unexpanded state)
+    expect(screen.getByText("hero.ctaButton")).not.toBeNull();
+    // Form should NOT be visible yet
+    expect(screen.queryByTestId("cma-form-mock")).toBeNull();
+  });
+
+  it("expands to show children when CTA is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <CmaHero locale="en">
+        <div data-testid="cma-form-mock" />
+      </CmaHero>,
+    );
+
+    await user.click(screen.getByText("hero.ctaButton"));
+
+    // Now the form (children) should be visible
+    expect(screen.getByTestId("cma-form-mock")).not.toBeNull();
+    // CTA button should be hidden after expanding
+    expect(screen.queryByText("hero.ctaButton")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Story 5.2 — CMA Request Form

Replaces #142 with a clean implementation rebased onto `development` (includes Vitest 4 migration from #143).

### What's new
- **CmaForm** — single-page CMA request form with client-side validation
- **CmaHero** — collapsible value proposition CTA section  
- **CmaFormLoader** — lazy-load wrapper via `next/dynamic` (ssr: false, R-006)
- **SellerConfirmation** — enhanced with `source` prop for CMA/seller variants
- **sell/page.tsx** — CMA section integrated as secondary CTA
- **i18n** — `CmaForm` namespace added to `en.json` and `es.json`

### Tests
All **13 tests passing** (un-skipped from the previous red-phase scaffolds):
- 5.2-COMP-001 through 007 (form rendering, validation, payload, confirmation, LocationPicker reuse, i18n, unit toggle)
- 5.2-E2E-001 (CMA hero renders and expands)
- Lazy-load export contract

### Full suite
```
Test Files  62 passed | 1 skipped (63)
Tests       839 passed | 3 skipped (842)
```

TypeScript: ✅ | ESLint: ✅