### PR TITLE
Fix : Fix Property Area Guide Classifications

### DIFF
--- a/src/lib/db/queries/properties.ts
+++ b/src/lib/db/queries/properties.ts
@@ -38,6 +38,11 @@ async function getAreaIdBySlug(slug: string): Promise<string | null> {
   return areaCache.get(slug) ?? null;
 }
 
+function containsWholeWord(text: string, word: string): boolean {
+  const regex = new RegExp(`(?:^|[^a-záéíóúüñ])${word}(?:$|[^a-záéíóúüñ])`, "i");
+  return regex.test(text);
+}
+
 export function resolveAreaSlug(raw: {
   officeApiId: number;
   location: string | null;
@@ -46,59 +51,86 @@ export function resolveAreaSlug(raw: {
   publicRemarksEn: string | null;
   publicRemarksEs: string | null;
 }): string {
+  const titleAndLocation = [raw.titleEn, raw.titleEs, raw.location ?? ""].join(" ").toLowerCase();
+
+  const publicRemarks = [raw.publicRemarksEn ?? "", raw.publicRemarksEs ?? ""]
+    .join(" ")
+    .toLowerCase();
+
+  const textToSearch = [titleAndLocation, publicRemarks].join(" ");
+
+  // 1. Uvita & Bahia Ballena
+  const hasUvita =
+    textToSearch.includes("uvita") ||
+    textToSearch.includes("bahia ballena") ||
+    textToSearch.includes("bahía ballena") ||
+    textToSearch.includes("marino ballena") ||
+    titleAndLocation.includes("ballena") ||
+    titleAndLocation.includes("whale tail");
+
+  if (hasUvita) {
+    return "uvita";
+  }
+
+  // 2. Ojochal & Coronado (avoiding water spring "ojo de agua" or common "cortesía" matches in description)
+  const hasOjochal =
+    textToSearch.includes("ojochal") ||
+    textToSearch.includes("coronado") ||
+    textToSearch.includes("chontales") ||
+    titleAndLocation.includes("ojo de agua") ||
+    titleAndLocation.includes("tres rios") ||
+    titleAndLocation.includes("tres ríos") ||
+    containsWholeWord(titleAndLocation, "cortes") ||
+    containsWholeWord(titleAndLocation, "cortés") ||
+    containsWholeWord(publicRemarks, "ciudad cortés") ||
+    containsWholeWord(publicRemarks, "ciudad cortes") ||
+    containsWholeWord(publicRemarks, "plaza cortés") ||
+    (containsWholeWord(publicRemarks, "cortes") &&
+      !publicRemarks.includes("cortesía") &&
+      !publicRemarks.includes("cortesia")) ||
+    (containsWholeWord(publicRemarks, "cortés") && !publicRemarks.includes("cortésmente"));
+
+  if (hasOjochal) {
+    return "ojochal";
+  }
+
+  // 3. Tinamastes & Platanillo (avoiding generic "lagunas" or common "san juan" in description)
+  const hasTinamastes =
+    textToSearch.includes("tinamaste") ||
+    textToSearch.includes("platanillo") ||
+    textToSearch.includes("chimirol") ||
+    textToSearch.includes("rio nuevo") ||
+    textToSearch.includes("río nuevo") ||
+    textToSearch.includes("alto de san juan") ||
+    titleAndLocation.includes("lagunas") ||
+    titleAndLocation.includes("baru") ||
+    titleAndLocation.includes("barú") ||
+    titleAndLocation.includes("san juan");
+
+  if (hasTinamastes) {
+    return "tinamastes-platanillo";
+  }
+
+  // 4. Perez Zeledon
+  const hasPerezZeledon =
+    textToSearch.includes("perez zeledon") ||
+    textToSearch.includes("pérez zeledón") ||
+    textToSearch.includes("perez zeledón") ||
+    textToSearch.includes("pérez zeledon") ||
+    textToSearch.includes("san isidro de el general") ||
+    textToSearch.includes("san isidro") ||
+    textToSearch.includes("el general");
+
+  if (hasPerezZeledon) {
+    return "perez-zeledon";
+  }
+
+  // 5. Office-based Fallbacks
   if (raw.officeApiId === 218) {
     return "perez-zeledon";
   }
 
-  const textToSearch = [
-    raw.location ?? "",
-    raw.titleEn,
-    raw.titleEs,
-    raw.publicRemarksEn ?? "",
-    raw.publicRemarksEs ?? "",
-  ]
-    .join(" ")
-    .toLowerCase();
-
-  if (
-    textToSearch.includes("uvita") ||
-    textToSearch.includes("bahia ballena") ||
-    textToSearch.includes("bahía ballena") ||
-    textToSearch.includes("ballena") ||
-    textToSearch.includes("marino ballena") ||
-    textToSearch.includes("whale tail")
-  ) {
-    return "uvita";
-  }
-
-  if (
-    textToSearch.includes("ojochal") ||
-    textToSearch.includes("coronado") ||
-    textToSearch.includes("cortes") ||
-    textToSearch.includes("cortés") ||
-    textToSearch.includes("ojo de agua") ||
-    textToSearch.includes("chontales") ||
-    textToSearch.includes("tres rios") ||
-    textToSearch.includes("tres ríos")
-  ) {
-    return "ojochal";
-  }
-
-  if (
-    textToSearch.includes("tinamaste") ||
-    textToSearch.includes("platanillo") ||
-    textToSearch.includes("baru") ||
-    textToSearch.includes("barú") ||
-    textToSearch.includes("alto de san juan") ||
-    textToSearch.includes("san juan") ||
-    textToSearch.includes("lagunas") ||
-    textToSearch.includes("chimirol") ||
-    textToSearch.includes("rio nuevo") ||
-    textToSearch.includes("río nuevo")
-  ) {
-    return "tinamastes-platanillo";
-  }
-
+  // Default fallback for office 235 / Altitud Cero
   return "dominical";
 }
 

--- a/tests/unit/sync/resolve-area-slug.spec.ts
+++ b/tests/unit/sync/resolve-area-slug.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { resolveAreaSlug } from "@/lib/db/queries/properties";
+
+describe("resolveAreaSlug", () => {
+  // Helpers to create raw property objects with minimal fields
+  function makeRawInput(overrides: Partial<Parameters<typeof resolveAreaSlug>[0]>) {
+    return {
+      officeApiId: 235, // default to Dominical office
+      location: null,
+      titleEn: "",
+      titleEs: "",
+      publicRemarksEn: null,
+      publicRemarksEs: null,
+      ...overrides,
+    };
+  }
+
+  it("[P0] returns 'perez-zeledon' for properties listed by office 218 (Perez Zeledon) without other keywords", () => {
+    const raw = makeRawInput({ officeApiId: 218 });
+    expect(resolveAreaSlug(raw)).toBe("perez-zeledon");
+  });
+
+  it("[P0] returns 'perez-zeledon' for properties listed by office 235 (Dominical) but explicitly located in Perez Zeledon", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Beautiful farm in Pérez Zeledón",
+      publicRemarksEs: "Finca hermosa en San Isidro de El General",
+    });
+    expect(resolveAreaSlug(raw)).toBe("perez-zeledon");
+  });
+
+  it("[P0] returns 'uvita' for cross-office listings from office 218 (Perez Zeledon) but physically in Uvita", () => {
+    const raw = makeRawInput({
+      officeApiId: 218,
+      titleEn: "Lot in Uvita near Whale Tail",
+    });
+    expect(resolveAreaSlug(raw)).toBe("uvita");
+  });
+
+  it("[P0] returns 'ojochal' for properties with Ojochal or Coronado in title/location", () => {
+    const raw1 = makeRawInput({ titleEn: "House in Ojochal" });
+    const raw2 = makeRawInput({ location: "Coronado, Osa" });
+    const raw3 = makeRawInput({ publicRemarksEs: "Ubicado en Chontales" });
+    expect(resolveAreaSlug(raw1)).toBe("ojochal");
+    expect(resolveAreaSlug(raw2)).toBe("ojochal");
+    expect(resolveAreaSlug(raw3)).toBe("ojochal");
+  });
+
+  it("[P0] returns 'tinamastes-platanillo' for properties with Tinamastes keywords", () => {
+    const raw1 = makeRawInput({ titleEn: "Lot in Platanillo" });
+    const raw2 = makeRawInput({ publicRemarksEs: "Finca en Tinamaste" });
+    expect(resolveAreaSlug(raw1)).toBe("tinamastes-platanillo");
+    expect(resolveAreaSlug(raw2)).toBe("tinamastes-platanillo");
+  });
+
+  it("[P1] does NOT return 'ojochal' for properties that mention 'ojo de agua' (water spring) ONLY in public remarks (descriptive)", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Mountain Lot with Ocean View",
+      publicRemarksEs: "Esta hermosa propiedad cuenta con su propio ojo de agua y bosques.",
+    });
+    expect(resolveAreaSlug(raw)).toBe("dominical"); // falls back to Dominical
+  });
+
+  it("[P1] returns 'ojochal' for properties that mention 'ojo de agua' in the title or location", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      location: "Ojo de Agua",
+      titleEn: "Ocean View Lot",
+    });
+    expect(resolveAreaSlug(raw)).toBe("ojochal");
+  });
+
+  it("[P1] does NOT return 'ojochal' for properties that mention 'cortesía' in remarks (avoiding courtesy match)", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Modern Villa with Ocean Views",
+      publicRemarksEs: "Fotos por cortesía del desarrollador.",
+    });
+    expect(resolveAreaSlug(raw)).toBe("dominical"); // should not match 'cortes' substring in 'cortesía'
+  });
+
+  it("[P1] returns 'ojochal' if 'cortés' or 'cortes' is used as a whole word in the title or location", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Lot near Ciudad Cortés",
+    });
+    expect(resolveAreaSlug(raw)).toBe("ojochal");
+  });
+
+  it("[P1] does NOT return 'tinamastes-platanillo' for properties that mention generic 'lagunas' (lagoons/ponds) ONLY in public remarks", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Valley View Land",
+      publicRemarksEs: "La propiedad cuenta con dos lagunas naturales espectaculares.",
+    });
+    expect(resolveAreaSlug(raw)).toBe("dominical"); // falls back to Dominical
+  });
+
+  it("[P1] returns 'tinamastes-platanillo' for properties that mention 'lagunas' in title or location", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Ocean View Lot in Lagunas",
+    });
+    expect(resolveAreaSlug(raw)).toBe("tinamastes-platanillo");
+  });
+
+  it("[P2] returns 'dominical' as the default fallback for office 235", () => {
+    const raw = makeRawInput({ officeApiId: 235 });
+    expect(resolveAreaSlug(raw)).toBe("dominical");
+  });
+});


