### PR TITLE
Chore : Dist-Compatible Scripts for Coolify Deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
+RUN npm run scripts:build
 
 FROM node:24-alpine@sha256:d1b3b4da11eefd5941e7f0b9cf17783fc99d9c6fc34884a665f40a06dbdfc94f AS runner
 WORKDIR /app
@@ -21,6 +22,11 @@ RUN adduser --system --uid 1001 nextjs
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+
+# Bundled scripts for server-side operations (migrate, sync)
+COPY --from=builder --chown=nextjs:nodejs /app/dist ./dist
+# Migration SQL files needed by drizzle migrator at runtime
+COPY --from=builder --chown=nextjs:nodejs /app/src/lib/db/migrations ./src/lib/db/migrations
 
 # NOTE: /app/public/property-images requires a Docker volume mount for persistence
 # across redeploys. Configure in Coolify / docker-compose as:
@@ -35,3 +41,4 @@ ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
 CMD ["node", "server.js"]
+

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "db:studio": "drizzle-kit studio",
     "sync": "tsx scripts/run-sync.ts",
     "sync:dry-run": "tsx scripts/run-sync.ts --dry-run --verbose",
+    "scripts:build": "node scripts/build-scripts.mjs",
+    "dist:migrate": "node dist/migrate.mjs",
+    "dist:sync": "node dist/run-sync.mjs",
+    "dist:sync:dry-run": "node dist/run-sync.mjs --dry-run --verbose",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/build-scripts.mjs
+++ b/scripts/build-scripts.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+/**
+ * Bundles the standalone TypeScript scripts (migrate, sync) into plain JS
+ * that can run with `node` — no tsx required.
+ *
+ * Usage:  node scripts/build-scripts.mjs
+ *
+ * Output:
+ *   dist/migrate.mjs
+ *   dist/run-sync.mjs
+ */
+import { build } from "esbuild";
+import { mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, "..");
+
+// ── Plugin: resolve "server-only" to an empty shim ──────────────────────────
+// Next.js uses the `server-only` package to prevent importing server code
+// into client bundles. Outside Next.js this package throws at import-time.
+// We replace it with an empty module so the bundled scripts can run standalone.
+const serverOnlyShimPlugin = {
+  name: "server-only-shim",
+  setup(build) {
+    build.onResolve({ filter: /^server-only$/ }, () => ({
+      path: "server-only",
+      namespace: "server-only-shim",
+    }));
+    build.onLoad({ filter: /.*/, namespace: "server-only-shim" }, () => ({
+      contents: "// server-only shim — intentionally empty",
+      loader: "js",
+    }));
+  },
+};
+
+// ── Shared build options ────────────────────────────────────────────────────
+const shared = {
+  bundle: true,
+  platform: "node",
+  target: "node20",
+  format: "esm",
+  // Resolve the `@/*` path alias used throughout the codebase
+  alias: {
+    "@": path.resolve(root, "src"),
+  },
+  plugins: [serverOnlyShimPlugin],
+  // Keep node built-ins and heavy native deps external (they'll be in
+  // node_modules at runtime via Next.js standalone output)
+  external: [
+    "dotenv",
+    "drizzle-orm",
+    "drizzle-orm/*",
+    "postgres",
+    "sharp",
+    "deepl-node",
+    "zod",
+  ],
+  banner: {
+    js: "// Auto-generated — do not edit. Re-run `npm run scripts:build` to regenerate.",
+  },
+};
+
+// ── Entries ──────────────────────────────────────────────────────────────────
+const entries = [
+  {
+    entryPoints: [path.resolve(root, "src/lib/db/migrate.ts")],
+    outfile: path.resolve(root, "dist/migrate.mjs"),
+  },
+  {
+    entryPoints: [path.resolve(root, "scripts/run-sync.ts")],
+    outfile: path.resolve(root, "dist/run-sync.mjs"),
+  },
+];
+
+// ── Build ───────────────────────────────────────────────────────────────────
+mkdirSync(path.resolve(root, "dist"), { recursive: true });
+
+for (const entry of entries) {
+  await build({ ...shared, ...entry });
+  const name = path.basename(entry.outfile);
+  console.log(`  ✓ dist/${name}`);
+}
+
+console.log("\nDone — scripts are ready to run with `node`.");


### PR DESCRIPTION
# Dist-Compatible Scripts for Coolify Deployment

## Overview

The `db:migrate` and `sync` npm scripts rely on `tsx` to run TypeScript directly, but `tsx` is a devDependency that is not available in the Coolify production container. This PR adds an **esbuild-based bundler** that compiles both scripts into standalone `.mjs` files runnable with plain `node`, along with corresponding `dist:*` npm scripts and Dockerfile integration.

## Changes

### New File: `scripts/build-scripts.mjs`
esbuild bundler script that:
- Compiles `src/lib/db/migrate.ts` → `dist/migrate.mjs`
- Compiles `scripts/run-sync.ts` → `dist/run-sync.mjs`
- Resolves the `@/*` TypeScript path alias at bundle time
- Uses an esbuild plugin to replace `import "server-only"` with an empty module (since the `server-only` package throws outside Next.js)
- Keeps heavy native dependencies (`sharp`, `deepl-node`, `postgres`, `drizzle-orm`, `zod`, `dotenv`) external so they resolve from `node_modules` at runtime

### Modified: `package.json`
Added 4 new scripts:
- `scripts:build` — runs the esbuild bundler
- `dist:migrate` — runs migrations with plain `node`
- `dist:sync` — runs the full sync pipeline with plain `node`
- `dist:sync:dry-run` — dry-run variant of the sync

The original `tsx`-based scripts remain unchanged for local development convenience.

### Modified: `Dockerfile`
- Added `RUN npm run scripts:build` after `next build` in the builder stage
- Added `COPY` instructions for `dist/` and `src/lib/db/migrations/` into the runner stage (migrations SQL files are needed at runtime by drizzle migrator)

### Modified: `.gitignore`
Added `/dist` to prevent generated bundles from being committed.

## Prior Commits in This Branch

This branch also includes fixes from earlier sessions:
- **Connection pool capping** for PostgreSQL during SSG prerendering
- **Turbopack root pinning** to prevent workspace misdetection
- **Node 24 Alpine upgrade** with cross-platform esbuild handling
- **Dependency version pinning** (exact versions in `package.json`)
- **Architecture docs sync** to match pinned versions

## Testing

- `npm run scripts:build` — produces `dist/migrate.mjs` (1.2 KB) and `dist/run-sync.mjs` (63 KB)
- `node dist/migrate.mjs` — successfully ran migrations against the database (exit 0)
- `node dist/run-sync.mjs --dry-run` — successfully fetched 179 properties and 19 agents from the RE/MAX CCA API (exit 0)
- `npm run lint` — 0 errors (15 warnings, all pre-existing or from generated code)
- `npm run build` — compiled successfully with zero errors

## Usage on Coolify

```bash
# Instead of: npm run db:migrate (needs tsx)
npm run dist:migrate

# Instead of: npm run sync (needs tsx)
npm run dist:sync

# Dry run:
npm run dist:sync:dry-run
```