### PR TITLE
Docs : Epic 5 Retrospective & Story 6.1 Spec Creation

### DIFF
--- a/_bmad-output/implementation-artifacts/6-1-area-guide-pages.md
+++ b/_bmad-output/implementation-artifacts/6-1-area-guide-pages.md
@@ -1,0 +1,403 @@
+# Story 6.1: Area Guide Pages
+
+**Status:** ready-for-dev
+**GH Issue:** #101
+**Epic:** 6 — Community Pages & Area Guides
+**Story Key:** 6-1-area-guide-pages
+**Created:** 2026-05-26
+
+---
+
+## Story
+
+As a **visitor**,
+I want to explore area guides with lifestyle narratives, climate info, and filtered properties,
+So that I can understand what living in a specific area feels like before browsing listings.
+
+---
+
+## Acceptance Criteria
+
+1. **Given** an area guide page (e.g., `/{locale}/areas/perez-zeledon`) **When** loaded **Then** it renders: hero image with area name (h1), lifestyle narrative description (always visible — not behind a tab), climate/altitude data, and nearest services (FR17, UX-DR13). `data-testid="area-guide-hero"` on the hero section, `data-testid="area-guide-description"` on the description section.
+
+2. **Given** the area guide description section **When** rendered **Then** it is always visible (not tabbed) to ensure full SEO indexing of the content (UX-DR13). The description MUST be in the initial SSG HTML output, not client-rendered.
+
+3. **Given** the area guide page **When** scrolling below the description **Then** tabbed sections appear: "Properties" (filtered property grid for this area), "Agents" (AgentCards for agents covering this area), and "Similar Areas" (SimilarAreasSlider with nearby area cards). `data-testid="area-guide-tabs"` on the tab container.
+
+4. **Given** the Properties tab **When** selected **Then** it shows a property grid filtered to this area, using the existing `PropertyCard` component from Epic 3. `data-testid="area-guide-properties-tab"` on the tab panel.
+
+5. **Given** the Agents tab **When** selected **Then** it shows `AgentCard` components for agents covering this area. `data-testid="area-guide-agents-tab"` on the tab panel.
+
+6. **Given** the area guide page **When** a community belongs to this area **Then** linked communities are shown as gold-bordered CommunityCards within the area guide. Gold border uses `--color-gold` (#C2A661) token.
+
+7. **Given** an area index page (`/{locale}/areas`) **When** loaded **Then** it lists all available areas with hero cards showing area name, region badge, property count, and description snippet (FR18). `data-testid="area-index-card"` on each card.
+
+8. **And** area guide pages are SSG (static generation) — no ISR revalidation. Content changes require rebuild.
+9. **And** all content displays in the selected locale (EN/ES) via `next-intl`.
+10. **And** JSON-LD structured data for Place schema is present (AR14) using the existing `generatePlaceJsonLd` function.
+11. **Given** an area guide page with zero properties **When** the Properties tab is viewed **Then** a localized empty state message is shown (e.g., "No properties currently listed in this area").
+12. **Given** an area without a hero image **When** the page loads **Then** a gradient placeholder (navy-to-cream) is used instead of a broken image.
+13. **Given** the area guide tabs **When** navigated via keyboard **Then** tab panels follow WAI-ARIA Tabs pattern: `role="tablist"`, `role="tab"`, `role="tabpanel"`, `aria-selected`, `aria-controls`, and arrow-key navigation between tabs.
+
+---
+
+## Tasks / Subtasks
+
+- [ ] Task 1: Create area DB query functions (AC: #1, #4, #5, #7)
+  - [ ] 1.1 Create `src/lib/db/queries/areas.ts` with: `getAllAreas()`, `getAreaBySlug(slug)`, `getAllAreaSlugs()`, `getPropertiesByAreaSlug(areaSlug)`, `getAgentsByAreaSlugs(areaSlugs)`
+  - [ ] 1.2 Query `properties` table filtering by `area_slug` and `is_visible = true`; return `PropertySearchItem` shape using existing `mapPropertyRowToSearchItem`
+  - [ ] 1.3 Query `agents` table — for MVP, return all active agents (area-specific agent assignment is not yet implemented; all agents serve all areas)
+  - [ ] 1.4 Create `getSimilarAreas(region, excludeSlug)` — returns areas with same region, excluding current area, ordered by `sortOrder` ASC
+
+- [ ] Task 2: Create area guide page route (AC: #1, #2, #3, #8, #9, #10)
+  - [ ] 2.1 Create `src/app/[locale]/areas/[slug]/page.tsx` — SSG page with `generateStaticParams` and `generateMetadata`
+  - [ ] 2.2 Implement `generateStaticParams()` returning all area slugs (no locale dimension needed — inherited from parent layout)
+  - [ ] 2.3 Implement `generateMetadata()` with localized title/description, `alternates` using `buildAlternatesMetadata`, and OpenGraph tags
+  - [ ] 2.4 Render hero, description (always visible), climate metadata, and tabbed sections
+  - [ ] 2.5 Inject JSON-LD `<script>` using `generatePlaceJsonLd` + `serializeJsonLd` from `src/lib/seo/structured-data.ts`
+
+- [ ] Task 3: Create area guide components (AC: #1, #2, #3, #4, #5, #6, #11, #12, #13)
+  - [ ] 3.1 Create `src/components/area/area-guide-hero.tsx` — Server Component: hero image (or gradient fallback per AC #12), h1, region badge, climate/altitude data
+  - [ ] 3.2 Create `src/components/area/area-guide-description.tsx` — Server Component: lifestyle narrative, nearest services. Must be in initial DOM (not client-rendered)
+  - [ ] 3.3 Create `src/components/area/area-guide-tabs.tsx` — Client Component: tab navigation for Properties/Agents/Similar Areas. WAI-ARIA Tabs pattern per AC #13. Empty state per AC #11.
+  - [ ] 3.4 Create `src/components/area/community-card.tsx` — Server Component: gold-bordered card linking to community page (placeholder URL until Story 6.2)
+  - [ ] 3.5 Create `src/components/area/similar-areas-slider.tsx` — Client Component: horizontal card slider showing nearby areas (same region)
+
+- [ ] Task 4: Create area index page (AC: #7)
+  - [ ] 4.1 Create `src/app/[locale]/areas/page.tsx` — SSG index page listing all areas
+  - [ ] 4.2 Create `src/components/area/area-index-card.tsx` — card with hero image, name, region badge, property count, description snippet
+
+- [ ] Task 5: Add i18n strings (AC: #9)
+  - [ ] 5.1 Add `AreaGuide` namespace to `src/messages/en.json`
+  - [ ] 5.2 Add `AreaGuide` namespace to `src/messages/es.json`
+  - [ ] 5.3 Keys needed: `meta.title`, `meta.description`, `meta.ogTitle`, `meta.ogDescription`, `tabs.properties`, `tabs.agents`, `tabs.similarAreas`, `hero.regionBadge`, `hero.propertyCount`, `description.heading`, `index.title`, `index.description`, `index.meta.title`, `index.meta.description`, `noProperties`, `noAgents`, `communityCard.viewCommunity`
+
+- [ ] Task 6: Add Breadcrumb structured data (AC: #10)
+  - [ ] 6.1 Use existing `generateBreadcrumbJsonLd` for area guide pages: Home → Areas → {Area Name}
+  - [ ] 6.2 Use existing `generateBreadcrumbJsonLd` for area index: Home → Areas
+
+---
+
+## Dev Notes
+
+### Rendering Strategy
+
+Area guide pages use **pure SSG** — no ISR. The architecture spec (line 123) defines:
+> Area guides (`/areas/[slug]`) | SSG | Build-time (manual) | Edge | Content rarely changes
+
+This means **no `revalidate` export**. SSG is the default rendering strategy when `generateStaticParams` is defined and there is no dynamic data fetching. Follow the exact same pattern as `src/app/[locale]/about/page.tsx`:
+- Call `setRequestLocale(locale)` at the top of the page component
+- Use `await params` to extract locale and slug
+- No `export const dynamic` or `export const revalidate` needed
+
+### Critical: Description Visibility for SEO (R-003)
+
+The area guide description MUST be rendered in the initial server HTML, not behind a tab or client-side rendered. This is the #1 SEO risk for this story (Risk R-003, score 6). The description section uses a Server Component that renders directly in the page — no `use client`, no `useState`, no tab gating.
+
+**Test verification:** Fetch the raw HTML of the area guide page (no JS execution); assert the description text is present in the response body.
+
+### Page Component Pattern
+
+Follow `src/app/[locale]/about/page.tsx` as the canonical SSG pattern:
+
+```typescript
+// src/app/[locale]/areas/[slug]/page.tsx
+import type { Metadata } from 'next';
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+import { notFound } from 'next/navigation';
+import { getAreaBySlug, getAllAreaSlugs, getPropertiesByAreaSlug } from '@/lib/db/queries/areas';
+import { getAllAgents } from '@/lib/db/queries/agents';
+import { generatePlaceJsonLd, generateBreadcrumbJsonLd, serializeJsonLd } from '@/lib/seo/structured-data';
+import { buildAlternatesMetadata } from '@/lib/seo/metadata';
+import { AreaGuideHero } from '@/components/area/area-guide-hero';
+import { AreaGuideDescription } from '@/components/area/area-guide-description';
+import { AreaGuideTabs } from '@/components/area/area-guide-tabs';
+
+export async function generateStaticParams() {
+  const slugs = await getAllAreaSlugs();
+  return slugs.map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ locale: string; slug: string }> }): Promise<Metadata> {
+  const { locale, slug } = await params;
+  const area = await getAreaBySlug(slug);
+  if (!area) return {};
+  const t = await getTranslations({ locale, namespace: 'AreaGuide' });
+  const areaName = locale === 'es' ? area.nameEs : area.nameEn;
+  return {
+    title: t('meta.title', { area: areaName }),
+    description: t('meta.description', { area: areaName }),
+    alternates: { ...buildAlternatesMetadata(`/areas/${slug}`) },
+    openGraph: { title: t('meta.ogTitle', { area: areaName }), description: t('meta.ogDescription', { area: areaName }) },
+  };
+}
+
+export default async function AreaGuidePage({ params }: { params: Promise<{ locale: string; slug: string }> }) {
+  const { locale, slug } = await params;
+  setRequestLocale(locale);
+  const area = await getAreaBySlug(slug);
+  if (!area) notFound();
+  
+  const [areaProperties, agents] = await Promise.all([
+    getPropertiesByAreaSlug(slug),
+    getAllAgents(),
+  ]);
+
+  const placeJsonLd = generatePlaceJsonLd(area, locale);
+  const areaName = locale === 'es' ? area.nameEs : area.nameEn;
+  const breadcrumbJsonLd = generateBreadcrumbJsonLd([
+    { name: 'Home', href: `/${locale}`, position: 1 },
+    { name: t('index.title'), href: `/${locale}/areas`, position: 2 },
+    { name: areaName, href: `/${locale}/areas/${slug}`, position: 3 },
+  ]);
+
+  return (
+    <main>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: serializeJsonLd(placeJsonLd) }} />
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: serializeJsonLd(breadcrumbJsonLd) }} />
+      <AreaGuideHero area={area} locale={locale} />
+      <AreaGuideDescription area={area} locale={locale} />
+      <AreaGuideTabs
+        properties={areaProperties}
+        agents={agents}
+        area={area}
+        locale={locale}
+      />
+    </main>
+  );
+}
+```
+
+**NOTE:** The breadcrumb `t` reference above is pseudocode — you must fetch translations with `getTranslations` before using `t(...)`. Fix the scoping during implementation.
+
+### Database Query Pattern
+
+Create `src/lib/db/queries/areas.ts` following the same patterns as `src/lib/db/queries/properties.ts` and `src/lib/db/queries/agents.ts`:
+
+```typescript
+// src/lib/db/queries/areas.ts
+import 'server-only';
+import { desc, eq } from 'drizzle-orm';
+import { db } from '@/lib/db/client';
+import { areas } from '@/lib/db/schema/areas';
+import { properties } from '@/lib/db/schema/properties';
+import { mapPropertyRowToSearchItem } from './properties';
+
+export async function getAllAreas() {
+  return db.select().from(areas).orderBy(asc(areas.sortOrder));
+}
+
+export async function getAreaBySlug(slug: string) {
+  const rows = await db.select().from(areas).where(eq(areas.slug, slug)).limit(1);
+  return rows[0] ?? null;
+}
+
+export async function getAllAreaSlugs(): Promise<string[]> {
+  const rows = await db.select({ slug: areas.slug }).from(areas);
+  return rows.map((r) => r.slug);
+}
+
+export async function getPropertiesByAreaSlug(areaSlug: string) {
+  // Reuse the exact same column set and mapper as getSimilarPropertiesRanked
+  // to produce PropertySearchItem[] compatible with PropertyCard
+  const rows = await db
+    .select({ /* propertySearchColumns */ })
+    .from(properties)
+    .where(and(eq(properties.areaSlug, areaSlug), eq(properties.isVisible, true)))
+    .orderBy(desc(properties.syncedAt));
+  return rows.map(mapPropertyRowToSearchItem);
+}
+```
+
+**CRITICAL — Reuse `propertySearchColumns`:** The `propertySearchColumns` constant is defined in `src/lib/db/queries/properties.ts` (line 349). You MUST either:
+1. Export `propertySearchColumns` from properties.ts and import it in areas.ts, OR
+2. Duplicate the exact same column set inline
+
+Option 1 is preferred. Add `export` to the existing `const propertySearchColumns` declaration.
+
+### Existing `generatePlaceJsonLd` — REUSE, DO NOT RECREATE
+
+The `generatePlaceJsonLd` function already exists in `src/lib/seo/structured-data.ts` (line 149). It was created in Story 4.4 specifically for Epic 6 area pages. It accepts `(area: Area, locale: string)` and returns a Place schema object. **Use it directly — do not create a new one.**
+
+Also reuse `serializeJsonLd` from the same file for safe HTML injection.
+
+### Existing Components — REUSE, DO NOT RECREATE
+
+| Component | Location | Usage in 6.1 |
+|-----------|----------|-------------|
+| `PropertyCard` | `src/components/property/property-card.tsx` | Properties tab grid |
+| `AgentCard` | `src/components/agent/agent-card.tsx` | Agents tab |
+| `PropertyGrid` | `src/components/property/property-grid.tsx` | Properties tab (optional — it's a Client Component; may be simpler to create a server-rendered grid for SSG) |
+| `generatePlaceJsonLd` | `src/lib/seo/structured-data.ts` | JSON-LD Place schema |
+| `generateBreadcrumbJsonLd` | `src/lib/seo/structured-data.ts` | Breadcrumb structured data |
+| `serializeJsonLd` | `src/lib/seo/structured-data.ts` | Safe JSON-LD serialization |
+| `buildAlternatesMetadata` | `src/lib/seo/metadata.ts` | hreflang alternates |
+| `mapPropertyRowToSearchItem` | `src/lib/db/queries/properties.ts` | DB row → PropertySearchItem |
+
+### PropertyGrid Consideration
+
+`PropertyGrid` (`src/components/property/property-grid.tsx`) is a **Client Component** (`'use client'`). For the area guide SSG page, you have two options:
+
+1. **Use `PropertyGrid` directly** — the grid will render server-side during build, then hydrate client-side. This works but bundles client JS for pagination and search state.
+2. **Create a simpler `AreaPropertyGrid` Server Component** — renders `PropertyCard` components in a static grid without client-side pagination. Properties tab content is static at build time.
+
+**Recommended: Option 2** for SSG. Create a minimal Server Component that maps properties to `PropertyCard`. Keep the component simple — no pagination needed for area-filtered results (typically 5-20 properties).
+
+### Areas Schema
+
+The `areas` table schema is already defined in `src/lib/db/schema/areas.ts`. Key fields:
+
+| Column | Type | Usage |
+|--------|------|-------|
+| `slug` | text, unique | URL parameter, `generateStaticParams` |
+| `nameEn` / `nameEs` | text | Localized area name for h1 |
+| `region` | text | Region badge ("Mountain" / "Coast") |
+| `descriptionEn` / `descriptionEs` | text | Lifestyle narrative (SEO content) |
+| `heroImageUrl` | text, nullable | Hero background image |
+| `province` / `canton` / `district` | text, nullable | Administrative subdivisions |
+| `latitude` / `longitude` | double, nullable | Geo coordinates for JSON-LD |
+| `propertyCount` | integer | Denormalized count for index cards |
+| `metadata` | jsonb | Climate, altitude, distances, amenities |
+| `sortOrder` | integer | Display ordering |
+
+The `metadata` JSONB field should contain structured data like:
+```json
+{
+  "elevation": "700m",
+  "climate": "Tropical humid",
+  "nearestAirport": "San José (SJO) — 3.5 hours",
+  "nearestHospital": "Hospital Escalante Pradilla — 15 min",
+  "nearestBeach": "Dominical — 45 min"
+}
+```
+
+### CommunityCard — Placeholder for Story 6.2
+
+Story 6.1 renders community cards within the area guide. However, the `communities` table does NOT exist in the schema yet — it will be created in Story 6.2 or 6.5. For Story 6.1:
+
+1. Create the `CommunityCard` component UI with gold border styling
+2. Use hardcoded/seeded community data from the `areas.metadata` JSONB field, OR
+3. Leave the community section as "Coming soon" with the component structure in place
+
+**Recommended:** Create the `CommunityCard` component with the correct visual design (gold border, hero image, name, tagline) but do NOT query a `communities` table. Either pass community data as props from the area's metadata, or render an empty section with a comment `{/* Communities — populated in Story 6.2 */}`.
+
+### Styling Requirements
+
+Follow the project's design system tokens defined in `_bmad-output/planning-artifacts/ux-design-specification.md`:
+
+- **Font**: Montserrat (via `next/font`) — weights 400, 600, 700, 800
+- **Hero overlay**: Dark overlay on photography + white text (`--color-text-on-dark`)
+- **Region badge**: `--mountain-primary` (#233428) for mountain, `--beach-primary` (#183C5A) for coast
+- **Gold border on community cards**: `--color-gold` (#C2A661) — 2px solid
+- **Card styling**: `--color-bg-white`, `--shadow-sm` resting, `--shadow-lg` on hover, `--radius-lg` (12px)
+- **Tab styling**: Active tab indicator uses `--color-primary` (#000E35)
+- **Spacing**: Follow 4px base grid (`--space-*` tokens)
+- **Hero fallback**: When `heroImageUrl` is null, render a CSS gradient from `--color-navy` to `--color-cream` instead of `<Image>`
+- **Touch targets**: Minimum 44×44px for all interactive elements (tab triggers, card links)
+
+### Accessibility Requirements
+
+- Tab component MUST follow WAI-ARIA Tabs pattern:
+  - `role="tablist"` on the tab container
+  - `role="tab"` on each tab trigger, with `aria-selected`, `aria-controls="panel-id"`
+  - `role="tabpanel"` on each panel, with `aria-labelledby="tab-id"`
+  - Arrow Left/Right to navigate between tabs, Home/End for first/last
+- Hero section: `<h1>` is the area name; do NOT nest inside another heading
+- Images: All `<Image>` elements have descriptive `alt` text using localized area name
+- Skip link: Existing site skip-to-content link covers the area guide page (no new skip link needed)
+
+### Similar Areas Logic
+
+"Similar areas" for the `SimilarAreasSlider` are determined by **same region** (e.g., "Mountain" or "Coast"). Query all areas where `region === area.region` and `slug !== area.slug`, ordered by `sortOrder`. This is a simple filter — no geo-distance calculation needed.
+
+Add a query function:
+```typescript
+export async function getSimilarAreas(region: string, excludeSlug: string) {
+  return db.select().from(areas)
+    .where(and(eq(areas.region, region), not(eq(areas.slug, excludeSlug))))
+    .orderBy(asc(areas.sortOrder));
+}
+```
+
+### Testing Strategy
+
+**Required `data-testid` attributes** (from test design `test-design-epic-6.md`):
+
+| Attribute | Component |
+|-----------|-----------|
+| `data-testid="area-guide-hero"` | AreaGuideHero |
+| `data-testid="area-guide-description"` | AreaGuideDescription |
+| `data-testid="area-guide-tabs"` | AreaGuideTabs container |
+| `data-testid="area-guide-properties-tab"` | Properties tab panel |
+| `data-testid="area-guide-agents-tab"` | Agents tab panel |
+| `data-testid="area-guide-similar-tab"` | Similar Areas tab panel |
+| `data-testid="area-index-card"` | AreaIndexCard |
+
+**Key test scenarios from test design:**
+- 6.1-E2E-001: Description visible without clicking any tab
+- 6.1-E2E-002: Description text present in raw SSG HTML (no JS execution)
+- 6.1-E2E-003: Properties tab shows property grid filtered to this area
+- 6.1-COMP-001: JSON-LD Place schema present on area guide page
+
+### Project Structure Notes
+
+New files to create:
+```
+src/
+├── app/[locale]/areas/
+│   ├── page.tsx                          # Area index (SSG)
+│   └── [slug]/
+│       └── page.tsx                      # Area guide (SSG)
+├── components/area/
+│   ├── area-guide-hero.tsx               # Server Component
+│   ├── area-guide-description.tsx        # Server Component
+│   ├── area-guide-tabs.tsx               # Client Component (tab state)
+│   ├── area-property-grid.tsx            # Server Component (static grid)
+│   ├── area-index-card.tsx               # Server Component
+│   ├── community-card.tsx                # Server Component (gold border)
+│   └── similar-areas-slider.tsx          # Client Component (carousel)
+└── lib/db/queries/
+    └── areas.ts                          # Area DB queries (includes getSimilarAreas)
+```
+
+Files to modify:
+```
+src/messages/en.json          — Add AreaGuide namespace
+src/messages/es.json          — Add AreaGuide namespace
+src/lib/db/queries/properties.ts — Export propertySearchColumns
+```
+
+### Do NOT Modify
+
+- `src/components/property/property-card.tsx` — reuse as-is
+- `src/components/agent/agent-card.tsx` — reuse as-is
+- `src/lib/seo/structured-data.ts` — reuse `generatePlaceJsonLd`, `generateBreadcrumbJsonLd`, `serializeJsonLd` as-is
+- Any existing `data-testid` values from Epics 1–5
+
+### References
+
+- [Source: _bmad-output/planning-artifacts/epics.md#Story 6.1] — Story requirements and acceptance criteria
+- [Source: _bmad-output/planning-artifacts/architecture.md#L123] — SSG rendering strategy for area guides
+- [Source: _bmad-output/planning-artifacts/architecture.md#L162-168] — Directory structure for areas routes
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#L1252-1261] — Area guide UX composition and sections
+- [Source: _bmad-output/planning-artifacts/ux-design-specification.md#L1282] — Gold border community card differentiation
+- [Source: src/lib/seo/structured-data.ts#L149-161] — Existing `generatePlaceJsonLd` function
+- [Source: src/lib/db/schema/areas.ts] — Areas table schema
+- [Source: src/lib/db/queries/properties.ts#L349-365] — `propertySearchColumns` constant to export
+- [Source: src/app/[locale]/about/page.tsx] — Canonical SSG page pattern
+- [Source: _bmad-output/test-artifacts/test-design-epic-6.md#L87-97] — Required data-testid contracts
+- [Source: _bmad-output/test-artifacts/test-design-epic-6.md#L206-214] — P0 test scenarios for Story 6.1
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+
+{{agent_model_name_version}}
+
+### Debug Log References
+
+### Completion Notes List
+
+### File List

--- a/_bmad-output/implementation-artifacts/epic-5-retro-2026-05-27.md
+++ b/_bmad-output/implementation-artifacts/epic-5-retro-2026-05-27.md
@@ -1,0 +1,442 @@
+# Epic 5 Retrospective — Seller Lead Capture
+**Date:** 2026-05-27
+**Facilitator:** Amelia (Developer)
+**Project:** remax-altitud
+**Epic:** 5 — Seller Lead Capture
+
+---
+
+## Retrospective Session
+
+Amelia (Developer): "Welcome to the Epic 5 retrospective, Sebicas. Three stories — the first epic where we accept *writes* from end users via lead forms. This is also the epic where the project crossed a major boundary: from a read-only property discovery site to a genuine lead-capture platform with PII encryption, agent routing, and Zod-validated API endpoints. Let's unpack what we shipped and what we learned."
+
+Alice (Product Owner): "From a product lens, this is the second half of our conversion funnel. Epic 4 captured buyer lead intent on listings — WhatsApp clicks, agent cards. Epic 5 captures seller lead intent through structured forms. Different funnel, different user journey, but they both converge into the same lead management pipeline."
+
+Charlie (Senior Dev): "Three stories: progressive 3-step seller form with map pin-drop and lazy-loading, a CMA request form reusing shared components, and the backend API with AES-256-GCM PII encryption, geo-based agent routing, 60-second dedup, and Zod validation. The security surface area increased significantly this epic."
+
+Dana (QA Engineer): "We grew from 797 unit tests to 910 in this epic. 113 new tests across 3 stories, zero failures, zero flakes. That includes encryption roundtrip tests, agent routing tests, Zod schema validation, and API integration tests."
+
+Elena (Junior Dev): "And the component reuse was excellent — `LocationPicker` was designed in 5.1, shared into 5.2 without modification, and the `SellerConfirmation` component got extended with a `source` variant prop for CMA vs seller confirmation."
+
+Amelia (Developer): "Let's get into specifics. Sebicas, you're the Project Lead — your perspective on the delivery matters most."
+
+Sebicas (Project Lead): [Participating in the retrospective]
+
+---
+
+## Epic 5 Summary
+
+### Delivery Metrics
+
+| Metric | Value |
+|---|---|
+| Stories completed | 3 / 3 (100%) |
+| PRs merged | 3 (#137, #144, #152) |
+| Test count at start | 797 pass (Epic 4 baseline) |
+| Test count at end | 910 pass, 4 skips, 0 failures |
+| New unit tests added | ~113 tests across 3 stories |
+| Production incidents | 0 |
+| Wall-clock duration (5.1 merge → 5.3 merge) | ~20 days (2026-05-04 → 2026-05-24) |
+| Intermediate work | Vitest 4 migration (#143), package-lock fixes (#145–#149), dist inline bundling fixes (#150–#151) |
+| Epic retrospective | This document |
+
+### Stories Delivered
+
+| Story | Title | PR | Merged At | Status |
+|---|---|---|---|---|
+| 5.1 | Seller Landing Page & "List With Us" Form | #137 | 2026-05-04 | done |
+| 5.2 | CMA Request Form | #144 | 2026-05-13 | done |
+| 5.3 | Seller Lead Storage, Routing & Source Tracking | #152 | 2026-05-24 | done |
+
+### Quality and Technical
+
+- **Blockers encountered:** 0 story-level blockers; Vitest 4 migration required between 5.1 and 5.2 (#143)
+- **New patterns established:** AES-256-GCM column-level PII encryption (`encryptField`/`decryptField`), SHA-256 phone hash for idempotency dedup, Zod API validation with structured 400 errors, geo-based agent routing (`matchAgentByCoordinates`), `react-hook-form` multi-step form with single `useForm()` instance, `LocationPicker` with progressive map + text fallback, WhatsApp click tracking via `navigator.sendBeacon`
+- **Architecture compliance:** 100% — SSG seller page with lazy-loaded `SellerForm` (~15KB), `next/dynamic` with `{ ssr: false }`, `useLocaleUnits` for consistent unit toggles
+- **Security surface area:** First write-path API (`POST /api/leads`); PII encryption (AR17, NFR9) validated; Zod validation (AR18); rate limiting (10 req/min/IP); idempotency (60s dedup); Sentry error capture (AR19)
+
+### Business Outcomes
+
+- Complete seller lead capture funnel live: 3-step progressive form, CMA request form, agent match confirmation
+- Progressive form completable in under 3 minutes on budget devices (AC-verified)
+- "I need help with pricing" checkbox allows pricing consultation leads
+- CMA form with distinct `source = "cma_form"` for funnel segmentation
+- Geo-based agent routing: nearest office (PZ or Dominical) → most active agent
+- UTM/referrer tracking on all lead submissions for marketing attribution
+- WhatsApp click tracking on confirmation screen for lead event capture
+- All PII (phone, email) encrypted at column level — never stored in plaintext
+
+---
+
+## Previous Epic Retrospective Follow-Through
+
+Amelia (Developer): "Let me check how we did on the Epic 4 commitments before we discuss Epic 5."
+
+### Action Item Tracking (from Epic 4 retro, 2026-05-03)
+
+#### Process Improvements
+
+| Action Item | Status | Evidence |
+|---|---|---|
+| Add a "Translatable Surfaces" section to every story spec | ✅ Completed | Stories 5.1, 5.2, and 5.3 all have explicit "Translatable Surfaces" sections listing every i18n key including aria-labels, form validation messages, confirmation text, and meta descriptions |
+| Add `dangerouslySetInnerHTML` audit to code review checklist | ✅ Completed | Stories 5.1 and 5.2 both have explicit "dangerouslySetInnerHTML Audit" sections confirming no usage. The audit pattern is now part of every story spec |
+| Document Step 7 PR review as a load-bearing review pass | ⏳ Not confirmed | Pipeline ran with multi-pass review but no explicit documentation artifact was created; the practice continued successfully through all 3 stories |
+| Document async Server Component testing pattern as project standard | ✅ Completed | Story 5.1 spec explicitly references the pattern (`await SellerHero({ locale: 'en' })`) and it was applied for hero component testing |
+| Triage `deferred-work.md` at Epic 5 kickoff | ✅ Completed | Story 5.1 spec references deferred items (email regex, phone validation, CSP headers) and Story 5.3 explicitly owns the Zod validation replacement for permissive client-side validation |
+
+#### Technical Debt
+
+| Action Item | Status | Evidence |
+|---|---|---|
+| Add sync pipeline operations runbook | ❌ Not addressed | Fourth epic this is open — still no runbook. Now with a write-path API in production, operational visibility is more critical than ever |
+| Wire Lighthouse CI as PR-blocking check | ❌ Not addressed | Still advisory-only. No change from Epic 4 |
+| Consolidate `as unknown as { src: string }[]` cast into shared type | ❌ Not addressed | Still 4 scattered call sites with no shared type alias |
+| Rename `generalInquiryEn` i18n key | ❌ Not addressed | Key naming inconsistency persists |
+| Decide on `Link` import pattern | ⏳ Partially addressed | Story 5.1 spec explicitly says "use `Link` from `@/i18n/navigation` — not from `next/link`" and "do NOT use the `/${locale}/...` manual prefix pattern in new code." Standard documented in story specs, but no codemod of existing call sites |
+| Address brand-name fallback hardcoding | ❌ Not addressed | `"RE/MAX Altitud"` still hardcoded in agent profile namespace |
+| Wire Place JSON-LD generator into area pages | ⏳ In progress | Story 6.1 (Area Guide Pages) is done per sprint-status; likely addressed there |
+| Implement area context block (deferred from 4.5) | ⏳ Pending | Mapped to Epic 6 Story 6.4, which is still in backlog |
+
+#### Documentation
+
+| Action Item | Status | Evidence |
+|---|---|---|
+| Add `serializeJsonLd()` helper documentation | ⏳ Not confirmed | No explicit doc artifact found; pattern continues to be used correctly |
+| Update `deferred-work.md` with new Epic 4 items | ✅ Completed | `deferred-work.md` contains entries through Epic 4 stories |
+
+Charlie (Senior Dev): "5 of 15 fully completed, 3 partially addressed, 7 not addressed. The pattern from Epic 3 continues: blocking items always get done, doc-only and tech-debt items keep slipping."
+
+Alice (Product Owner): "The sync runbook gap concerns me more every epic. We now have a write-path API. If a lead insert fails and we can't diagnose it in production, that's revenue lost."
+
+Amelia (Developer): "The Translatable Surfaces section was a clear win though. All 3 Epic 5 stories had it, and the i18n story is noticeably better this epic — let's talk about that in the main discussion."
+
+---
+
+## What Went Well
+
+Amelia (Developer): "Wins first."
+
+**Epic 4 commitment to 'Translatable Surfaces' sections paid off immediately.**
+All three Epic 5 stories included a comprehensive "Translatable Surfaces" section listing every i18n key — form labels, aria-labels, validation messages, confirmation text, meta tags. Story 5.1 alone had 80+ translatable keys explicitly enumerated in the spec. Story 5.2 included full Spanish translations inline in the spec. This is a direct result of the Epic 4 retrospective action item. Zero i18n hardcoded string findings in Epic 5.
+
+Charlie (Senior Dev): "That's a significant improvement. Epic 4 had at least one i18n hardcoded-string finding in every single story — seven total. Epic 5 had zero. The fix wasn't more code review; it was better story specs. Winston would be proud."
+
+**Component reuse architecture validated — LocationPicker designed for sharing, shared without modification.**
+`LocationPicker` was designed in Story 5.1 with an explicit comment: "shared with Story 5.2." When Story 5.2 implemented the CMA form, it imported `LocationPicker` directly — no modifications, no duplication. Same with `SellerConfirmation`, which was extended with a `source` variant prop (`"seller" | "cma"`) for backward-compatible polymorphism.
+
+Elena (Junior Dev): "That felt really good. When I started 5.2, the component was just... there. Right interface, right props. The story spec even said 'Do NOT Modify' — and we didn't need to."
+
+**AES-256-GCM encryption + SHA-256 dedup — security architecture solved elegantly.**
+Story 5.3 had a subtle complexity: PII encryption uses random IVs (security best practice), which means encrypted values are non-deterministic — you can't compare ciphertexts for dedup. The solution was a `phone_hash` column (SHA-256 of raw phone) for deterministic dedup lookups, while phone/email columns store `iv:authTag:ciphertext`. This wasn't in the original architecture schema — it was discovered during implementation and documented in the story spec.
+
+Charlie (Senior Dev): "That's the kind of discovery that validates the incremental story-spec approach. The architecture doc said 'column-level encryption.' The story spec discovered that random-IV encryption breaks idempotency comparisons. The solution (separate hash column) emerged during the spec-writing phase, not during a panicked implementation."
+
+**`react-hook-form` multi-step pattern established.**
+Story 5.1 established the canonical pattern for multi-step forms: single `useForm()` instance across all steps, local `step` state for navigation, form data preserved on back/next. This is the first form in the project using `react-hook-form` (Epic 1 used controlled components). The pattern is now documented and reusable for any future multi-step form.
+
+Dana (QA Engineer): "The testing for multi-step was clean too. Single form instance means single state source. Tests validate each step renders correctly, data persists across step navigation, and conditional rendering works (beds/baths hidden for Lote/Terreno)."
+
+**Lazy-loading SellerForm met the ~15KB budget.**
+The `SellerForm` component was lazy-loaded via `next/dynamic` with `{ ssr: false }`, following the `PropertyGallery` pattern from Epic 4. The SellerForm component is not in the initial bundle — the page shell (hero + form skeleton) renders at the edge, and the form hydrates client-side. Critically, the SellerForm does NOT import Mapbox GL JS (230KB); the map loads progressively inside `LocationPicker`.
+
+**Stub → real API wiring was seamless.**
+Stories 5.1 and 5.2 deliberately shipped with stub submissions (`console.log` + 500ms delay + confirmation screen). Story 5.3 replaced these stubs with real `POST /api/leads` calls. The stub approach worked exactly as designed: the UX was validated and tested independently of the backend. The replacement was surgical — specific line ranges in `seller-form.tsx` and `cma-form.tsx` were identified in the story spec.
+
+Alice (Product Owner): "This is the pattern I want for every epic with front-end + back-end dependencies. Ship the UX first with stubs, then wire the API. It means we can demo earlier and catch UX issues before the backend exists."
+
+**Summary of successes:**
+- "Translatable Surfaces" section (Epic 4 action item) eliminated i18n hardcoded-string findings — zero in this epic vs seven in Epic 4
+- Component reuse architecture validated: LocationPicker, SellerConfirmation shared across stories without modification
+- AES-256-GCM encryption + SHA-256 dedup hash — discovered and solved the random-IV dedup problem at spec time
+- `react-hook-form` multi-step pattern established as project standard
+- SellerForm lazy-loaded within ~15KB budget, not pulling Mapbox into main bundle
+- Stub → real API wiring pattern validated for front-end/back-end decoupling
+
+---
+
+## Challenges and Growth Areas
+
+Amelia (Developer): "Where we struggled."
+
+**Vitest 4 migration was unplanned work between stories 5.1 and 5.2.**
+Between Story 5.1 (merged 2026-05-04) and Story 5.2 (merged 2026-05-13), the team had to do a Vitest 4 migration (#143). This was infrastructure work that wasn't planned in any story spec. It didn't block Epic 5 delivery, but it added friction and wall-clock time to the epic.
+
+Charlie (Senior Dev): "This is a recurring theme — we don't have a process for infrastructure/tooling upgrades. They show up as surprise work between stories. We need a 'chores' budget or a specific cadence for tooling updates."
+
+**Package-lock and bundling fixes consumed significant intermediate effort.**
+PRs #145 through #151 (7 PRs!) were all fixes for sync package-lock issues and dist inline bundling problems. These were resolved between stories 5.2 and 5.3. None of these were anticipated in the sprint plan.
+
+Alice (Product Owner): "That's 7 infrastructure PRs in an epic that only has 3 story PRs. The ratio is concerning. Stakeholders see 3 features delivered; they don't see the 7 infrastructure fixes that made them possible."
+
+**Wall-clock duration was ~20 days for 3 stories.**
+Epic 4 delivered 5 stories in ~18 hours. Epic 5 delivered 3 stories across ~20 days. The comparison isn't entirely fair — Epic 4 ran fully autonomously via BAD pipeline, while Epic 5 had manual intervention, infrastructure work, and more complex security/backend requirements. But the velocity difference is notable.
+
+Dana (QA Engineer): "Story 5.3 was the heaviest backend story in the project's history. Encryption, routing, Zod validation, idempotency, Sentry integration, rate limiting — all in one story. That's a lot of new patterns to establish."
+
+**`dangerouslySetInnerHTML` audit sections say "not used" but don't cover future risk.**
+Both Stories 5.1 and 5.2 have dangerouslySetInnerHTML audit sections that correctly note "this story does NOT use dangerouslySetInnerHTML." But the audit is reactive — it checks whether the current story introduces the pattern. It doesn't catch cases where future stories might add it to existing components.
+
+Elena (Junior Dev): "The JSON-LD XSS from Epic 4 was in existing code that was deemed 'safe.' The audit needs to be part of the continuous review, not just the story spec."
+
+**Sync pipeline operations runbook — fourth epic without it.**
+This action item has appeared in retrospectives since Epic 2. It's now been deferred for four consecutive epics. With Story 5.3 shipping a write-path API (`POST /api/leads`), the operational visibility gap is more concerning than ever. If lead creation fails silently in production, there's no runbook for diagnosing it.
+
+Charlie (Senior Dev): *frustrated* "I keep saying this. We have a production API that encrypts PII, routes agents, captures UTM data — and no runbook for what to do when something breaks. This isn't a doc-only item anymore; it's an ops risk."
+
+**Story 5.3 task complexity — 9 tasks with 50+ subtasks in a single story.**
+Story 5.3 had 9 major tasks with 50+ subtasks. This is the densest story in the project's history. While it was delivered successfully, the sheer density makes it harder to review, test, and debug. Future backend-heavy stories might benefit from being split into 2 stories.
+
+**Summary of challenges:**
+- Vitest 4 migration and 7 infrastructure PRs added unplanned work between stories
+- Wall-clock duration was ~20 days for 3 stories — slower than Epic 4's autonomous 18-hour run
+- Sync runbook still not addressed — fourth consecutive epic deferral, now with write-path API in production
+- Story 5.3 was extremely dense (9 tasks, 50+ subtasks) — consider splitting backend-heavy stories
+- `dangerouslySetInnerHTML` audit is story-scoped, not component-lifecycle-scoped
+- Infrastructure/tooling upgrade process is ad hoc — no chores budget or cadence
+
+---
+
+## Key Insights
+
+**1. "Translatable Surfaces" in story specs eliminated i18n hardcoded-string findings.**
+Epic 4 had 7 i18n findings across 5 stories. Epic 5 had 0 across 3 stories. The difference: every Epic 5 story spec enumerated every translatable surface (80+ keys in Story 5.1 alone). The lesson is structural: agent-written code only translates what the spec lists. Making the spec exhaustive is the fix, not more code review.
+
+**2. Stub → real API wiring is the canonical pattern for front-end/back-end decoupled delivery.**
+Stories 5.1 and 5.2 shipped UX with stub submissions. Story 5.3 replaced stubs with real API calls. This pattern validated that: (a) UX can be tested independently of backend, (b) stub replacement is surgical when the story spec identifies exact line ranges, (c) the team can demo front-end features before the API exists. This pattern should be used for any future epic with front-end + back-end dependencies.
+
+**3. Random-IV encryption breaks dedup — discover these constraints at spec time, not implementation time.**
+The `phone_hash` column for idempotency dedup was discovered during story spec writing, not during a panicked implementation. This shows the value of deep technical specs: they surface architectural constraints before code is written. Encryption + dedup is a common pattern; the random-IV incompatibility with value comparison should be documented as a project-level pattern.
+
+**4. Component reuse requires intentional interface design in the first story.**
+`LocationPicker` was designed with an explicit `onChange` callback and a clean interface in Story 5.1. The spec said "shared with Story 5.2." When 5.2 arrived, zero modifications were needed. This wasn't accidental — it was designed for sharing from the start. Future stories should identify shared components early and design their interfaces for reuse.
+
+**5. Infrastructure work needs a visible budget — "chores" PRs are invisible but real.**
+7 infrastructure PRs (#143, #145–#151) were merged during Epic 5. None were planned. None appear in the sprint-status. From the outside, Epic 5 is "3 stories"; from the inside, it's "3 stories + 8 infrastructure PRs." This invisible work needs to be tracked and budgeted.
+
+**6. Dense backend stories (50+ subtasks) should be considered for splitting.**
+Story 5.3 had 9 tasks with 50+ subtasks covering encryption, routing, validation, idempotency, rate limiting, Sentry integration, and form stub replacement. While it was delivered successfully, the density made review and testing more complex. A natural split point existed: Tasks 1-3 (schema, encryption, routing) could have been a separate story from Tasks 4-9 (API, wiring, tracking).
+
+**7. Doc-only and tech-debt action items have a structural deferral problem.**
+Across 3 retrospectives, the pattern is consistent: blocking items always get done (100% completion rate for items that gate the next story/epic), but doc-only and tech-debt items slip (>60% deferral rate). The current process treats them as optional. They need either explicit sprint-status tracking or a dedicated "tech debt sprint" cadence.
+
+**8. The dangerouslySetInnerHTML audit needs to be component-lifecycle-scoped, not story-scoped.**
+The current audit checks whether the current story introduces `dangerouslySetInnerHTML`. But the Epic 4 JSON-LD XSS was in existing code that was deemed "safe." The audit should extend to any component that outputs user-supplied or DB-sourced content into HTML context — regardless of which story introduced it.
+
+---
+
+## Previous Epic Commitment Tracking
+
+### Epic 4 Action Items — Completion Summary
+
+- **Completed (5 of 15):** Translatable Surfaces section, dangerouslySetInnerHTML audit, async Server Component testing pattern, deferred-work triage, deferred-work.md update
+- **Partially addressed (3 of 15):** Link import pattern standard, Place JSON-LD wiring (via Epic 6.1), Step 7 PR review documentation
+- **Not addressed (7 of 15):** Sync runbook, Lighthouse CI enforcement, cast consolidation, generalInquiryEn rename, brand-name fallback, serializeJsonLd docs, area context block
+- **Overall completion rate:** 33% fully addressed, 20% partially addressed, 47% not addressed
+
+The high-impact process items (Translatable Surfaces, dangerouslySetInnerHTML audit) were completed and had measurable impact. The tech-debt and documentation items continue to accumulate.
+
+---
+
+## Next Epic Preview — Epic 6: Community Pages & Area Guides
+
+Amelia (Developer): "Epic 6 is 5 stories — the richest content epic in the project. Community pages, area guides, geo-fence auto-tagging."
+
+Alice (Product Owner): "This is the content marketing engine. Area guides with lifestyle narratives, climate data, and property grids. Community pages with hero imagery, quick facts, mini-maps, and availability status. This is what drives SEO long-term."
+
+Charlie (Senior Dev): "Story 6.1 (Area Guide Pages) is already done per sprint-status. Stories 6.2 through 6.5 are in backlog. The geo-fence auto-tagging in 6.5 extends the sync pipeline from Epic 2 — that's the most complex story."
+
+Dana (QA Engineer): "Community pages have status indicators (Available, Sold, Reserved) — that's new dynamic content that changes daily via ISR. Testing those state transitions will be important."
+
+Elena (Junior Dev): "And Story 6.4 (Investment Discovery & Area Context) finally delivers the area context block that was deferred from Story 4.5. Two epics of deferral resolved."
+
+**Stories in Epic 6 (5 stories):**
+
+| Story | Title | GH Issue | Status | Notable patterns |
+|---|---|---|---|---|
+| 6.1 | Area Guide Pages | #101 | done | SSG, Place JSON-LD, lifestyle narratives, area property grid, agent cards, similar areas slider |
+| 6.2 | Community Pages | #102 | backlog | SSG + ISR, community hero, quick facts grid, availability status indicators, mini-map, gold-bordered cards |
+| 6.3 | Community Mini-Map & Geo-Fence Display | #103 | backlog | Mapbox static mini-maps, geo-fence polygon overlay, lightweight image-based maps |
+| 6.4 | Investment Discovery & Area Context | #104 | backlog | Investment context data, area context block (deferred from 4.5), lifestyle tag filtering |
+| 6.5 | Community Geo-Fence Auto-Tagging | #105 | backlog | PostGIS `ST_Within`, sync pipeline extension (Step 6: GEO-TAG), admin override preservation |
+
+**Dependencies on Epic 5 work:**
+- Seller landing page provides a template for content-rich SSG pages (Story 5.1's page structure)
+- `POST /api/leads` endpoint from Story 5.3 may be extended for community-context leads
+- Agent routing logic from Story 5.3 may be reused for community-based agent matching
+
+**Dependencies on Epic 1–4 work:**
+- Property grid, PropertyCard from Epic 3
+- AgentCard from Epic 4
+- JSON-LD generators, hreflang helpers from Epic 4
+- SSG/ISR pattern from Epic 4
+- Sync pipeline from Epic 2 (extended in 6.5)
+
+---
+
+## Action Items
+
+### Process Improvements
+
+1. **Create an infrastructure/tooling "chores" tracking category in sprint-status**
+   Owner: Amelia (Developer)
+   Deadline: Before Epic 6 Story 6.2 starts
+   Success criteria: Infrastructure PRs (migrations, dependency upgrades, bundling fixes) are tracked as named entries in sprint-status.yaml under a `chores` section, making invisible work visible
+
+2. **Maintain the "Translatable Surfaces" section in every story spec — it works**
+   Owner: Amelia (Developer) / BAD pipeline `create-story` step
+   Deadline: Ongoing — already established
+   Success criteria: Every story spec continues to enumerate translatable surfaces. Zero tolerance for i18n hardcoded-string findings going forward
+
+3. **Extend dangerouslySetInnerHTML audit to component-lifecycle scope**
+   Owner: Charlie (Senior Dev)
+   Deadline: Before Epic 6 Story 6.2 code review
+   Success criteria: Code review checklist explicitly audits any component that outputs DB-sourced or user-supplied content into HTML context — not just components newly introduced in the current story
+
+4. **Split backend-heavy stories with 40+ subtasks into two stories**
+   Owner: Amelia (Developer) / story creation step
+   Deadline: Ongoing policy
+   Success criteria: No single story exceeds 40 subtasks. Natural split points identified at spec time (e.g., schema/encryption/routing vs. API/wiring/tracking)
+
+5. **Use stub → real API wiring pattern for all front-end/back-end decoupled delivery**
+   Owner: Amelia (Developer)
+   Deadline: Ongoing pattern
+   Success criteria: Any epic with form/API dependencies ships UX with stubs first, then wires real APIs in a subsequent story. Story specs identify exact line ranges for stub replacement
+
+### Technical Debt
+
+1. **Add sync pipeline operations runbook (CRITICAL — fifth epic open)**
+   Owner: Charlie (Senior Dev)
+   Priority: CRITICAL — now gates production write-path operations; overdue since Epic 2
+   Target: Before any production deployment of `POST /api/leads`
+   Content: How to diagnose lead creation failures, read sync_logs, verify encryption, check agent routing, Sentry alert setup, manual lead inspection (decrypt PII), force re-routing
+
+2. **Wire Lighthouse CI as PR-blocking check**
+   Owner: Amelia (Developer) / Charlie (Senior Dev)
+   Priority: MEDIUM — second epic deferred
+   Action: Move advisory job to PR-trigger; set ≥ 80 threshold on listing-detail, agent-profile, and sell pages
+
+3. **Consolidate `as unknown as { src: string }[]` cast into shared type**
+   Owner: Amelia (Developer)
+   Priority: MEDIUM — 4 call sites, no compile guidance if image shape changes
+   Action: Create `src/lib/db/types/property-images.ts` with the shape and a `castToOptimizedImages(jsonb)` helper
+
+4. **Rename `generalInquiryEn` i18n key to drop misleading suffix**
+   Owner: Amelia (Developer)
+   Priority: LOW — cosmetic but naming-convention drift
+   Action: Rename to `generalInquiry` in next i18n key consolidation pass
+
+5. **Address brand-name fallback hardcoding in AgentProfile namespace**
+   Owner: Amelia (Developer)
+   Priority: LOW — unreachable in practice but defensive
+   Action: Move `"RE/MAX Altitud"` to i18n constants used by office-name fallback
+
+6. **Document encryption pattern (random IV + hash for dedup) as project-level security standard**
+   Owner: Charlie (Senior Dev)
+   Priority: MEDIUM — pattern from Story 5.3 needs to be documented for any future encrypted column
+   Action: Create `docs/security/pii-encryption.md` documenting AES-256-GCM pattern, `phone_hash` dedup pattern, key management
+
+7. **Address `Link` import pattern inconsistency codemod**
+   Owner: Amelia (Developer)
+   Priority: LOW — standard documented in story specs, existing call sites not migrated
+   Action: Project-wide grep + codemod existing `/${locale}/...` manual-prefix patterns to `@/i18n/navigation` Link
+
+### Documentation
+
+1. **Create PII encryption and dedup documentation**
+   Owner: Charlie (Senior Dev)
+   Deadline: Before Epic 6 Story 6.5 (which extends the sync pipeline)
+   Content: AES-256-GCM pattern, `iv:authTag:ciphertext` format, `phone_hash` for dedup, `LEAD_ENCRYPTION_KEY` management, `decryptField` for admin use
+
+2. **Document stub → real API wiring pattern**
+   Owner: Amelia (Developer)
+   Deadline: Before next epic with front-end/back-end dependencies
+   Content: Pattern description, example from Stories 5.1/5.2 → 5.3, line-range identification technique, testing strategy for stubbed vs real API
+
+### Team Agreements for Epic 6
+
+- All translatable surfaces (visible text + aria-labels + JSON-LD names + schema.org fields + form templates) MUST be listed in story spec's Translatable Surfaces section — **zero tolerance for i18n hardcoded strings** (proven effective in Epic 5)
+- All `dangerouslySetInnerHTML` usages MUST have escape-rules audit — now component-lifecycle-scoped, not just story-scoped
+- Step 7 PR review remains REQUIRED — it catches integration-boundary issues Step 5 misses
+- Backend stories with 40+ subtasks MUST be considered for splitting at spec time
+- Infrastructure PRs MUST be tracked in sprint-status under a chores category
+- `data-testid` values established in Epics 3–5 MUST NOT be renamed or removed
+- `npm run typecheck && npm run lint && npm run format:check && npm run build && npm test` must all pass green before any PR is opened
+- Sync runbook is CRITICAL priority — must ship before next production deployment
+
+---
+
+## Epic 6 Preparation Tasks
+
+**Critical (must complete before Epic 6 Story 6.2 starts):**
+
+- [ ] Sync pipeline operations runbook — CRITICAL; now overdue across 5 epics
+- [ ] Verify PostGIS `ST_Within` is available in the deployment environment (required for Story 6.5 geo-fence auto-tagging)
+- [ ] Confirm community data model and `communities` table schema exist or need creation
+
+**Parallel (can happen during early Epic 6 stories):**
+
+- [ ] Document PII encryption pattern for future reference
+- [ ] Wire Lighthouse CI as PR-blocking check on listing-detail, agent-profile, sell pages
+- [ ] Document stub → real API wiring pattern
+- [ ] Extend `dangerouslySetInnerHTML` audit scope in code review checklist
+
+**No significant discoveries requiring Epic 6 plan update.** Epic 5 implementation confirms that the security and lead-capture architecture scales correctly. The `POST /api/leads` endpoint, PII encryption, and agent routing are all stable and well-tested. Epic 6's content-focused stories (area guides, community pages) don't depend on any undiscovered constraints from Epic 5.
+
+---
+
+## Readiness Assessment
+
+| Dimension | Status | Notes |
+|---|---|---|
+| Testing & Quality | PASS | 910 pass, 4 skips, 0 failures. Encryption roundtrip, agent routing, Zod validation, API integration all tested |
+| Deployment | Not yet deployed | Epic 5 merged to `main`; production deploy still pending |
+| Stakeholder Acceptance | Pending | Seller lead capture funnel complete; needs demo with real form submission + agent match |
+| Technical Health | Good with known gaps | Sync runbook missing (CRITICAL); Lighthouse CI still advisory; 5 LOW-priority tech debt items |
+| Unresolved Blockers for Epic 6 | 0 critical | Story 6.1 already done; remaining stories don't have Epic-5-dependent blockers |
+
+**Epic 5 status:** Complete from a story perspective. All 3 stories merged, 113 new tests added, first write-path API with PII encryption validated. One critical operational gap (sync runbook) that affects all production deployments, not just Epic 6.
+
+---
+
+## Retrospective Closure
+
+Amelia (Developer): "Epic 5 delivered 3 stories, 113 new tests, and crossed the most significant architectural boundary in the project: from read-only to write-path with PII encryption. The seller lead capture funnel is complete — 3-step form, CMA request, agent routing, UTM tracking, all bilingual."
+
+Alice (Product Owner): "Sellers can now fill a 3-minute form, get matched with a local agent, and the lead arrives encrypted with full marketing attribution. The CMA form gives us a second entry point for pricing-curious sellers. This is the product closing the loop."
+
+Charlie (Senior Dev): "The encryption architecture is solid. AES-256-GCM with random IVs, SHA-256 hash for dedup, Zod validation on the API. But I'll say it again: we need that sync runbook before we deploy this to production. This is the fifth epic I'm saying it."
+
+Dana (QA Engineer): "910 tests, 0 failures, 0 flakes. The encryption roundtrip tests and agent routing tests give me confidence. The Vitest 4 migration was painful but the test infrastructure is now modern and stable."
+
+Elena (Junior Dev): "I learned that component reuse isn't just about sharing code — it's about designing interfaces for sharing from the start. The LocationPicker worked in 5.2 because it was designed for 5.2 in 5.1. And the Translatable Surfaces section? That's the best retro action item we've ever had. Zero i18n findings."
+
+Amelia (Developer): "Alright team — Epic 5 reviewed. Write that runbook, document the encryption pattern, track the infrastructure work, and let's ship Epic 6. Meeting adjourned."
+
+---
+
+## Key Takeaways
+
+1. **"Translatable Surfaces" in story specs eliminated i18n hardcoded-string findings** — 0 findings in Epic 5 vs 7 in Epic 4. Making specs exhaustive is the fix, not more code review
+2. **Stub → real API wiring is the canonical front-end/back-end decoupling pattern** — Ship UX first with stubs, wire APIs later. Validated across Stories 5.1/5.2 → 5.3
+3. **Random-IV encryption breaks dedup — discover constraints at spec time** — `phone_hash` column for idempotency was discovered during spec writing, not implementation
+4. **Component reuse requires intentional interface design in the first consumer** — LocationPicker shared without modification because it was designed for sharing
+5. **Infrastructure work needs visible tracking** — 7 infra PRs in a 3-story epic is invisible but real work
+6. **Dense backend stories (50+ subtasks) should be split** — Story 5.3's density worked but made review complex
+7. **Doc-only and tech-debt items have a structural deferral problem** — 47% of Epic 4 action items were not addressed; needs process change
+8. **Sync runbook is CRITICAL — now in its fifth epic of deferral** — Write-path API makes operational visibility non-optional
+
+---
+
+## Commitments Made
+
+- Action Items: 5 process improvements + 7 technical debt + 2 documentation
+- Preparation Tasks: 7 (3 critical, 4 parallel)
+- Critical Path Items: 1 (sync runbook — fifth epic overdue)
+
+## Next Steps
+
+1. **Write the sync pipeline operations runbook** — CRITICAL; fifth epic overdue; gates production deployment
+2. **Document PII encryption pattern** — captures the AES-256-GCM + SHA-256 hash pattern for future use
+3. **Track infrastructure work visibly** — add chores category to sprint-status
+4. **Continue Epic 6 story creation** — Story 6.1 already done; Stories 6.2–6.5 in backlog
+   - Epic 6 is `in-progress` per sprint-status

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -90,7 +90,7 @@ development_status:
   5-1-seller-landing-page-and-list-with-us-form: done
   5-2-cma-request-form: done
   5-3-seller-lead-storage-routing-and-source-tracking: done
-  epic-5-retrospective: optional
+  epic-5-retrospective: done
 
   # Epic 6: Community Pages & Area Guides
   epic-6: in-progress

--- a/_bmad-output/test-artifacts/atdd-checklist-6-1-area-guide-pages.md
+++ b/_bmad-output/test-artifacts/atdd-checklist-6-1-area-guide-pages.md
@@ -1,0 +1,173 @@
+---
+stepsCompleted:
+  - step-01-preflight-and-context
+  - step-02-generation-mode
+  - step-03-test-strategy
+  - step-04-generate-tests
+  - step-05-validate-and-complete
+lastStep: step-05-validate-and-complete
+lastSaved: '2026-05-26'
+storyId: '6.1'
+storyKey: 6-1-area-guide-pages
+storyFile: _bmad-output/implementation-artifacts/6-1-area-guide-pages.md
+atddChecklistPath: _bmad-output/test-artifacts/atdd-checklist-6-1-area-guide-pages.md
+generatedTestFiles:
+  - tests/e2e/area-guide-pages.spec.ts
+  - tests/unit/area/area-queries.spec.ts
+  - tests/unit/area/area-components.spec.tsx
+inputDocuments:
+  - _bmad-output/implementation-artifacts/6-1-area-guide-pages.md
+  - _bmad-output/test-artifacts/test-design-epic-6.md
+  - _bmad-output/planning-artifacts/epics.md
+  - src/lib/db/schema/areas.ts
+  - src/lib/seo/structured-data.ts
+  - vitest.config.mts
+  - tests/e2e/property-cards.spec.ts
+  - tests/unit/db/properties.spec.ts
+---
+
+# ATDD Checklist — Story 6.1: Area Guide Pages
+
+**Story:** As a visitor, I want to explore area guides with lifestyle narratives, climate info, and filtered properties, so that I can understand what living in a specific area feels like before browsing listings.
+
+**TDD Phase:** 🔴 RED — All tests are scaffolded with `test.skip()` / `it.skip()` and will fail until implementation.
+
+---
+
+## Preflight Summary
+
+- **Stack:** Frontend (Next.js + Vitest + Playwright)
+- **Generation Mode:** AI Generation (acceptance criteria are clear, standard SSG page scenarios)
+- **Execution Mode:** Sequential (single agent)
+- **Test Framework:** Vitest (unit/component), Playwright (E2E)
+- **Story Status:** ready-for-dev
+
+---
+
+## Test Strategy — AC to Test Level Mapping
+
+| AC # | Acceptance Criteria Summary | Test Level | Priority | Test ID |
+|------|---------------------------|------------|----------|---------|
+| AC #1 | Area guide page renders hero, description, climate data | E2E | P1 | 6.1-E2E-004 |
+| AC #2 | Description always visible (not tabbed) for SEO | E2E | P0 | 6.1-E2E-001, 6.1-E2E-002 |
+| AC #3 | Tabbed sections: Properties, Agents, Similar Areas | E2E | P1 | 6.1-E2E-006 |
+| AC #4 | Properties tab shows filtered property grid | E2E | P0 | 6.1-E2E-003 |
+| AC #5 | Agents tab shows AgentCards | E2E | P1 | 6.1-E2E-005 |
+| AC #6 | Community cards with gold border | E2E | P1 | 6.1-E2E-007 |
+| AC #7 | Area index page lists all areas | E2E | P1 | 6.1-E2E-008 |
+| AC #8 | SSG — no ISR revalidation | Component | P2 | 6.1-COMP-003 |
+| AC #9 | Locale support (EN/ES) via next-intl | E2E | P2 | 6.1-E2E-009 |
+| AC #10 | JSON-LD Place schema | Component | P1 | 6.1-COMP-001 |
+| AC #11 | Empty state for zero properties | E2E | P1 | 6.1-E2E-011 |
+| AC #12 | Gradient fallback when no hero image | E2E | P2 | 6.1-E2E-012 |
+| AC #13 | WAI-ARIA Tabs pattern with keyboard nav | E2E | P1 | 6.1-E2E-013 |
+
+---
+
+## Generated Test Files
+
+### 1. E2E Tests: `tests/e2e/area-guide-pages.spec.ts`
+
+| Test ID | Priority | AC | Description | Risk |
+|---------|----------|----|-------------|------|
+| 6.1-E2E-001 | P0 | #2 | Description visible without clicking any tab | R-003 |
+| 6.1-E2E-002 | P0 | #2 | Description present in SSG HTML (no JS) | R-003 |
+| 6.1-E2E-003 | P0 | #4 | Properties tab shows filtered grid | — |
+| 6.1-E2E-004 | P1 | #1 | Hero renders h1 with area name | — |
+| 6.1-E2E-005 | P1 | #5 | Agents tab shows AgentCards | — |
+| 6.1-E2E-006 | P1 | #3 | Similar Areas tab renders | — |
+| 6.1-E2E-007 | P1 | #6 | CommunityCards with gold border | R-011 |
+| 6.1-E2E-008 | P1 | #7 | Area index page lists all areas | R-010 |
+| 6.1-E2E-009 | P2 | #9 | Spanish locale renders correctly | — |
+| 6.1-E2E-011 | P1 | #11 | Empty state for zero properties | — |
+| 6.1-E2E-012 | P2 | #12 | Gradient fallback (no hero image) | — |
+| 6.1-E2E-013 | P1 | #13 | WAI-ARIA Tabs keyboard navigation | — |
+
+**Total E2E tests:** 12 (all `test.skip()`)
+
+### 2. Unit Tests: `tests/unit/area/area-queries.spec.ts`
+
+| Test ID | Priority | AC | Description |
+|---------|----------|----|-------------|
+| getAllAreas-P0-1 | P0 | #1, #7 | db.select is called |
+| getAllAreas-P0-2 | P0 | #7 | Results ordered by sortOrder |
+| getAllAreas-P1-1 | P1 | #7 | Returns empty array when no areas |
+| getAreaBySlug-P0-1 | P0 | #1 | Returns area by slug |
+| getAreaBySlug-P0-2 | P0 | #1 | Returns null for non-existent slug |
+| getAreaBySlug-P1-1 | P1 | #1 | Uses .limit(1) |
+| getAllAreaSlugs-P0-1 | P0 | #8 | Returns array of 3 slugs |
+| getAllAreaSlugs-P1-1 | P1 | #8 | Returns empty array when no areas |
+| getAllAreaSlugs-P0-2 | P0 | #8 | Each element is a string |
+| getPropertiesByArea-P0-1 | P0 | #4 | Returns 2 PropertySearchItems |
+| getPropertiesByArea-P0-2 | P0 | #4, #11 | Returns empty for no properties |
+| getPropertiesByArea-P1-1 | P1 | #4 | Only is_visible=true properties |
+| getSimilarAreas-P0-1 | P0 | #3 | Returns same-region areas |
+| getSimilarAreas-P1-1 | P1 | #3 | Empty when no similar areas |
+| getSimilarAreas-P1-2 | P1 | #3 | Ordered by sortOrder |
+
+**Total unit tests:** 15 (all `it.skip()`)
+
+### 3. Component Tests: `tests/unit/area/area-components.spec.tsx`
+
+| Test ID | Priority | AC | Description |
+|---------|----------|----|-------------|
+| 6.1-COMP-001 | P1 | #10 | Place JSON-LD schema |
+| 6.1-COMP-001b | P1 | #10 | English name in Place schema |
+| 6.1-COMP-001c | P1 | #10 | Spanish description in Place schema |
+| 6.1-COMP-001d | P2 | #10 | Geo coordinates in Place schema |
+| 6.1-COMP-002 | P2 | #1 | Climate/altitude metadata |
+| breadcrumb-area | P1 | #10 | Breadcrumb: Home → Areas → Area Name |
+| breadcrumb-index | P2 | #10 | Breadcrumb: Home → Areas |
+| hero-no-image | P2 | #12 | Gradient fallback (null heroImageUrl) |
+| hero-with-image | P2 | #12 | Image used when heroImageUrl present |
+| index-card-data | P1 | #7 | AreaIndexCard data contract |
+| slug-url-safe | P2 | #8 | Slug is URL-safe |
+| tabs-count | P1 | #3 | 3 tab panels expected |
+| tabs-testids | P1 | #13 | data-testid contract |
+
+**Total component tests:** 13 (all `it.skip()`)
+
+---
+
+## Risk Mitigations Covered
+
+| Risk | Score | Mitigation Tests |
+|------|-------|-----------------|
+| R-003 (SEO description visibility) | 6 | 6.1-E2E-001, 6.1-E2E-002 |
+| R-010 (stale property counts) | 3 | 6.1-E2E-008 |
+| R-011 (gold border missing) | 2 | 6.1-E2E-007 |
+
+---
+
+## Statistics
+
+| Category | Count |
+|----------|-------|
+| Total test scaffolds | 40 |
+| P0 tests | 10 |
+| P1 tests | 18 |
+| P2 tests | 12 |
+| E2E tests | 12 |
+| Unit tests | 15 |
+| Component tests | 13 |
+| ACs covered | 13/13 (100%) |
+| Risks mitigated | 3/3 story-level risks |
+
+---
+
+## Completion Summary
+
+- **Test files created:** 3
+- **Checklist output path:** `_bmad-output/test-artifacts/atdd-checklist-6-1-area-guide-pages.md`
+- **Story key:** `6-1-area-guide-pages`
+- **Story file:** `_bmad-output/implementation-artifacts/6-1-area-guide-pages.md`
+
+### Key Risks / Assumptions
+
+1. **R-003 (SEO):** Description visibility is the #1 risk. Two P0 tests verify the description is always visible and present in SSG HTML.
+2. **Playwright not installed:** E2E tests use `@ts-expect-error` for the import until Playwright is configured.
+3. **Areas table seeded:** Unit tests mock DB calls; E2E tests require seeded area data.
+
+### Next Recommended Workflow
+
+→ `dev-story` — Implement Story 6.1 using the story spec file. Remove `test.skip()` / `it.skip()` as each AC is implemented.


### PR DESCRIPTION
# Epic 5 Retrospective & Story 6.1 Spec Creation

## Overview

This branch adds two documentation artifacts to advance the project from Epic 5 completion into Epic 6 execution:

1. **Epic 5 Retrospective** — A comprehensive post-epic review of the Seller Lead Capture epic (3 stories, 113 new tests, first write-path API with PII encryption).
2. **Story 6.1 Spec & ATDD Checklist** — Full implementation specification and acceptance test scaffolds for the first story in Epic 6 (Community Pages & Area Guides): the Area Guide Pages.

## Changes

### Epic 5 Retrospective (`_bmad-output/implementation-artifacts/epic-5-retro-2026-05-27.md`)

- Full retrospective covering delivery metrics (3/3 stories, 910 tests, 0 failures), Epic 4 action item follow-through (33% fully completed, 20% partial, 47% not addressed), wins (Translatable Surfaces eliminating i18n findings, component reuse, AES-256-GCM encryption architecture), challenges (Vitest 4 migration, 7 infra PRs, 20-day wall-clock for 3 stories), 8 key insights, 14 action items (5 process + 7 tech debt + 2 docs), and Epic 6 preparation tasks.
- Updated `sprint-status.yaml` to mark `epic-5-retrospective: done`.

### Story 6.1: Area Guide Pages (`_bmad-output/implementation-artifacts/6-1-area-guide-pages.md`)

- Complete story spec with 13 acceptance criteria covering: SSG area guide pages with hero, lifestyle narrative description (always visible for SEO), tabbed sections (Properties, Agents, Similar Areas), area index page, JSON-LD Place schema, WAI-ARIA tabs, empty states, gradient fallback, and i18n support.
- 6 tasks with ~25 subtasks: DB queries, page route, components, index page, i18n strings, breadcrumb structured data.
- Detailed dev notes: rendering strategy (pure SSG), component reuse map (PropertyCard, AgentCard, generatePlaceJsonLd), CommunityCard placeholder for Story 6.2, styling tokens, accessibility requirements.

### ATDD Checklist (`_bmad-output/test-artifacts/atdd-checklist-6-1-area-guide-pages.md`)

- 40 test scaffolds across 3 test files (E2E, unit, component).
- 10 P0 tests, 18 P1 tests, 12 P2 tests.
- 100% AC coverage (13/13), 3/3 story-level risks mitigated.
- All tests scaffolded with `test.skip()` / `it.skip()` — RED phase.

### Sprint Status Update (`_bmad-output/implementation-artifacts/sprint-status.yaml`)

- `epic-5-retrospective`: `optional` -> `done`

## Testing

- All changes are documentation-only (markdown and YAML files).
- No source code modified — existing test suite (910 tests) unaffected.
- Production build passes: Compiled successfully with 28 static pages generated.