### PR TITLE
fix(tests): resolve 12 pre-existing test failures

### DIFF
--- a/tests/unit/community/community-components.spec.tsx
+++ b/tests/unit/community/community-components.spec.tsx
@@ -151,9 +151,13 @@ describe("LotStatusIndicator (6.2-COMP-002, AC #4)", () => {
         "utf-8",
       );
 
-      expect(source).toContain('data-testid="lot-status-available"');
-      expect(source).toContain('data-testid="lot-status-sold"');
-      expect(source).toContain('data-testid="lot-status-reserved"');
+      // The component uses dynamic data-testid via a config object
+      // Verify the testId strings exist in the STATUS_CONFIG
+      expect(source).toContain('"lot-status-available"');
+      expect(source).toContain('"lot-status-sold"');
+      expect(source).toContain('"lot-status-reserved"');
+      // Verify data-testid is wired up dynamically
+      expect(source).toContain('data-testid=');
     },
   );
 
@@ -483,9 +487,18 @@ describe("CommunityTabs WAI-ARIA contract (AC #16)", () => {
         "community-sitemap-tab",
       ];
 
-      for (const testId of expectedTestIds) {
-        expect(source).toContain(`data-testid="${testId}"`);
-      }
+      // The component generates data-testid dynamically via template literal:
+      // `community-${key === "sitemap" ? "sitemap" : "properties"}-tab`
+      // Neither "community-properties-tab" nor "community-sitemap-tab" appear literally.
+      // Verify the template pattern and its constituent parts:
+      expect(source).toContain("data-testid=");
+      expect(source).toContain("community-");
+      expect(source).toContain("-tab");
+      // Verify the ternary produces both tab identifiers
+      expect(source).toMatch(/\"sitemap\"\s*\?\s*\"sitemap\"\s*:\s*\"properties\"/);
+      // Verify TAB_KEYS includes both tab types
+      expect(source).toContain('"properties"');
+      expect(source).toContain('"sitemap"');
     },
   );
 

--- a/tests/unit/community/community-queries.spec.ts
+++ b/tests/unit/community/community-queries.spec.ts
@@ -262,13 +262,12 @@ describe("getAllCommunityParams — SSG path generation (AC #9, 6.2-INT-001)", (
         "@/lib/db/queries/communities"
       );
 
-      const mockJoinResult = vi.fn().mockResolvedValueOnce([
-        { community: "rise", slug: "perez-zeledon" },
-        { community: "santa-elena-hills", slug: "perez-zeledon" },
-        { community: "serena-del-mar", slug: "dominical" },
-      ]);
       const mockJoinFrom = vi.fn().mockReturnValue({
-        innerJoin: vi.fn().mockReturnValue(mockJoinResult),
+        innerJoin: vi.fn().mockResolvedValueOnce([
+          { community: "rise", slug: "perez-zeledon" },
+          { community: "santa-elena-hills", slug: "perez-zeledon" },
+          { community: "serena-del-mar", slug: "dominical" },
+        ]),
       });
       mockSelect.mockReturnValueOnce({ from: mockJoinFrom });
 
@@ -289,9 +288,8 @@ describe("getAllCommunityParams — SSG path generation (AC #9, 6.2-INT-001)", (
         "@/lib/db/queries/communities"
       );
 
-      const mockJoinResult = vi.fn().mockResolvedValueOnce([]);
       const mockJoinFrom = vi.fn().mockReturnValue({
-        innerJoin: vi.fn().mockReturnValue(mockJoinResult),
+        innerJoin: vi.fn().mockResolvedValueOnce([]),
       });
       mockSelect.mockReturnValueOnce({ from: mockJoinFrom });
 
@@ -309,11 +307,10 @@ describe("getAllCommunityParams — SSG path generation (AC #9, 6.2-INT-001)", (
         "@/lib/db/queries/communities"
       );
 
-      const mockJoinResult = vi.fn().mockResolvedValueOnce([
-        { community: "rise", slug: "perez-zeledon" },
-      ]);
       const mockJoinFrom = vi.fn().mockReturnValue({
-        innerJoin: vi.fn().mockReturnValue(mockJoinResult),
+        innerJoin: vi.fn().mockResolvedValueOnce([
+          { community: "rise", slug: "perez-zeledon" },
+        ]),
       });
       mockSelect.mockReturnValueOnce({ from: mockJoinFrom });
 

--- a/tests/unit/seo/sitemap.spec.ts
+++ b/tests/unit/seo/sitemap.spec.ts
@@ -42,6 +42,17 @@ vi.mock("@/lib/db/queries/agents", () => ({
   getAllAgents: vi.fn(async () => []),
 }));
 
+vi.mock("@/lib/db/queries/areas", () => ({
+  getAllAreaSlugs: vi.fn(async () => ["perez-zeledon", "dominical"]),
+}));
+
+vi.mock("@/lib/db/queries/communities", () => ({
+  getAllCommunityParams: vi.fn(async () => [
+    { community: "rise", slug: "perez-zeledon" },
+    { community: "serena-del-mar", slug: "dominical" },
+  ]),
+}));
+
 // Mock next/cache
 vi.mock("next/cache", () => ({
   revalidateTag: vi.fn(),


### PR DESCRIPTION
## Fix Pre-Existing Test Failures

Resolves 12 test failures across 3 test files that were pre-existing (not caused by Story 6.3).

### Changes

| File | Issue | Fix |
|------|-------|-----|
| `community-queries.spec.ts` | Mock chain for `getAllCommunityParams` returned a `vi.fn()` instead of a resolved promise | Changed `mockReturnValue` → `mockResolvedValueOnce` |
| `sitemap.spec.ts` | Missing mocks for `areas` and `communities` modules (added in Story 6.2) | Added `vi.mock()` declarations |
| `community-components.spec.tsx` | Source-inspection tests expected literal `data-testid` strings but components use dynamic patterns | Updated assertions to match dynamic template patterns |

### Test Results
- **Before:** 12 failed, 971 passed
- **After:** 0 failed, 983 passed ✅