### PR TITLE
Feature : VIP Buyer Service Search Bar Link

### DIFF
--- a/src/components/home/hero-search-shell.tsx
+++ b/src/components/home/hero-search-shell.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Search, Sparkles, SlidersHorizontal, ChevronDown } from "lucide-react";
+import { Search, Sparkles, SlidersHorizontal, ChevronDown, Globe } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
-import { useRouter } from "@/i18n/navigation";
+import { useRouter, Link } from "@/i18n/navigation";
 import { getAvailableAreas } from "@/app/actions/search-actions";
 
 type Variant = "desktop-overlay" | "mobile-inline";
@@ -500,6 +500,21 @@ export function HeroSearchShell({ variant }: { variant: Variant }) {
               </div>
             </div>
           )}
+
+          {/* VIP Buyer Section Link */}
+          <div className="mt-4 pt-3 border-t border-white/10 flex flex-wrap items-center justify-center gap-1.5 text-center text-xs text-white/70">
+            <Globe className="h-3.5 w-3.5 text-brand-gold/80 shrink-0" aria-hidden="true" />
+            <span>
+              {t("vipPrompt")}{" "}
+              <Link
+                href="/find-your-dream-property"
+                className="text-brand-gold hover:text-brand-gold-light hover:underline font-bold transition-colors inline-flex items-center gap-0.5"
+              >
+                {t("vipCta")}
+                <span className="no-underline">→</span>
+              </Link>
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -75,7 +75,9 @@
       "searchSubmit": "Search",
       "smartToggle": "Smart Search",
       "traditionalToggle": "Traditional Search",
-      "shellNotice": ""
+      "shellNotice": "",
+      "vipPrompt": "Looking in other areas of the country or the world?",
+      "vipCta": "Connect with our VIP Buyers Service"
     },
     "featuredProperties": {
       "heading": "Featured Properties",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -75,7 +75,9 @@
       "searchSubmit": "Buscar",
       "smartToggle": "Búsqueda Inteligente",
       "traditionalToggle": "Búsqueda Tradicional",
-      "shellNotice": ""
+      "shellNotice": "",
+      "vipPrompt": "¿Busca en otras zonas del país o del mundo?",
+      "vipCta": "Conozca nuestro Servicio de Comprador VIP"
     },
     "featuredProperties": {
       "heading": "Propiedades Destacadas",


### PR DESCRIPTION
This change implements a beautiful, premium prompt below the homepage search bar. It directs users looking in other areas of the country or the world to the **VIP Buyer Service** page (`/find-your-dream-property`).

## Changes Made

### 1. Localization Strings
We added specialized translations for both English and Spanish to ensure a premium localized experience under the `HomePage.hero` namespace:
- **English (`en.json`):**
  - `"vipPrompt": "Looking in other areas of the country or the world?"`
  - `"vipCta": "Connect with our VIP Buyers Service"`
- **Spanish (`es.json`):**
  - `"vipPrompt": "¿Busca en otras zonas del país o del mundo?"`
  - `"vipCta": "Conozca nuestro Servicio de Comprador VIP"`

### 2. UI Component
We modified the search bar overlay component [hero-search-shell.tsx](src/components/home/hero-search-shell.tsx):
- Imported the localized `Link` component from `@/i18n/navigation` to maintain correct language prefix routing.
- Imported the `Globe` icon from `lucide-react` for a premium, globetrotting visual cue.
- Placed a beautiful, centered flex-row element at the bottom of the glassmorphic search shell block that displays dynamically under both **Smart Search** and **Traditional Search** modes.

## Verification

### Automated Tests
- Ran type-checking and code formatting:
  ```bash
  npm run typecheck
  npm run format
  ```
  Both passed with 0 errors.
- Ran the full test suite (`npm run test`):
  - **1,105 tests passed successfully**!

### Manual Verification
1. Open the homepage on your local browser.
2. In the bottom part of the glassmorphic search bar container, you will see a subtle, premium text styled with the golden brand theme and a globe icon next to it:
   - **EN**: "Looking in other areas of the country or the world? Connect with our VIP Buyers Service →"
   - **ES**: "¿Busca en otras zonas del país o del mundo? Conozca nuestro Servicio de Comprador VIP →"
3. Clicking on the link correctly navigates to the localized VIP Buyer Service page (`/find-your-dream-property` or `/es/find-your-dream-property`).