### PR TITLE
Fix : Bundle all deps inline for dist scripts

### DIFF
--- a/scripts/build-scripts.mjs
+++ b/scripts/build-scripts.mjs
@@ -46,19 +46,21 @@ const shared = {
     "@": path.resolve(root, "src"),
   },
   plugins: [serverOnlyShimPlugin],
-  // Keep node built-ins and heavy native deps external (they'll be in
-  // node_modules at runtime via Next.js standalone output)
+  // Only keep native-addon packages external — everything else is bundled
+  // inline so the scripts are fully self-contained in the runner stage
+  // (Next.js standalone only traces deps used by the app, not our scripts).
   external: [
-    "dotenv",
-    "drizzle-orm",
-    "drizzle-orm/*",
-    "postgres",
     "sharp",
-    "deepl-node",
-    "zod",
   ],
+  // When esbuild bundles CJS packages (dotenv, postgres, etc.) into ESM,
+  // it generates a synthetic `require()` that can't resolve Node built-ins.
+  // Inject a real `require` via createRequire so CJS→ESM interop works.
   banner: {
-    js: "// Auto-generated — do not edit. Re-run `npm run scripts:build` to regenerate.",
+    js: [
+      "// Auto-generated — do not edit. Re-run `npm run scripts:build` to regenerate.",
+      'import { createRequire as __createRequire } from "node:module";',
+      "const require = __createRequire(import.meta.url);",
+    ].join("\n"),
   },
 };
 


### PR DESCRIPTION
Hotfix — the previous PR (#149) was merged before commit `14afd7c` was included.

## Problem

The dist scripts (`dist/migrate.mjs`, `dist/run-sync.mjs`) marked `dotenv`, `postgres`, `drizzle-orm`, `zod`, and `deepl-node` as external. These packages are **not available** in the Next.js standalone runner stage because standalone only traces dependencies used by the app itself.

## Fix

- Bundle all pure-JS dependencies inline (only `sharp` stays external since it has native C++ bindings and is already traced by Next.js)
- Add `createRequire` banner so CJS packages bundled into ESM can resolve Node built-ins like `fs` and `path`

## Testing

- `node dist/migrate.mjs` — exit 0, migrations applied
- `node dist/run-sync.mjs --dry-run` — exit 0, fetched 179 properties