### PR TITLE
Feature : Zillow-style Property Gallery Redesign

### DIFF
--- a/src/components/listing/property-gallery.tsx
+++ b/src/components/listing/property-gallery.tsx
@@ -375,11 +375,21 @@ export function PropertyGallery({ images, youtubeUrl, propertyTitle }: PropertyG
         >
           {/* Mobile Text */}
           <span className="md:hidden">{t("openLightbox")}</span>
-          
+
           {/* Desktop Content */}
           <span className="hidden md:inline-flex items-center gap-2">
-            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"
+              />
             </svg>
             <span>
               {t("openLightbox")} ({total})

--- a/src/components/listing/property-gallery.tsx
+++ b/src/components/listing/property-gallery.tsx
@@ -77,49 +77,321 @@ export function PropertyGallery({ images, youtubeUrl, propertyTitle }: PropertyG
 
   const activeImage = images[activeIndex];
 
+  // Dynamic grid layouts for desktop based on total images
+  const renderDesktopGrid = () => {
+    if (total === 1) {
+      return (
+        <div className="hidden md:grid grid-cols-1 gap-2 h-full w-full overflow-hidden rounded-xl">
+          <div
+            onClick={() => {
+              setActiveIndex(0);
+              setLightboxOpen(true);
+            }}
+            className="relative h-full w-full overflow-hidden cursor-pointer group"
+          >
+            <PropertyImage
+              src={images[0].src}
+              alt={images[0].alt || propertyTitle}
+              fallbackSrc={images[0].fallbackSrc || "/property-placeholder.svg"}
+              fill
+              priority
+              sizes="100vw"
+              {...(images[0].blurDataUrl
+                ? { placeholder: "blur" as const, blurDataURL: images[0].blurDataUrl }
+                : {})}
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+          </div>
+        </div>
+      );
+    }
+
+    if (total === 2) {
+      return (
+        <div className="hidden md:grid grid-cols-2 gap-2 h-full w-full overflow-hidden rounded-xl">
+          {images.slice(0, 2).map((img, idx) => (
+            <div
+              key={img.src}
+              onClick={() => {
+                setActiveIndex(idx);
+                setLightboxOpen(true);
+              }}
+              className="relative h-full w-full overflow-hidden cursor-pointer group"
+            >
+              <PropertyImage
+                src={img.src}
+                alt={img.alt || propertyTitle}
+                fallbackSrc={img.fallbackSrc || "/property-placeholder.svg"}
+                fill
+                priority={idx === 0}
+                sizes="50vw"
+                {...(img.blurDataUrl
+                  ? { placeholder: "blur" as const, blurDataURL: img.blurDataUrl }
+                  : {})}
+                className="object-cover transition-transform duration-500 group-hover:scale-105"
+              />
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    if (total === 3) {
+      return (
+        <div className="hidden md:grid grid-cols-3 grid-rows-2 gap-2 h-full w-full overflow-hidden rounded-xl">
+          {/* Main Large Photo */}
+          <div
+            onClick={() => {
+              setActiveIndex(0);
+              setLightboxOpen(true);
+            }}
+            className="col-span-2 row-span-2 relative h-full w-full overflow-hidden cursor-pointer group"
+          >
+            <PropertyImage
+              src={images[0].src}
+              alt={images[0].alt || propertyTitle}
+              fallbackSrc={images[0].fallbackSrc || "/property-placeholder.svg"}
+              fill
+              priority
+              sizes="66vw"
+              {...(images[0].blurDataUrl
+                ? { placeholder: "blur" as const, blurDataURL: images[0].blurDataUrl }
+                : {})}
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+          </div>
+          {/* Right Side Two Stacked */}
+          {images.slice(1, 3).map((img, idx) => (
+            <div
+              key={img.src}
+              onClick={() => {
+                setActiveIndex(idx + 1);
+                setLightboxOpen(true);
+              }}
+              className="col-span-1 row-span-1 relative h-full w-full overflow-hidden cursor-pointer group"
+            >
+              <PropertyImage
+                src={img.src}
+                alt={img.alt || propertyTitle}
+                fallbackSrc={img.fallbackSrc || "/property-placeholder.svg"}
+                fill
+                sizes="33vw"
+                {...(img.blurDataUrl
+                  ? { placeholder: "blur" as const, blurDataURL: img.blurDataUrl }
+                  : {})}
+                className="object-cover transition-transform duration-500 group-hover:scale-105"
+              />
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    if (total === 4) {
+      return (
+        <div className="hidden md:grid grid-cols-4 grid-rows-2 gap-2 h-full w-full overflow-hidden rounded-xl">
+          {/* Main Large Photo */}
+          <div
+            onClick={() => {
+              setActiveIndex(0);
+              setLightboxOpen(true);
+            }}
+            className="col-span-2 row-span-2 relative h-full w-full overflow-hidden cursor-pointer group"
+          >
+            <PropertyImage
+              src={images[0].src}
+              alt={images[0].alt || propertyTitle}
+              fallbackSrc={images[0].fallbackSrc || "/property-placeholder.svg"}
+              fill
+              priority
+              sizes="50vw"
+              {...(images[0].blurDataUrl
+                ? { placeholder: "blur" as const, blurDataURL: images[0].blurDataUrl }
+                : {})}
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+          </div>
+          {/* Stacked Mid Column */}
+          {images.slice(1, 3).map((img, idx) => (
+            <div
+              key={img.src}
+              onClick={() => {
+                setActiveIndex(idx + 1);
+                setLightboxOpen(true);
+              }}
+              className="col-span-1 row-span-1 relative h-full w-full overflow-hidden cursor-pointer group"
+            >
+              <PropertyImage
+                src={img.src}
+                alt={img.alt || propertyTitle}
+                fallbackSrc={img.fallbackSrc || "/property-placeholder.svg"}
+                fill
+                sizes="25vw"
+                {...(img.blurDataUrl
+                  ? { placeholder: "blur" as const, blurDataURL: img.blurDataUrl }
+                  : {})}
+                className="object-cover transition-transform duration-500 group-hover:scale-105"
+              />
+            </div>
+          ))}
+          {/* Tall Right Column */}
+          <div
+            onClick={() => {
+              setActiveIndex(3);
+              setLightboxOpen(true);
+            }}
+            className="col-span-1 row-span-2 relative h-full w-full overflow-hidden cursor-pointer group"
+          >
+            <PropertyImage
+              src={images[3].src}
+              alt={images[3].alt || propertyTitle}
+              fallbackSrc={images[3].fallbackSrc || "/property-placeholder.svg"}
+              fill
+              sizes="25vw"
+              {...(images[3].blurDataUrl
+                ? { placeholder: "blur" as const, blurDataURL: images[3].blurDataUrl }
+                : {})}
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+          </div>
+        </div>
+      );
+    }
+
+    // Default: 5+ Photos
+    return (
+      <div className="hidden md:grid grid-cols-4 grid-rows-2 gap-2 h-full w-full overflow-hidden rounded-xl">
+        {/* Main Large Photo */}
+        <div
+          onClick={() => {
+            setActiveIndex(0);
+            setLightboxOpen(true);
+          }}
+          className="col-span-2 row-span-2 relative h-full w-full overflow-hidden cursor-pointer group"
+        >
+          <PropertyImage
+            src={images[0].src}
+            alt={images[0].alt || propertyTitle}
+            fallbackSrc={images[0].fallbackSrc || "/property-placeholder.svg"}
+            fill
+            priority
+            sizes="50vw"
+            {...(images[0].blurDataUrl
+              ? { placeholder: "blur" as const, blurDataURL: images[0].blurDataUrl }
+              : {})}
+            className="object-cover transition-transform duration-500 group-hover:scale-105"
+          />
+        </div>
+        {/* Column 3: Two Stacked Photos */}
+        {images.slice(1, 3).map((img, idx) => (
+          <div
+            key={img.src}
+            onClick={() => {
+              setActiveIndex(idx + 1);
+              setLightboxOpen(true);
+            }}
+            className="col-span-1 row-span-1 relative h-full w-full overflow-hidden cursor-pointer group"
+          >
+            <PropertyImage
+              src={img.src}
+              alt={img.alt || propertyTitle}
+              fallbackSrc={img.fallbackSrc || "/property-placeholder.svg"}
+              fill
+              sizes="25vw"
+              {...(img.blurDataUrl
+                ? { placeholder: "blur" as const, blurDataURL: img.blurDataUrl }
+                : {})}
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+          </div>
+        ))}
+        {/* Column 4: Two Stacked Photos */}
+        {images.slice(3, 5).map((img, idx) => (
+          <div
+            key={img.src}
+            onClick={() => {
+              setActiveIndex(idx + 3);
+              setLightboxOpen(true);
+            }}
+            className="col-span-1 row-span-1 relative h-full w-full overflow-hidden cursor-pointer group"
+          >
+            <PropertyImage
+              src={img.src}
+              alt={img.alt || propertyTitle}
+              fallbackSrc={img.fallbackSrc || "/property-placeholder.svg"}
+              fill
+              sizes="25vw"
+              {...(img.blurDataUrl
+                ? { placeholder: "blur" as const, blurDataURL: img.blurDataUrl }
+                : {})}
+              className="object-cover transition-transform duration-500 group-hover:scale-105"
+            />
+          </div>
+        ))}
+      </div>
+    );
+  };
+
   return (
     <div className="w-full">
       <div
         data-testid="gallery-hero"
-        className="relative w-full aspect-[4/3] overflow-hidden bg-gray-100"
+        className="relative w-full aspect-[4/3] md:aspect-auto md:h-[450px] overflow-hidden bg-gray-100 md:bg-transparent"
       >
-        <PropertyImage
-          src={activeImage.src}
-          alt={activeImage.alt || propertyTitle}
-          fallbackSrc={activeImage.fallbackSrc || "/property-placeholder.svg"}
-          fill
-          sizes="100vw"
-          priority={activeIndex === 0}
-          {...(activeImage.blurDataUrl
-            ? { placeholder: "blur" as const, blurDataURL: activeImage.blurDataUrl }
-            : {})}
-          className="object-cover"
-        />
+        {/* Mobile View: Single hero image */}
+        <div className="relative w-full h-full md:hidden">
+          <PropertyImage
+            src={activeImage.src}
+            alt={activeImage.alt || propertyTitle}
+            fallbackSrc={activeImage.fallbackSrc || "/property-placeholder.svg"}
+            fill
+            sizes="100vw"
+            priority={activeIndex === 0}
+            {...(activeImage.blurDataUrl
+              ? { placeholder: "blur" as const, blurDataURL: activeImage.blurDataUrl }
+              : {})}
+            className="object-cover"
+          />
 
-        {/* Photo count overlay — single source of truth for gallery navigation */}
-        <div
-          data-testid="gallery-photo-count"
-          className="absolute bottom-4 right-4 bg-black/60 text-white text-sm font-medium px-3 py-1 rounded-full"
-          aria-live="polite"
-        >
-          {t("photoCount", { current: activeIndex + 1, total })}
+          {/* Photo count overlay — single source of truth for gallery navigation */}
+          <div
+            data-testid="gallery-photo-count"
+            className="absolute bottom-4 right-4 bg-black/60 text-white text-sm font-medium px-3 py-1 rounded-full"
+            aria-live="polite"
+          >
+            {t("photoCount", { current: activeIndex + 1, total })}
+          </div>
         </div>
 
-        {/* Fullscreen / open lightbox button */}
+        {/* Desktop View: Zillow-style collage grid */}
+        {renderDesktopGrid()}
+
+        {/* Fullscreen / open lightbox button (Unified responsive button) */}
         <button
           type="button"
           aria-label={t("openLightbox")}
           onClick={() => setLightboxOpen(true)}
-          className="absolute top-4 right-4 bg-black/60 text-white px-3 py-2 rounded-lg text-sm font-medium hover:bg-black/80 transition-colors"
+          className="absolute top-4 right-4 bg-black/60 text-white hover:bg-black/80 md:top-auto md:bottom-4 md:right-4 md:bg-white md:text-brand-navy md:border md:border-border/80 md:hover:bg-gray-50 md:shadow-md md:flex md:items-center md:gap-2 md:hover:scale-[1.02] md:active:scale-[0.98] z-10 font-medium md:font-semibold px-3 py-2 md:px-4 md:py-2 rounded-lg transition-all"
         >
-          {t("openLightbox")}
+          {/* Mobile Text */}
+          <span className="md:hidden">{t("openLightbox")}</span>
+          
+          {/* Desktop Content */}
+          <span className="hidden md:inline-flex items-center gap-2">
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z" />
+            </svg>
+            <span>
+              {t("openLightbox")} ({total})
+            </span>
+          </span>
         </button>
       </div>
 
-      {/* Thumbnail strip */}
+      {/* Thumbnail strip (Mobile only) */}
       <div
         data-testid="gallery-thumbnail-strip"
-        className="flex gap-2 overflow-x-auto py-2 px-1"
+        className="flex gap-2 overflow-x-auto py-2 px-1 md:hidden"
         role="list"
         aria-label={t("thumbnailStripLabel", { title: propertyTitle })}
       >


### PR DESCRIPTION
# Walkthrough — Zillow-style Property Image Gallery Redesign

We have successfully redesigned the property image gallery to look and feel like a modern Zillow-style collage grid on desktop viewports, while keeping a highly functional and responsive single-photo swipeable/thumbnail-supported layout on mobile!

## Changes Made

### 1. Viewport-Responsive Splitting
* **Mobile Viewport (`md:hidden`)**: Retained the original single-photo layout with `aspect-[4/3]`, custom photo-count overlay, and the horizontal thumbnail strip scrollable below.
* **Desktop Viewport (`hidden md:grid`)**: Built a premium collage layout with rounded corners (`rounded-xl`), custom layout columns, and high-definition hover states.

### 2. Adaptive Grid Layouts
To ensure the layout remains solid and beautiful across different listings regardless of how many photos they have, we implemented adaptive grid layouts:
* **1 Photo**: Renders as a full-width single panel.
* **2 Photos**: Renders as two equal columns side-by-side.
* **3 Photos**: Left main photo spans `col-span-2 row-span-2`, right side stacked with two photos.
* **4 Photos**: Left main photo spans `col-span-2 row-span-2`, center column stacked with two photos, right column spans full height.
* **5+ Photos (Standard Zillow Layout)**: Left main photo spans `col-span-2 row-span-2`, center column stacked with two photos, right column stacked with two photos.

### 3. Premium Interactions
* Wrapped all grid cells in `overflow-hidden cursor-pointer group` and added a premium hover scale animation: `transition-transform duration-500 group-hover:scale-105 object-cover`.
* Integrated grid-wide routing to the lightbox so clicking *any* photo in the collage opens the lightbox directly at that clicked index.
* Added a unified responsive lightbox button:
  * On mobile: rendered as the standard black top-right overlay button.
  * On desktop: rendered as a highly polished white bottom-right pill button with a sleek grid icon and dynamic total photo counts (`View all photos (24)`).

---

## Verification Results

### 1. Automated Unit Tests
We verified the complete suite of component tests in `tests/unit/listing/property-gallery.spec.tsx` to prevent any regressions. All tests passed flawlessly:
```bash
npx vitest run tests/unit/listing/property-gallery.spec.tsx
```
```
✓ tests/unit/listing/property-gallery.spec.tsx (14 tests)
Test Files  1 passed (1)
     Tests  14 passed (14)
  Duration  2.85s
```

### 2. Manual Visual Verification
* The collage grid container has clean styling, a cohesive `gap-2` structure, and a premium `rounded-xl` boundary.
* Subtly hovering over any panel activates the high-definition zoom (`group-hover:scale-105`) with absolute visual consistency.
* Clicking any panel or the bottom-right unified responsive button activates the lightbox overlay flawlessly.