### PR TITLE
feat: shortlist keep-searching link and area filter fix

### DIFF
--- a/src/components/shortlist/shortlist-page-client.tsx
+++ b/src/components/shortlist/shortlist-page-client.tsx
@@ -213,6 +213,7 @@ export function ShortlistPageClient() {
           source: channel === "whatsapp" ? "whatsapp_click" : "contact_form",
           assignedAgentId: agent.id,
           shortlistPropertyIds: shortlist,
+          location: { text: "", lat: null, lng: null },
         }),
       });
     } catch (err) {
@@ -305,6 +306,7 @@ export function ShortlistPageClient() {
         assignedAgentId: recipientAgentId,
         shortlistPropertyIds: shortlist,
         notes: `${formMessage.trim() ? formMessage.trim() + " | " : ""}Shortlist Link: ${shareUrl}`,
+        location: { text: "", lat: null, lng: null },
       };
 
       const leadResponse = await fetch("/api/leads", {
@@ -318,11 +320,11 @@ export function ShortlistPageClient() {
         setSubmittedLeadAgent(chosen);
         setFormSubmitted(true);
       } else {
-        alert(t("shareError"));
+        alert(t("formSubmitError"));
       }
     } catch (err) {
       console.error("Form submission failed:", err);
-      alert(t("shareError"));
+      alert(t("formSubmitError"));
     } finally {
       setFormSubmitting(false);
     }

--- a/src/components/shortlist/shortlist-page-client.tsx
+++ b/src/components/shortlist/shortlist-page-client.tsx
@@ -479,7 +479,25 @@ export function ShortlistPageClient() {
   // Comparison grid + interactive map
   return (
     <div className="container mx-auto px-4 py-8">
-      <h1 className="text-3xl font-bold mb-6 text-brand-navy">{t("title")}</h1>
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6 border-b pb-4 border-slate-100">
+        <h1 className="text-3xl font-bold text-brand-navy">{t("title")}</h1>
+        <Link
+          href={`/${locale}/search`}
+          className="inline-flex items-center text-sm font-semibold text-brand-navy hover:text-brand-red transition-all duration-200 group"
+        >
+          <svg
+            className="w-4 h-4 mr-1.5 transition-transform duration-200 group-hover:-translate-x-0.5"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            viewBox="0 0 24 24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
+          </svg>
+          {t("keepSearching")}
+        </Link>
+      </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
         {/* Left Side: Property list and Actions */}

--- a/src/components/shortlist/shortlist-page-client.tsx
+++ b/src/components/shortlist/shortlist-page-client.tsx
@@ -479,24 +479,22 @@ export function ShortlistPageClient() {
   // Comparison grid + interactive map
   return (
     <div className="container mx-auto px-4 py-8">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6 border-b pb-4 border-slate-100">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6 border-b pb-4 border-slate-100">
         <h1 className="text-3xl font-bold text-brand-navy">{t("title")}</h1>
-        <Link
-          href={`/${locale}/search`}
-          className="inline-flex items-center text-sm font-semibold text-brand-navy hover:text-brand-red transition-all duration-200 group"
-        >
-          <svg
-            className="w-4 h-4 mr-1.5 transition-transform duration-200 group-hover:-translate-x-0.5"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2.5"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
+        <div className="flex flex-wrap items-center gap-3">
+          <Link
+            href={`/${locale}/search`}
+            className="inline-flex h-11 items-center justify-center rounded-md bg-white border border-brand-navy/30 text-brand-navy hover:bg-brand-navy/5 font-semibold px-5 transition-colors shadow-xs"
           >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 19.5L8.25 12l7.5-7.5" />
-          </svg>
-          {t("keepSearching")}
-        </Link>
+            {t("addMoreProperties")}
+          </Link>
+          <button
+            onClick={handleShareShortlist}
+            className="inline-flex h-11 items-center justify-center rounded-md bg-brand-navy hover:bg-brand-navy/90 text-white font-semibold px-5 shadow-md transition-colors relative min-w-[150px]"
+          >
+            {copied ? (locale === "es" ? "¡Copiado!" : "Copied!") : t("shareShortlistCta")}
+          </button>
+        </div>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
@@ -842,39 +840,31 @@ export function ShortlistPageClient() {
             </div>
           )}
 
-          {/* Action buttons (Share Shortlist + optional Ask Agent + optional Contact Form toggle) */}
-          <div className="flex flex-col sm:flex-row gap-4 mt-6 border-t pt-6 border-border">
-            {!showContactForm && !formSubmitted && (
-              <>
-                <button
-                  onClick={handleAskAgent}
-                  className="flex-1 inline-flex h-11 items-center justify-center rounded-md bg-brand-navy hover:bg-brand-navy/90 text-white font-semibold px-6 shadow-md transition-colors"
-                >
-                  {t("askAgentCta")}
-                </button>
-                <button
-                  onClick={() => {
-                    setShowContactForm(true);
-                    setTimeout(() => {
-                      const formEl = document.getElementById("shortlist-contact-form");
-                      if (formEl && typeof formEl.scrollIntoView === "function") {
-                        formEl.scrollIntoView({ behavior: "smooth", block: "start" });
-                      }
-                    }, 100);
-                  }}
-                  className="flex-1 inline-flex h-11 items-center justify-center rounded-md bg-white border border-brand-navy text-brand-navy hover:bg-brand-navy/5 font-semibold px-6 transition-colors"
-                >
-                  {locale === "es" ? "Contactar por Formulario" : "Contact via Form"}
-                </button>
-              </>
-            )}
-            <button
-              onClick={handleShareShortlist}
-              className="flex-1 inline-flex h-11 items-center justify-center rounded-md border border-brand-navy/30 text-brand-navy hover:bg-brand-navy/5 font-semibold px-6 transition-colors relative"
-            >
-              {copied ? "Copied!" : t("shareShortlistCta")}
-            </button>
-          </div>
+          {/* Action buttons (Ask Agent + optional Contact Form toggle) */}
+          {!showContactForm && !formSubmitted && (
+            <div className="flex flex-col sm:flex-row gap-4 mt-6 border-t pt-6 border-border">
+              <button
+                onClick={handleAskAgent}
+                className="flex-1 inline-flex h-11 items-center justify-center rounded-md bg-brand-navy hover:bg-brand-navy/90 text-white font-semibold px-6 shadow-md transition-colors"
+              >
+                {t("askAgentCta")}
+              </button>
+              <button
+                onClick={() => {
+                  setShowContactForm(true);
+                  setTimeout(() => {
+                    const formEl = document.getElementById("shortlist-contact-form");
+                    if (formEl && typeof formEl.scrollIntoView === "function") {
+                      formEl.scrollIntoView({ behavior: "smooth", block: "start" });
+                    }
+                  }, 100);
+                }}
+                className="flex-1 inline-flex h-11 items-center justify-center rounded-md bg-white border border-brand-navy text-brand-navy hover:bg-brand-navy/5 font-semibold px-6 transition-colors"
+              >
+                {locale === "es" ? "Contactar por Formulario" : "Contact via Form"}
+              </button>
+            </div>
+          )}
         </div>
 
         {/* Right Side: Mini-map showing saved property locations */}

--- a/src/lib/db/queries/properties.ts
+++ b/src/lib/db/queries/properties.ts
@@ -38,6 +38,11 @@ async function getAreaIdBySlug(slug: string): Promise<string | null> {
   return areaCache.get(slug) ?? null;
 }
 
+function containsWholeWord(text: string, word: string): boolean {
+  const regex = new RegExp(`(?:^|[^a-záéíóúüñ])${word}(?:$|[^a-záéíóúüñ])`, "i");
+  return regex.test(text);
+}
+
 export function resolveAreaSlug(raw: {
   officeApiId: number;
   location: string | null;
@@ -46,59 +51,86 @@ export function resolveAreaSlug(raw: {
   publicRemarksEn: string | null;
   publicRemarksEs: string | null;
 }): string {
+  const titleAndLocation = [raw.titleEn, raw.titleEs, raw.location ?? ""].join(" ").toLowerCase();
+
+  const publicRemarks = [raw.publicRemarksEn ?? "", raw.publicRemarksEs ?? ""]
+    .join(" ")
+    .toLowerCase();
+
+  const textToSearch = [titleAndLocation, publicRemarks].join(" ");
+
+  // 1. Uvita & Bahia Ballena
+  const hasUvita =
+    textToSearch.includes("uvita") ||
+    textToSearch.includes("bahia ballena") ||
+    textToSearch.includes("bahía ballena") ||
+    textToSearch.includes("marino ballena") ||
+    titleAndLocation.includes("ballena") ||
+    titleAndLocation.includes("whale tail");
+
+  if (hasUvita) {
+    return "uvita";
+  }
+
+  // 2. Ojochal & Coronado (avoiding water spring "ojo de agua" or common "cortesía" matches in description)
+  const hasOjochal =
+    textToSearch.includes("ojochal") ||
+    textToSearch.includes("coronado") ||
+    textToSearch.includes("chontales") ||
+    titleAndLocation.includes("ojo de agua") ||
+    titleAndLocation.includes("tres rios") ||
+    titleAndLocation.includes("tres ríos") ||
+    containsWholeWord(titleAndLocation, "cortes") ||
+    containsWholeWord(titleAndLocation, "cortés") ||
+    containsWholeWord(publicRemarks, "ciudad cortés") ||
+    containsWholeWord(publicRemarks, "ciudad cortes") ||
+    containsWholeWord(publicRemarks, "plaza cortés") ||
+    (containsWholeWord(publicRemarks, "cortes") &&
+      !publicRemarks.includes("cortesía") &&
+      !publicRemarks.includes("cortesia")) ||
+    (containsWholeWord(publicRemarks, "cortés") && !publicRemarks.includes("cortésmente"));
+
+  if (hasOjochal) {
+    return "ojochal";
+  }
+
+  // 3. Tinamastes & Platanillo (avoiding generic "lagunas" or common "san juan" in description)
+  const hasTinamastes =
+    textToSearch.includes("tinamaste") ||
+    textToSearch.includes("platanillo") ||
+    textToSearch.includes("chimirol") ||
+    textToSearch.includes("rio nuevo") ||
+    textToSearch.includes("río nuevo") ||
+    textToSearch.includes("alto de san juan") ||
+    titleAndLocation.includes("lagunas") ||
+    titleAndLocation.includes("baru") ||
+    titleAndLocation.includes("barú") ||
+    titleAndLocation.includes("san juan");
+
+  if (hasTinamastes) {
+    return "tinamastes-platanillo";
+  }
+
+  // 4. Perez Zeledon
+  const hasPerezZeledon =
+    textToSearch.includes("perez zeledon") ||
+    textToSearch.includes("pérez zeledón") ||
+    textToSearch.includes("perez zeledón") ||
+    textToSearch.includes("pérez zeledon") ||
+    textToSearch.includes("san isidro de el general") ||
+    textToSearch.includes("san isidro") ||
+    textToSearch.includes("el general");
+
+  if (hasPerezZeledon) {
+    return "perez-zeledon";
+  }
+
+  // 5. Office-based Fallbacks
   if (raw.officeApiId === 218) {
     return "perez-zeledon";
   }
 
-  const textToSearch = [
-    raw.location ?? "",
-    raw.titleEn,
-    raw.titleEs,
-    raw.publicRemarksEn ?? "",
-    raw.publicRemarksEs ?? "",
-  ]
-    .join(" ")
-    .toLowerCase();
-
-  if (
-    textToSearch.includes("uvita") ||
-    textToSearch.includes("bahia ballena") ||
-    textToSearch.includes("bahía ballena") ||
-    textToSearch.includes("ballena") ||
-    textToSearch.includes("marino ballena") ||
-    textToSearch.includes("whale tail")
-  ) {
-    return "uvita";
-  }
-
-  if (
-    textToSearch.includes("ojochal") ||
-    textToSearch.includes("coronado") ||
-    textToSearch.includes("cortes") ||
-    textToSearch.includes("cortés") ||
-    textToSearch.includes("ojo de agua") ||
-    textToSearch.includes("chontales") ||
-    textToSearch.includes("tres rios") ||
-    textToSearch.includes("tres ríos")
-  ) {
-    return "ojochal";
-  }
-
-  if (
-    textToSearch.includes("tinamaste") ||
-    textToSearch.includes("platanillo") ||
-    textToSearch.includes("baru") ||
-    textToSearch.includes("barú") ||
-    textToSearch.includes("alto de san juan") ||
-    textToSearch.includes("san juan") ||
-    textToSearch.includes("lagunas") ||
-    textToSearch.includes("chimirol") ||
-    textToSearch.includes("rio nuevo") ||
-    textToSearch.includes("río nuevo")
-  ) {
-    return "tinamastes-platanillo";
-  }
-
+  // Default fallback for office 235 / Altitud Cero
   return "dominical";
 }
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -837,6 +837,7 @@
     "title": "My Saved Properties",
     "emptyState": "No properties saved yet. Browse listings and tap ♡ to save.",
     "browseCta": "Browse Listings",
+    "keepSearching": "Keep searching for more properties",
     "askAgentCta": "Ask about these",
     "shareShortlistCta": "Share my shortlist",
     "removeButtonLabel": "Remove property from saved",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -871,7 +871,8 @@
     "formValidationError": "Please fill out all required fields.",
     "nameError": "Please enter your name",
     "emailError": "Please enter a valid email address",
-    "phoneError": "Please enter a valid phone number (min. 7 digits)"
+    "phoneError": "Please enter a valid phone number (min. 7 digits)",
+    "formSubmitError": "Failed to send form. Please try again."
   },
   "ShortlistRouting": {
     "autoSuggestText": "{name} specializes in the areas you're exploring. They can show you all {count} properties.",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -838,6 +838,7 @@
     "emptyState": "No properties saved yet. Browse listings and tap ♡ to save.",
     "browseCta": "Browse Listings",
     "keepSearching": "Keep searching for more properties",
+    "addMoreProperties": "Add more properties",
     "askAgentCta": "Ask about these",
     "shareShortlistCta": "Share my shortlist",
     "removeButtonLabel": "Remove property from saved",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -837,6 +837,7 @@
     "title": "Mis Propiedades Guardadas",
     "emptyState": "No tienes propiedades guardadas. Explora listados y toca ♡ para guardar.",
     "browseCta": "Explorar Propiedades",
+    "keepSearching": "Seguir buscando más propiedades",
     "askAgentCta": "Consultar por estas",
     "shareShortlistCta": "Compartir mi lista",
     "removeButtonLabel": "Eliminar propiedad de guardados",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -871,7 +871,8 @@
     "formValidationError": "Por favor completa todos los campos requeridos.",
     "nameError": "Por favor ingresa tu nombre",
     "emailError": "Por favor ingresa un correo electrónico válido",
-    "phoneError": "Por favor ingresa un número de teléfono válido (mín. 7 dígitos)"
+    "phoneError": "Por favor ingresa un número de teléfono válido (mín. 7 dígitos)",
+    "formSubmitError": "Error al enviar el formulario. Por favor, inténtelo de nuevo."
   },
   "ShortlistRouting": {
     "autoSuggestText": "{name} se especializa en las zonas que estás explorando. Puede mostrarte las {count} propiedades.",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -838,6 +838,7 @@
     "emptyState": "No tienes propiedades guardadas. Explora listados y toca ♡ para guardar.",
     "browseCta": "Explorar Propiedades",
     "keepSearching": "Seguir buscando más propiedades",
+    "addMoreProperties": "Agregar más propiedades",
     "askAgentCta": "Consultar por estas",
     "shareShortlistCta": "Compartir mi lista",
     "removeButtonLabel": "Eliminar propiedad de guardados",

--- a/tests/unit/sync/resolve-area-slug.spec.ts
+++ b/tests/unit/sync/resolve-area-slug.spec.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { resolveAreaSlug } from "@/lib/db/queries/properties";
+
+describe("resolveAreaSlug", () => {
+  // Helpers to create raw property objects with minimal fields
+  function makeRawInput(overrides: Partial<Parameters<typeof resolveAreaSlug>[0]>) {
+    return {
+      officeApiId: 235, // default to Dominical office
+      location: null,
+      titleEn: "",
+      titleEs: "",
+      publicRemarksEn: null,
+      publicRemarksEs: null,
+      ...overrides,
+    };
+  }
+
+  it("[P0] returns 'perez-zeledon' for properties listed by office 218 (Perez Zeledon) without other keywords", () => {
+    const raw = makeRawInput({ officeApiId: 218 });
+    expect(resolveAreaSlug(raw)).toBe("perez-zeledon");
+  });
+
+  it("[P0] returns 'perez-zeledon' for properties listed by office 235 (Dominical) but explicitly located in Perez Zeledon", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Beautiful farm in Pérez Zeledón",
+      publicRemarksEs: "Finca hermosa en San Isidro de El General",
+    });
+    expect(resolveAreaSlug(raw)).toBe("perez-zeledon");
+  });
+
+  it("[P0] returns 'uvita' for cross-office listings from office 218 (Perez Zeledon) but physically in Uvita", () => {
+    const raw = makeRawInput({
+      officeApiId: 218,
+      titleEn: "Lot in Uvita near Whale Tail",
+    });
+    expect(resolveAreaSlug(raw)).toBe("uvita");
+  });
+
+  it("[P0] returns 'ojochal' for properties with Ojochal or Coronado in title/location", () => {
+    const raw1 = makeRawInput({ titleEn: "House in Ojochal" });
+    const raw2 = makeRawInput({ location: "Coronado, Osa" });
+    const raw3 = makeRawInput({ publicRemarksEs: "Ubicado en Chontales" });
+    expect(resolveAreaSlug(raw1)).toBe("ojochal");
+    expect(resolveAreaSlug(raw2)).toBe("ojochal");
+    expect(resolveAreaSlug(raw3)).toBe("ojochal");
+  });
+
+  it("[P0] returns 'tinamastes-platanillo' for properties with Tinamastes keywords", () => {
+    const raw1 = makeRawInput({ titleEn: "Lot in Platanillo" });
+    const raw2 = makeRawInput({ publicRemarksEs: "Finca en Tinamaste" });
+    expect(resolveAreaSlug(raw1)).toBe("tinamastes-platanillo");
+    expect(resolveAreaSlug(raw2)).toBe("tinamastes-platanillo");
+  });
+
+  it("[P1] does NOT return 'ojochal' for properties that mention 'ojo de agua' (water spring) ONLY in public remarks (descriptive)", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Mountain Lot with Ocean View",
+      publicRemarksEs: "Esta hermosa propiedad cuenta con su propio ojo de agua y bosques.",
+    });
+    expect(resolveAreaSlug(raw)).toBe("dominical"); // falls back to Dominical
+  });
+
+  it("[P1] returns 'ojochal' for properties that mention 'ojo de agua' in the title or location", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      location: "Ojo de Agua",
+      titleEn: "Ocean View Lot",
+    });
+    expect(resolveAreaSlug(raw)).toBe("ojochal");
+  });
+
+  it("[P1] does NOT return 'ojochal' for properties that mention 'cortesía' in remarks (avoiding courtesy match)", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Modern Villa with Ocean Views",
+      publicRemarksEs: "Fotos por cortesía del desarrollador.",
+    });
+    expect(resolveAreaSlug(raw)).toBe("dominical"); // should not match 'cortes' substring in 'cortesía'
+  });
+
+  it("[P1] returns 'ojochal' if 'cortés' or 'cortes' is used as a whole word in the title or location", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Lot near Ciudad Cortés",
+    });
+    expect(resolveAreaSlug(raw)).toBe("ojochal");
+  });
+
+  it("[P1] does NOT return 'tinamastes-platanillo' for properties that mention generic 'lagunas' (lagoons/ponds) ONLY in public remarks", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Valley View Land",
+      publicRemarksEs: "La propiedad cuenta con dos lagunas naturales espectaculares.",
+    });
+    expect(resolveAreaSlug(raw)).toBe("dominical"); // falls back to Dominical
+  });
+
+  it("[P1] returns 'tinamastes-platanillo' for properties that mention 'lagunas' in title or location", () => {
+    const raw = makeRawInput({
+      officeApiId: 235,
+      titleEn: "Ocean View Lot in Lagunas",
+    });
+    expect(resolveAreaSlug(raw)).toBe("tinamastes-platanillo");
+  });
+
+  it("[P2] returns 'dominical' as the default fallback for office 235", () => {
+    const raw = makeRawInput({ officeApiId: 235 });
+    expect(resolveAreaSlug(raw)).toBe("dominical");
+  });
+});


### PR DESCRIPTION
This PR merges:
1. The **Keep searching for more properties** link on the saved properties Shortlist page.
2. The **Area Guide property filtering fix** to ensure area guides only display listings belonging to their respective regions.