### PR TITLE
Fix : Dockerfile Permission for Sync Image Optimizer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 
-COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
@@ -32,6 +32,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/src/lib/db/migrations ./src/lib/d
 # across redeploys. Configure in Coolify / docker-compose as:
 #   volumes:
 #     - property_images:/app/public/property-images
+RUN mkdir -p /app/public/property-images && chown nextjs:nodejs /app/public/property-images
 
 USER nextjs
 


### PR DESCRIPTION
# Fix Dockerfile Permission for Sync Image Optimizer

## Overview

The `dist:sync` pipeline was crashing with `EACCES: permission denied, mkdir '/app/public/property-images/137923'` because the `/app/public` directory was owned by **root** in the Docker image, while the Node.js process runs as the unprivileged `nextjs` user (uid 1001).

## Root Cause

In the multi-stage `Dockerfile`, line 22 was the **only** `COPY` instruction missing the `--chown=nextjs:nodejs` flag:

```dockerfile
# ❌ Before — owned by root
COPY --from=builder /app/public ./public
```

All other `COPY` lines (`.next/standalone`, `.next/static`, `dist/`, `migrations/`) already had `--chown=nextjs:nodejs`. When `optimizePropertyImages()` in `image-optimizer.ts` called `mkdirSync('/app/public/property-images/<apiId>', { recursive: true })`, the `nextjs` user could not write to the root-owned directory.

## Changes

### Dockerfile

1. **Added `--chown=nextjs:nodejs`** to the `COPY --from=builder /app/public ./public` instruction so the entire `public/` tree is owned by the app user — consistent with every other `COPY` in the runner stage.

2. **Pre-created the `property-images` mount-point** with `RUN mkdir -p /app/public/property-images && chown nextjs:nodejs /app/public/property-images` as a belt-and-suspenders safeguard for when a Docker volume overlays this path.

```diff
-COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public

 # NOTE: /app/public/property-images requires a Docker volume mount …
+RUN mkdir -p /app/public/property-images && chown nextjs:nodejs /app/public/property-images
```

## Testing

- **Production build** (`npm run build`) passed with zero errors.
- The fix is a Dockerfile-only change — no application logic was modified.
- Full verification requires a redeploy to Coolify to confirm the sync pipeline can now create property image directories.