### PR TITLE
fix: upgrade to node:24-alpine, cap DB pool, pin turbopack root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM node:22-alpine AS deps
+FROM node:24-alpine AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
 
-FROM node:22-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
-FROM node:22-alpine AS runner
+FROM node:24-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Fixes

Three deployment fixes that address the remaining build failures after PR #146 (lock file sync):

### 1. Upgrade to Node 24 Alpine (`Dockerfile`)
Node 22 ships npm 10.x which treats platform mismatches on optional dependencies (`@esbuild/aix-ppc64`, etc.) as fatal `EBADPLATFORM` errors during `npm ci`. Node 24 ships npm 11.x which properly skips incompatible optional deps.

### 2. Cap postgres connection pool (`src/lib/db/client.ts`)
During `next build`, multiple workers each create a `postgres()` instance (default 10 connections). With hundreds of property pages prerendering in parallel, this exceeds PostgreSQL's `max_connections` (typically 100), causing `sorry, too many clients already` (error 53300). Capped at `max: 3`.

### 3. Pin turbopack.root (`next.config.ts`)
Prevents Next.js from walking up the directory tree and finding stray lockfiles in parent directories, which causes incorrect workspace root detection.