### PR DESCRIPTION
# Walkthrough: Fix Property Area Guide Classifications

We successfully implemented a robust, descriptive-safe keyword resolution algorithm in the RE/MAX Altitud sync pipeline, fixing the issue where properties physically located in Pérez Zeledón (or other regions) were misclassified under the Ojochal & Coronado area guide.

---

## Changes Made

### 1. Robust Area Resolution Algorithm
In `src/lib/db/queries/properties.ts`, we rewrote `resolveAreaSlug`:
- **Keyword Division**: Divided text inputs into `titleAndLocation` (safe for descriptive keywords) and `publicRemarks` (long descriptions).
- **Descriptive Safety**:
  - The phrase `"ojo de agua"` (meaning "water spring" in Spanish) is now matched **only** in the title or location field (where it refers to the Coronado neighborhood), preventing properties in Pérez Zeledón or Tinamastes with natural springs from matching it.
  - The names `"lagunas"`, `"baru"`, `"barú"`, and `"san juan"` are similarly restricted to titles and locations to avoid matches on descriptive words like lagoons or rivers.
  - The names `"tres rios"` and `"tres ríos"` are restricted to titles and locations.
- **Accurate Whole-Word Matches**:
  - Added a `containsWholeWord` helper utilizing a custom Spanish-accentuation-friendly boundary regex: `(?:^|[^a-záéíóúüñ])${word}(?:$|[^a-záéíóúüñ])`.
  - Matched `"cortes"` and `"cortés"` **only** as whole words in titles/locations, or explicitly via `"ciudad cortés"`/`"plaza cortés"` in descriptions. This completely prevents substrings inside `"cortesía"` (courtesy) or `"cortésmente"` (courteously) from matching.
