### PR TITLE
Fix : Navigation Bar Styling Fixes

### DIFF
--- a/src/components/layout/desktop-nav.tsx
+++ b/src/components/layout/desktop-nav.tsx
@@ -84,7 +84,7 @@ function CtaNavItem({ item, pathname, t }: { item: NavItem; pathname: string; t:
       variant="outline"
       asChild
       className={cn(
-        "ml-1 border-brand-gold text-brand-gold hover:bg-brand-gold/10 hover:text-white",
+        "ml-1 bg-transparent border-brand-gold text-brand-gold hover:bg-brand-gold/10 hover:text-white",
         isActive && "bg-brand-gold/15 text-white",
       )}
     >

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -56,7 +56,7 @@ function NavigationMenuItem({
 }
 
 const navigationMenuTriggerStyle = cva(
-  "group/navigation-menu-trigger inline-flex h-9 w-max items-center justify-center rounded-lg px-2.5 py-1.5 text-sm font-medium transition-all outline-none hover:bg-muted focus:bg-muted focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-popup-open:bg-muted/50 data-popup-open:hover:bg-muted data-open:bg-muted/50 data-open:hover:bg-muted data-open:focus:bg-muted",
+  "group/navigation-menu-trigger inline-flex h-9 w-max items-center justify-center rounded-lg px-2.5 py-1.5 text-sm font-medium transition-all outline-none hover:bg-white/10 hover:text-white focus:bg-white/10 focus:text-white focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-popup-open:bg-white/15 data-popup-open:hover:bg-white/20 data-open:bg-white/15 data-open:text-white data-open:hover:bg-white/20 data-open:focus:bg-white/20",
 );
 
 function NavigationMenuTrigger({


### PR DESCRIPTION
# Navigation Bar Styling Fixes

We have updated the navigation bar component to resolve readability and hover behavior issues, making the interactions feel premium, responsive, and completely seamless on our dark navy site header.

## Changes Made

### 1. Dropdown Navigation Trigger Styling
- **File modified**: `src/components/ui/navigation-menu.tsx`
- **Problem**: When a user clicked or rolled over dropdown triggers like **Propiedades** or **Zonas**, they turned into a solid white/crema background (`bg-muted`), but the text remained white (`text-white`), causing severe readability issues (white-on-white). Additionally, when clicking elsewhere, focus remained on the item keeping it white.
- **Solution**: Replaced the default solid `bg-muted` and `focus:bg-muted` classes with modern transparent white glassmorphism states:
  - **Hover**: Subtle white overlay `hover:bg-white/10` and solid white text `hover:text-white`.
  - **Focus**: Subtle white overlay `focus:bg-white/10` and solid white text `focus:text-white`.
  - **Open Dropdown state**: `bg-white/15` and `text-white` while the menu is open, smoothly turning back to normal (`text-white/90` with transparent background) when closed or focus moves away.

### 2. CTA Nav Item ("Vende tu Propiedad") Transparency & Hover
- **File modified**: `src/components/layout/desktop-nav.tsx`
- **Problem**: The CTA button was styled using shadcn's outline button variant, which defaults to a solid crema/white background (`bg-background`). Because of this, it was solid crema in its normal state instead of transparent, which stood out aggressively and caused text to become invisible (white-on-white) when hovered, and it remained white even when clicking elsewhere.
- **Solution**: Added `bg-transparent` directly to the `CtaNavItem` button's class list. This overrides the default solid outline background:
  - **Normal**: Beautiful transparent background with a gold border and gold text.
  - **Hover**: Subtle gold tint background (`bg-brand-gold/10`) and white text.
  - **Active**: Soft gold background highlight (`bg-brand-gold/15`) with white text.
  - **Clicking Elsewhere**: Correctly reverts back to its elegant transparent background and gold border when the page changes.

## Verification

- **Code Integrity**: Ran TypeScript `tsc --noEmit` which completed successfully with zero compilation errors.
- **Code Style**: Formatted all changes using Prettier.