- **Pérez Zeledón Keywords**:
  - Added explicit keywords for `"perez-zeledon"` (e.g., `"perez zeledon"`, `"pérez zeledón"`, `"san isidro"`, `"el general"`).
  - Prioritized specific keyword routing over the `officeApiId === 218` fallback, meaning cross-office listings (e.g., Perez Zeledon agent listing a property in Uvita) resolve to their correct physical location while defaulting back to `"perez-zeledon"` for standard PZ office listings.

---

## Verification & Testing

### 1. New Unit Test Suite
We created `tests/unit/sync/resolve-area-slug.spec.ts` covering 12 target cases, including:
- Perez Zeledon properties listed by Dominical office (235) with PZ keywords → resolved to `"perez-zeledon"`.
- Perez Zeledon properties listed by Dominical office that mention a natural water spring ("ojo de agua") in remarks → resolved safely to `"dominical"` fallback (no false positives).
- Cross-office listings (PZ office 218 listing physically located in Uvita) → resolved to `"uvita"`.
- Avoiding substring matches in `"cortesía"` or `"cortésmente"` → resolved safely to `"dominical"` (no false positives).
- Whole-word matches of `"cortés"` or `"cortes"` in title/location → resolved to `"ojochal"`.
- Avoiding generic `"lagunas"` (ponds) in remarks → resolved safely to `"dominical"`.
- Neighborhood matches for `"lagunas"` in title/location → resolved to `"tinamastes-platanillo"`.

### 2. Automated Test Run Results

- **Targeted Test Suite**: Ran `npx vitest run tests/unit/sync/resolve-area-slug.spec.ts`. All **12 tests passed successfully** in `1.55s`!
- **Full Regression Suit**: Ran `npm run test`. All **1,097 tests passed successfully** in `21.12s` with zero regressions!

---

## Action Plan for Live/Development Deployment
Since the production/development database on Vercel contains already-synced properties with older, incorrect classifications:
1. **Push Changes**: Push the code to GitHub (which will trigger a Vercel rebuild and deployment).
2. **Trigger Retroactive Sync**: Call the secure retroactive area tagging endpoint:
   `https://dev.remax-altitud.cr/api/retroactive-area` (appending `?secret=...` or headers if auth is set) to instantly run the updated `resolveAreaSlug` logic against all existing properties and update the database values.
