### PR TITLE
Feature : Direct Listing Agent Routing

### DIFF
--- a/src/components/shortlist/agent-selection-modal.tsx
+++ b/src/components/shortlist/agent-selection-modal.tsx
@@ -83,7 +83,11 @@ export default function AgentSelectionModal({
     return a.agent.name.localeCompare(b.agent.name);
   });
 
-  const handleTriggerContact = (agent: Agent | null, properties: any[], channel: "whatsapp" | "email") => {
+  const handleTriggerContact = (
+    agent: Agent | null,
+    properties: any[],
+    channel: "whatsapp" | "email",
+  ) => {
     const key = agent ? agent.id : "office";
     if (!contactedKeys.includes(key)) {
       setContactedKeys((prev) => [...prev, key]);
@@ -137,9 +141,7 @@ export default function AgentSelectionModal({
               <p className="font-semibold text-blue-950 mb-0.5">
                 {locale === "es" ? "Enrutamiento Directo a Agentes" : "Direct Agent Routing"}
               </p>
-              <p className="text-blue-900/90 text-xs">
-                {t("educationInterstitial")}
-              </p>
+              <p className="text-blue-900/90 text-xs">{t("educationInterstitial")}</p>
             </div>
           </div>
 
@@ -192,8 +194,12 @@ export default function AgentSelectionModal({
                         ) : (
                           <span className="bg-slate-100 text-slate-600 text-[10px] font-semibold px-2 py-0.5 rounded-full whitespace-nowrap">
                             {isOffice
-                              ? (locale === "es" ? "Oficina Central" : "Central Office")
-                              : (locale === "es" ? "Agente a cargo" : "Listing Agent")}
+                              ? locale === "es"
+                                ? "Oficina Central"
+                                : "Central Office"
+                              : locale === "es"
+                                ? "Agente a cargo"
+                                : "Listing Agent"}
                           </span>
                         )}
                       </div>

--- a/src/components/shortlist/agent-selection-modal.tsx
+++ b/src/components/shortlist/agent-selection-modal.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useState } from "react";
 import { useTranslations } from "next-intl";
 
 interface Agent {
@@ -13,24 +14,30 @@ interface Agent {
   listingCount: number;
 }
 
+interface AgentGroup {
+  agent: Agent | null; // null represents the office
+  properties: any[];
+}
+
 interface AgentSelectionModalProps {
   isOpen: boolean;
   onClose: () => void;
-  agents: Agent[];
-  activeCoordinatorId: string | null;
-  onSelectAgent: (agent: Agent) => void;
+  agentGroups: AgentGroup[];
+  onContactAgent: (agent: Agent | null, properties: any[], channel: "whatsapp" | "email") => void;
+  onOpenContactForm?: () => void;
   locale: string;
 }
 
 export default function AgentSelectionModal({
   isOpen,
   onClose,
-  agents,
-  activeCoordinatorId,
-  onSelectAgent,
+  agentGroups,
+  onContactAgent,
+  onOpenContactForm,
   locale,
 }: AgentSelectionModalProps) {
   const t = useTranslations("ShortlistRouting");
+  const [contactedKeys, setContactedKeys] = useState<string[]>([]);
 
   React.useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -54,21 +61,35 @@ export default function AgentSelectionModal({
     return normalizedLanguages.includes(normalizedLocale);
   };
 
-  // Sort unique agents present in shortlist:
-  // 1. Language match first (agent speaks current locale/language)
-  // 2. Highest listingCount second
-  // 3. Alphabetical order of name third
-  const sortedAgents = [...agents].sort((a, b) => {
-    const aMatches = hasLangMatch(a.languages, locale) ? 1 : 0;
-    const bMatches = hasLangMatch(b.languages, locale) ? 1 : 0;
+  // Sort groups:
+  // 1. Office group is always at the end.
+  // 2. Agents grouped by language match to user's detected locale.
+  // 3. Highest property count within the group second.
+  // 4. Alphabetical by agent name third.
+  const sortedGroups = [...agentGroups].sort((a, b) => {
+    if (!a.agent) return 1; // office to end
+    if (!b.agent) return -1; // office to end
+
+    const aMatches = hasLangMatch(a.agent.languages, locale) ? 1 : 0;
+    const bMatches = hasLangMatch(b.agent.languages, locale) ? 1 : 0;
     if (aMatches !== bMatches) {
       return bMatches - aMatches;
     }
-    if (b.listingCount !== a.listingCount) {
-      return b.listingCount - a.listingCount;
+
+    if (b.properties.length !== a.properties.length) {
+      return b.properties.length - a.properties.length;
     }
-    return a.name.localeCompare(b.name);
+
+    return a.agent.name.localeCompare(b.agent.name);
   });
+
+  const handleTriggerContact = (agent: Agent | null, properties: any[], channel: "whatsapp" | "email") => {
+    const key = agent ? agent.id : "office";
+    if (!contactedKeys.includes(key)) {
+      setContactedKeys((prev) => [...prev, key]);
+    }
+    onContactAgent(agent, properties, channel);
+  };
 
   return (
     <div
@@ -80,13 +101,20 @@ export default function AgentSelectionModal({
       <div className="absolute inset-0" onClick={onClose} aria-hidden="true"></div>
 
       {/* Modal Content */}
-      <div className="relative bg-white rounded-2xl shadow-2xl max-w-lg w-full max-h-[90vh] flex flex-col overflow-hidden animate-in fade-in zoom-in-95 duration-200">
+      <div className="relative bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] flex flex-col overflow-hidden animate-in fade-in zoom-in-95 duration-200">
         {/* Header */}
         <div className="p-6 border-b border-slate-100 flex items-center justify-between">
-          <h2 className="text-xl font-bold text-slate-900">{t("modalTitle")}</h2>
+          <div>
+            <h2 className="text-xl font-bold text-slate-900">{t("modalTitle")}</h2>
+            <p className="text-xs text-slate-500 mt-1">
+              {locale === "es"
+                ? "Contacta directamente a cada agente para coordinar tus visitas."
+                : "Contact each listing agent directly to coordinate your visits."}
+            </p>
+          </div>
           <button
             onClick={onClose}
-            className="text-slate-400 hover:text-slate-600 transition-colors p-1 rounded-full hover:bg-slate-50"
+            className="text-slate-400 hover:text-slate-600 transition-colors p-1.5 rounded-full hover:bg-slate-50 flex-shrink-0"
             aria-label="Close modal"
           >
             <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -101,70 +129,186 @@ export default function AgentSelectionModal({
         </div>
 
         {/* Scrollable Body */}
-        <div className="p-6 overflow-y-auto space-y-6 flex-1">
-          {/* Education Interstitial Banner */}
-          <div className="bg-blue-50 border border-blue-100 text-blue-800 rounded-xl p-4 text-sm leading-relaxed">
-            {t("educationInterstitial")}
+        <div className="p-6 overflow-y-auto space-y-6 flex-1 bg-slate-50/30">
+          {/* Direct Agent Routing Interstitial */}
+          <div className="bg-blue-50/80 border border-blue-100/50 text-blue-900 rounded-xl p-4 text-sm leading-relaxed shadow-xs flex gap-3 items-start">
+            <span className="text-lg leading-none">🏠</span>
+            <div>
+              <p className="font-semibold text-blue-950 mb-0.5">
+                {locale === "es" ? "Enrutamiento Directo a Agentes" : "Direct Agent Routing"}
+              </p>
+              <p className="text-blue-900/90 text-xs">
+                {t("educationInterstitial")}
+              </p>
+            </div>
           </div>
 
-          {/* Agent Options List */}
-          <div className="space-y-3">
-            {sortedAgents.map((agent) => {
-              const isActive = agent.id === activeCoordinatorId;
-              const photoSrc =
-                agent.photoOptimizedUrl || agent.photoUrl || "/images/agent-placeholder.jpg";
+          {/* Groups list */}
+          <div className="space-y-4">
+            {sortedGroups.map((group) => {
+              const { agent, properties: groupProps } = group;
+              const isOffice = !agent;
+              const key = isOffice ? "office" : agent.id;
+              const isContacted = contactedKeys.includes(key);
+
+              const photoSrc = isOffice
+                ? "/images/agent-placeholder.jpg"
+                : agent.photoOptimizedUrl || agent.photoUrl || "/images/agent-placeholder.jpg";
+              const agentName = isOffice ? "RE/MAX Altitud" : agent.name;
+              const languages = isOffice ? "" : agent.languages;
 
               return (
-                <button
-                  key={agent.id}
-                  onClick={() => {
-                    onSelectAgent(agent);
-                    onClose();
-                  }}
-                  className={`w-full text-left p-4 rounded-xl border transition-all flex items-center gap-4 ${
-                    isActive
-                      ? "border-blue-500 bg-blue-50/50 shadow-sm ring-1 ring-blue-500/20"
-                      : "border-slate-200 hover:border-slate-300 hover:bg-slate-50"
+                <div
+                  key={key}
+                  className={`p-5 rounded-2xl border bg-white transition-all shadow-xs flex flex-col gap-4 ${
+                    isContacted
+                      ? "border-emerald-300 ring-1 ring-emerald-500/10"
+                      : "border-slate-200 hover:border-slate-300"
                   }`}
                 >
-                  {/* Photo */}
-                  <div className="relative w-16 h-16 rounded-full overflow-hidden border border-slate-100 bg-slate-50 flex-shrink-0">
-                    <img
-                      src={photoSrc}
-                      alt={agent.name}
-                      className="w-full h-full object-cover"
-                      onError={(e) => {
-                        e.currentTarget.src = "/images/agent-placeholder.jpg";
-                      }}
-                    />
-                  </div>
+                  {/* Agent Header Details */}
+                  <div className="flex gap-4 items-center">
+                    <div className="w-14 h-14 rounded-full overflow-hidden border border-slate-100 bg-slate-50 flex-shrink-0 relative">
+                      <img
+                        src={photoSrc}
+                        alt={agentName}
+                        className="w-full h-full object-cover"
+                        onError={(e) => {
+                          e.currentTarget.src = "/images/agent-placeholder.jpg";
+                        }}
+                      />
+                    </div>
 
-                  {/* Info */}
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="font-semibold text-slate-900 block truncate">
-                        {agent.name}
-                      </span>
-                      {isActive && (
-                        <span className="bg-blue-100 text-blue-800 text-[11px] font-medium px-2 py-0.5 rounded-full whitespace-nowrap">
-                          Active
-                        </span>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center justify-between gap-2 flex-wrap">
+                        <h3 className="font-bold text-slate-900 truncate text-base leading-snug">
+                          {agentName}
+                        </h3>
+                        {isContacted ? (
+                          <span className="inline-flex items-center gap-1 bg-emerald-100 text-emerald-800 text-[11px] font-bold px-2.5 py-0.5 rounded-full shadow-xs animate-in fade-in slide-in-from-bottom-1 duration-200">
+                            <span>✓</span>
+                            <span>{locale === "es" ? "Enviado" : "Sent"}</span>
+                          </span>
+                        ) : (
+                          <span className="bg-slate-100 text-slate-600 text-[10px] font-semibold px-2 py-0.5 rounded-full whitespace-nowrap">
+                            {isOffice
+                              ? (locale === "es" ? "Oficina Central" : "Central Office")
+                              : (locale === "es" ? "Agente a cargo" : "Listing Agent")}
+                          </span>
+                        )}
+                      </div>
+
+                      {!isOffice && languages && (
+                        <div className="text-xs text-slate-500 mt-1 truncate">
+                          <span className="font-medium text-slate-600">{t("languages")}</span>{" "}
+                          {languages}
+                        </div>
                       )}
                     </div>
+                  </div>
 
-                    <div className="text-xs text-slate-500 mt-1 truncate">
-                      <span className="font-medium text-slate-600">{t("languages")}</span>{" "}
-                      {agent.languages}
-                    </div>
-
-                    <div className="text-xs text-slate-400 mt-0.5">
-                      {agent.listingCount} {t("listings")}
+                  {/* Properties list within this group */}
+                  <div className="border-t border-slate-100 pt-3">
+                    <h4 className="text-[11px] font-bold text-slate-400 tracking-wider uppercase mb-2">
+                      {locale === "es"
+                        ? `Propiedades de este agente (${groupProps.length})`
+                        : `Properties represented (${groupProps.length})`}
+                    </h4>
+                    <div className="space-y-2">
+                      {groupProps.map((p) => {
+                        const propTitle = locale === "es" ? p.titleEs || p.titleEn : p.titleEn;
+                        const mainImg = p.images?.[0] || "/images/property-placeholder.jpg";
+                        return (
+                          <div
+                            key={p.id}
+                            className="flex items-center gap-3 p-2 rounded-lg bg-slate-50 border border-slate-100/50 hover:bg-slate-100/50 transition-colors"
+                          >
+                            <div className="w-12 h-9 rounded-md overflow-hidden bg-slate-200 flex-shrink-0">
+                              <img
+                                src={mainImg}
+                                alt={propTitle}
+                                className="w-full h-full object-cover"
+                                onError={(e) => {
+                                  e.currentTarget.src = "/images/property-placeholder.jpg";
+                                }}
+                              />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <div className="text-xs font-semibold text-slate-800 truncate">
+                                {propTitle}
+                              </div>
+                              <div className="text-[10px] text-slate-500 mt-0.5 flex gap-2">
+                                <span>Ref: {p.apiId}</span>
+                                <span>•</span>
+                                <span className="font-medium text-brand-navy">
+                                  ${p.priceUsd ? p.priceUsd.toLocaleString() : "N/A"}
+                                </span>
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })}
                     </div>
                   </div>
-                </button>
+
+                  {/* Actions for this agent group */}
+                  <div className="flex flex-col sm:flex-row gap-2 border-t border-slate-100 pt-3 mt-1">
+                    <button
+                      onClick={() => handleTriggerContact(agent, groupProps, "whatsapp")}
+                      className="flex-1 inline-flex h-9 items-center justify-center gap-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white font-semibold text-xs px-4 shadow-sm transition-colors"
+                    >
+                      <svg className="w-4 h-4 fill-current" viewBox="0 0 24 24">
+                        <path d="M17.472 14.382c-.022-.014-.492-.243-.58-.276-.089-.033-.153-.05-.218.048-.065.097-.25.243-.306.307-.056.064-.112.072-.218.019-.107-.053-.45-.165-.857-.528-.316-.28-.53-.628-.592-.733-.062-.105-.007-.162.046-.215.048-.047.107-.123.16-.186.054-.064.07-.108.106-.18.036-.072.018-.135-.009-.186-.027-.053-.218-.52-.3-.718-.08-.195-.163-.169-.224-.169-.057 0-.123-.008-.19-.008-.066 0-.173.024-.263.123-.09.099-.344.336-.344.821 0 .485.353.953.402 1.02.049.068.694 1.06 1.681 1.487.235.101.418.162.56.207.236.075.45.064.62.039.189-.028.58-.237.662-.466.082-.229.082-.426.058-.467-.024-.041-.088-.065-.195-.119zm-5.43 7.37c-1.802 0-3.567-.483-5.112-1.397l-.367-.218-3.79 1 .993-3.69-.239-.38C2.593 15.545 2 13.829 2 12.052c0-5.523 4.512-10 10.05-10 5.539 0 10.052 4.478 10.052 10 0 5.525-4.513 10-10.06 10zm0-22c-6.627 0-12 5.373-12 12 0 2.115.55 4.178 1.597 6.002L0 24l6.335-1.662C8.127 23.36 10.016 24 12 24c6.627 0 12-5.373 12-12s-5.373-12-12-12z" />
+                      </svg>
+                      {t("contactWhatsApp")}
+                    </button>
+                    <button
+                      onClick={() => handleTriggerContact(agent, groupProps, "email")}
+                      className="flex-1 inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-slate-300 bg-white text-slate-700 hover:bg-slate-50 font-semibold text-xs px-4 transition-colors"
+                    >
+                      <svg
+                        className="w-4 h-4"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={2}
+                          d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                        />
+                      </svg>
+                      {t("contactEmail")}
+                    </button>
+                  </div>
+                </div>
               );
             })}
           </div>
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-slate-100 flex flex-col sm:flex-row justify-between items-center gap-3 bg-slate-50/50">
+          {onOpenContactForm && (
+            <button
+              onClick={() => {
+                onOpenContactForm();
+                onClose();
+              }}
+              className="text-xs text-brand-navy hover:underline font-bold"
+            >
+              {locale === "es"
+                ? "← O usa nuestro Formulario de Contacto Unificado"
+                : "← Or use our Unified Contact Form instead"}
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="w-full sm:w-auto inline-flex h-9 items-center justify-center rounded-lg bg-slate-900 hover:bg-slate-800 text-white font-semibold text-xs px-6 shadow-sm transition-colors"
+          >
+            {locale === "es" ? "Terminar" : "Done"}
+          </button>
         </div>
       </div>
     </div>

--- a/src/components/shortlist/shortlist-page-client.tsx
+++ b/src/components/shortlist/shortlist-page-client.tsx
@@ -6,9 +6,7 @@ import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
 import dynamic from "next/dynamic";
 import { useShortlist } from "@/hooks/use-shortlist";
-import {
-  getShortlistPropertiesWithAgents,
-} from "@/app/actions/shortlist-actions";
+import { getShortlistPropertiesWithAgents } from "@/app/actions/shortlist-actions";
 import { PropertyCard } from "@/components/property/property-card";
 import { PropertyCardSkeleton } from "@/components/property/property-card-skeleton";
 import { MapView } from "@/components/map/map-view-loader";
@@ -113,7 +111,11 @@ export function ShortlistPageClient() {
     setProperties((prev) => prev.filter((p) => p.id !== id));
   };
 
-  const handleContactAgent = async (agent: any | null, agentProperties: any[], channel: "whatsapp" | "email") => {
+  const handleContactAgent = async (
+    agent: any | null,
+    agentProperties: any[],
+    channel: "whatsapp" | "email",
+  ) => {
     const isOffice = !agent;
     const agentName = isOffice ? "RE/MAX Altitud" : agent.name;
     const agentEmail = isOffice ? "info@remax-altitud.cr" : agent.email;
@@ -130,7 +132,9 @@ export function ShortlistPageClient() {
       })
       .join("\n");
 
-    const fullMessage = isOffice ? `${intro}\n${propertyLines}` : `${intro}\n${propertyLines}\n${outro}`;
+    const fullMessage = isOffice
+      ? `${intro}\n${propertyLines}`
+      : `${intro}\n${propertyLines}\n${outro}`;
 
     // Lead Capture POST request
     fetch("/api/leads", {
@@ -533,7 +537,9 @@ export function ShortlistPageClient() {
                   <span className="text-base leading-none">ℹ️</span>
                   <div>
                     <span className="font-semibold text-slate-800">
-                      {locale === "es" ? "Enrutamiento inteligente directo: " : "Direct agent routing: "}
+                      {locale === "es"
+                        ? "Enrutamiento inteligente directo: "
+                        : "Direct agent routing: "}
                     </span>
                     {t("contactFormSubheading")}
                   </div>
@@ -629,7 +635,9 @@ export function ShortlistPageClient() {
                           </h3>
                           <p className="text-[11px] text-slate-500 mt-0.5">
                             {isOffice
-                              ? (locale === "es" ? "Oficina Central" : "Central Office")
+                              ? locale === "es"
+                                ? "Oficina Central"
+                                : "Central Office"
                               : `${tRouting("languages")} ${languages}`}
                           </p>
                           <p className="text-[10px] text-slate-400 font-semibold mt-0.5">

--- a/src/components/shortlist/shortlist-page-client.tsx
+++ b/src/components/shortlist/shortlist-page-client.tsx
@@ -8,7 +8,6 @@ import dynamic from "next/dynamic";
 import { useShortlist } from "@/hooks/use-shortlist";
 import {
   getShortlistPropertiesWithAgents,
-  getActiveAgentsList,
 } from "@/app/actions/shortlist-actions";
 import { PropertyCard } from "@/components/property/property-card";
 import { PropertyCardSkeleton } from "@/components/property/property-card-skeleton";
@@ -29,12 +28,9 @@ export function ShortlistPageClient() {
   const [properties, setProperties] = useState<any[]>([]);
   const [copied, setCopied] = useState(false);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
-  const [chosenAgentId, setChosenAgentId] = useState<string | null>(null);
-  const [showCoordinatorBanner, setShowCoordinatorBanner] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const fetchedShortlistRef = useRef<string[]>([]);
 
-  const [allAgents, setAllAgents] = useState<any[]>([]);
   const [showContactForm, setShowContactForm] = useState(false);
   const [formSubmitted, setFormSubmitted] = useState(false);
   const [formSubmitting, setFormSubmitting] = useState(false);
@@ -42,26 +38,7 @@ export function ShortlistPageClient() {
   const [formEmail, setFormEmail] = useState("");
   const [formPhone, setFormPhone] = useState("");
   const [formMessage, setFormMessage] = useState("");
-  const [formAgentId, setFormAgentId] = useState("office");
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
-  const [submittedLeadAgent, setSubmittedLeadAgent] = useState<any | null>(null);
-
-  useEffect(() => {
-    getActiveAgentsList()
-      .then((data) => {
-        setAllAgents(data);
-      })
-      .catch((err) => {
-        console.error("Error fetching active agents list:", err);
-      });
-  }, []);
-
-  useEffect(() => {
-    const saved = localStorage.getItem("Altitud:chosenCoordinator");
-    if (saved) {
-      setChosenAgentId(saved);
-    }
-  }, []);
 
   useEffect(() => {
     if (copied) {
@@ -113,119 +90,74 @@ export function ShortlistPageClient() {
       });
   }, [shortlist, isLoaded]);
 
-  // Compute unique agents present in fetched shortlist
-  const uniqueAgents = Array.from(
-    new Map(
-      properties
-        .map((p) => p.agent)
-        .filter((a): a is NonNullable<typeof a> => !!a)
-        .map((a) => [a.id, a]),
-    ).values(),
-  );
-
-  // Compute Auto-Selected Coordinator Agent dynamically
-  const getAutoSelectedAgent = () => {
-    const counts: Record<string, number> = {};
-    const agentMap: Record<string, any> = {};
+  // Compute properties grouped by listing agent (null represents the office)
+  const agentGroups = (() => {
+    const groupsMap = new Map<string | "office", { agent: any | null; properties: any[] }>();
 
     for (const p of properties) {
-      if (p.agent) {
-        counts[p.agent.id] = (counts[p.agent.id] || 0) + 1;
-        agentMap[p.agent.id] = p.agent;
+      const key = p.agent?.id || "office";
+      if (!groupsMap.has(key)) {
+        groupsMap.set(key, {
+          agent: p.agent || null,
+          properties: [],
+        });
       }
+      groupsMap.get(key)!.properties.push(p);
     }
 
-    const agentIds = Object.keys(counts);
-    if (agentIds.length === 0) return null;
-
-    agentIds.sort((idA, idB) => {
-      if (counts[idB] !== counts[idA]) {
-        return counts[idB] - counts[idA];
-      }
-      const agentA = agentMap[idA];
-      const agentB = agentMap[idB];
-      if (agentB.listingCount !== agentA.listingCount) {
-        return agentB.listingCount - agentA.listingCount;
-      }
-      return agentA.name.localeCompare(agentB.name);
-    });
-
-    const bestId = agentIds[0];
-    const bestAgent = agentMap[bestId];
-
-    // Tie detection: highest property count matches another agent
-    const maxCount = counts[bestId];
-    const tiedAgentIds = agentIds.filter((id) => counts[id] === maxCount);
-    const hasTie = tiedAgentIds.length > 1;
-
-    return { bestAgent, hasTie };
-  };
-
-  const autoSelectResult = getAutoSelectedAgent();
-  const autoSelectedAgent = autoSelectResult?.bestAgent || null;
-  const hasTie = autoSelectResult?.hasTie || false;
-
-  const chosenAgent = uniqueAgents.find((a) => a.id === chosenAgentId) || null;
-  const activeCoordinator = chosenAgent ?? autoSelectedAgent;
-
-  useEffect(() => {
-    if (activeCoordinator && formAgentId === "office") {
-      setFormAgentId(activeCoordinator.id);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeCoordinator]);
-
-  const handleSelectAgent = (agent: any) => {
-    setChosenAgentId(agent.id);
-    localStorage.setItem("Altitud:chosenCoordinator", agent.id);
-    setShowCoordinatorBanner(true);
-  };
+    return Array.from(groupsMap.values());
+  })();
 
   const handleRemove = (id: string) => {
     remove(id);
     setProperties((prev) => prev.filter((p) => p.id !== id));
   };
 
-  const handleContactAgent = async (agent: any, channel: "whatsapp" | "email") => {
-    const intro = tRouting("whatsappMessageIntro", { agentName: agent.name });
-    const outro = tRouting("whatsappMessageOutro");
-    const propertyLines = properties
+  const handleContactAgent = async (agent: any | null, agentProperties: any[], channel: "whatsapp" | "email") => {
+    const isOffice = !agent;
+    const agentName = isOffice ? "RE/MAX Altitud" : agent.name;
+    const agentEmail = isOffice ? "info@remax-altitud.cr" : agent.email;
+    const agentWhatsapp = isOffice ? "50688888888" : agent.whatsapp;
+
+    const intro = isOffice
+      ? t("whatsAppMessageHeader")
+      : tRouting("whatsappMessageIntro", { agentName });
+    const outro = isOffice ? "" : tRouting("whatsappMessageOutro");
+    const propertyLines = agentProperties
       .map((p) => {
         const title = locale === "es" ? p.titleEs || p.titleEn : p.titleEn;
-        return `- ${title} (Ref: ${p.apiId})`;
+        return isOffice ? `- ${title} (${p.id})` : `- ${title} (Ref: ${p.apiId})`;
       })
       .join("\n");
 
-    const fullMessage = `${intro}\n${propertyLines}\n${outro}`;
+    const fullMessage = isOffice ? `${intro}\n${propertyLines}` : `${intro}\n${propertyLines}\n${outro}`;
 
     // Lead Capture POST request
-    try {
-      await fetch("/api/leads", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          name: "Shortlist Lead",
-          phone: "+50600000000",
-          email: "",
-          intent: "buy",
-          source: channel === "whatsapp" ? "whatsapp_click" : "contact_form",
-          assignedAgentId: agent.id,
-          shortlistPropertyIds: shortlist,
-          location: { text: "", lat: null, lng: null },
-        }),
-      });
-    } catch (err) {
-      console.error("Lead capture failed:", err);
-    }
+    fetch("/api/leads", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        name: "Shortlist Lead",
+        phone: "+50600000000",
+        email: "",
+        intent: "buy",
+        source: channel === "whatsapp" ? "whatsapp_click" : "contact_form",
+        assignedAgentId: isOffice ? null : agent.id,
+        shortlistPropertyIds: agentProperties.map((p) => p.id),
+        location: { text: "", lat: null, lng: null },
+      }),
+    }).catch((err) => {
+      console.error("Lead capture failed in background:", err);
+    });
 
     if (channel === "whatsapp") {
-      const cleanWhatsApp = (agent.whatsapp || "").replace(/\D/g, "");
+      const cleanWhatsApp = (agentWhatsapp || "").replace(/\D/g, "");
       const whatsappUrl = `https://wa.me/${cleanWhatsApp}?text=${encodeURIComponent(fullMessage)}`;
       window.open(whatsappUrl, "_blank");
     } else {
-      const propertyLinesWithLinks = properties
+      const propertyLinesWithLinks = agentProperties
         .map((p) => {
           const title = locale === "es" ? p.titleEs || p.titleEn : p.titleEn;
           const link = `${window.location.origin}/${locale}/property/${p.slug}`;
@@ -234,8 +166,8 @@ export function ShortlistPageClient() {
         .join("\n");
 
       const subject = tRouting("emailSubject");
-      const body = tRouting("emailBody", { agentName: agent.name, list: propertyLinesWithLinks });
-      const mailtoUrl = `mailto:${agent.email}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+      const body = tRouting("emailBody", { agentName, list: propertyLinesWithLinks });
+      const mailtoUrl = `mailto:${agentEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
       window.open(mailtoUrl, "_blank");
     }
   };
@@ -295,33 +227,36 @@ export function ShortlistPageClient() {
           .join("\n")}`;
       }
 
-      const recipientAgentId = formAgentId === "office" ? null : formAgentId;
+      // Parallel submission of split inquiries for each agent group
+      const leadPromises = agentGroups.map(async (group) => {
+        const recipientAgentId = group.agent?.id || null;
+        const groupPropertyIds = group.properties.map((p) => p.id);
 
-      const apiPayload = {
-        name: formName,
-        phone: formPhone,
-        email: formEmail,
-        intent: "buy" as const,
-        source: "contact_form" as const,
-        assignedAgentId: recipientAgentId,
-        shortlistPropertyIds: shortlist,
-        notes: `${formMessage.trim() ? formMessage.trim() + " | " : ""}Shortlist Link: ${shareUrl}`,
-        location: { text: "", lat: null, lng: null },
-      };
+        const apiPayload = {
+          name: formName,
+          phone: formPhone,
+          email: formEmail,
+          intent: "buy" as const,
+          source: "contact_form" as const,
+          assignedAgentId: recipientAgentId,
+          shortlistPropertyIds: groupPropertyIds,
+          notes: `${formMessage.trim() ? formMessage.trim() + " | " : ""}Shortlist Link: ${shareUrl}`,
+          location: { text: "", lat: null, lng: null },
+        };
 
-      const leadResponse = await fetch("/api/leads", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(apiPayload),
+        const leadResponse = await fetch("/api/leads", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(apiPayload),
+        });
+
+        if (!leadResponse.ok && leadResponse.status !== 409) {
+          throw new Error(`Lead submission failed for agent ${recipientAgentId}`);
+        }
       });
 
-      if (leadResponse.status === 201 || leadResponse.status === 409) {
-        const chosen = allAgents.find((a) => a.id === formAgentId) || null;
-        setSubmittedLeadAgent(chosen);
-        setFormSubmitted(true);
-      } else {
-        alert(t("formSubmitError"));
-      }
+      await Promise.all(leadPromises);
+      setFormSubmitted(true);
     } catch (err) {
       console.error("Form submission failed:", err);
       alert(t("formSubmitError"));
@@ -331,7 +266,7 @@ export function ShortlistPageClient() {
   };
 
   const handleAskAgent = async () => {
-    if (uniqueAgents.length === 0) {
+    if (agentGroups.length === 0) {
       // Fallback office WhatsApp message
       const header = t("whatsAppMessageHeader");
       const message = `${header}\n${properties
@@ -345,17 +280,14 @@ export function ShortlistPageClient() {
       return;
     }
 
-    if (uniqueAgents.length === 1) {
-      await handleContactAgent(uniqueAgents[0], "whatsapp");
-    } else if (hasTie && !chosenAgent) {
-      setIsModalOpen(true);
+    if (agentGroups.length === 1) {
+      await handleContactAgent(agentGroups[0].agent, agentGroups[0].properties, "whatsapp");
     } else {
-      setShowCoordinatorBanner(true);
+      setIsModalOpen(true);
     }
   };
 
   const handleShareShortlist = () => {
-    // Legacy fallback text block
     const header = t("shareMessageHeader");
     const fallbackText = `${header}\n${properties
       .map((p) => `${window.location.origin}/${locale}/property/${p.slug}`)
@@ -513,87 +445,11 @@ export function ShortlistPageClient() {
             ))}
           </div>
 
-          {/* Coordinator Agent Interstitial Suggestion Banner */}
-          {showCoordinatorBanner && activeCoordinator && !showContactForm && !formSubmitted && (
-            <div className="bg-slate-50 border border-slate-200 rounded-2xl p-6 mt-4">
-              <div className="flex flex-col sm:flex-row gap-6 items-start sm:items-center">
-                {/* Profile Photo */}
-                <div className="w-20 h-20 rounded-full overflow-hidden border border-slate-200 bg-white flex-shrink-0">
-                  <img
-                    src={
-                      activeCoordinator.photoOptimizedUrl ||
-                      activeCoordinator.photoUrl ||
-                      "/images/agent-placeholder.jpg"
-                    }
-                    alt={activeCoordinator.name}
-                    className="w-full h-full object-cover"
-                  />
-                </div>
-
-                {/* Info & Auto-Suggest Text */}
-                <div className="flex-1 min-w-0">
-                  <h3 className="text-lg font-bold text-slate-900">{activeCoordinator.name}</h3>
-                  <p className="text-sm text-slate-500 mt-0.5">
-                    <span className="font-semibold text-slate-600">{tRouting("languages")}</span>{" "}
-                    {activeCoordinator.languages}
-                  </p>
-                  <p className="text-sm text-slate-700 mt-3 font-medium bg-blue-50/50 border border-blue-100/50 text-blue-900 p-3 rounded-lg leading-relaxed">
-                    {tRouting("autoSuggestText", {
-                      name: activeCoordinator.name,
-                      count: properties.length,
-                    })}
-                  </p>
-                </div>
-              </div>
-
-              {/* Contact Actions */}
-              <div className="flex flex-col sm:flex-row gap-4 mt-6">
-                <button
-                  onClick={() => handleContactAgent(activeCoordinator, "whatsapp")}
-                  className="flex-1 inline-flex h-11 items-center justify-center rounded-md bg-emerald-600 hover:bg-emerald-700 text-white font-semibold px-6 shadow-md transition-colors"
-                >
-                  {tRouting("contactAgent", { name: activeCoordinator.name })}
-                </button>
-                <button
-                  onClick={() => handleContactAgent(activeCoordinator, "email")}
-                  className="flex-1 inline-flex h-11 items-center justify-center rounded-md border border-slate-300 text-slate-700 hover:bg-slate-100 font-semibold px-6 transition-colors"
-                >
-                  {tRouting("contactEmail")}
-                </button>
-              </div>
-
-              <div className="text-center mt-4 flex flex-col gap-2">
-                <button
-                  onClick={() => {
-                    setShowContactForm(true);
-                    setTimeout(() => {
-                      const formEl = document.getElementById("shortlist-contact-form");
-                      if (formEl && typeof formEl.scrollIntoView === "function") {
-                        formEl.scrollIntoView({ behavior: "smooth", block: "start" });
-                      }
-                    }, 100);
-                  }}
-                  className="text-xs text-brand-navy hover:underline font-semibold"
-                >
-                  {locale === "es"
-                    ? "O usar nuestro Formulario de Contacto"
-                    : "Or use our Contact Form instead"}
-                </button>
-                <button
-                  onClick={() => setIsModalOpen(true)}
-                  className="text-xs text-blue-600 hover:text-blue-800 font-semibold underline"
-                >
-                  {tRouting("chooseDifferent")}
-                </button>
-              </div>
-            </div>
-          )}
-
           {/* Shortlist Contact Form */}
           {showContactForm && !formSubmitted && (
             <div
               id="shortlist-contact-form"
-              className="bg-slate-50 border border-slate-200/80 rounded-2xl p-6 md:p-8 mt-4 shadow-sm"
+              className="bg-slate-50 border border-slate-200/80 rounded-2xl p-6 md:p-8 mt-4 shadow-sm animate-in fade-in slide-in-from-bottom-2 duration-300"
             >
               <h2 className="text-xl font-bold text-brand-navy mb-1">{t("contactFormHeading")}</h2>
               <p className="text-sm text-muted-foreground mb-6">{t("contactFormSubheading")}</p>
@@ -673,39 +529,14 @@ export function ShortlistPageClient() {
                   </div>
                 </div>
 
-                <div className="flex flex-col gap-1.5">
-                  <label htmlFor="form-agent" className="text-sm font-semibold text-brand-navy">
-                    {t("agentLabel")}
-                  </label>
-                  <select
-                    id="form-agent"
-                    value={formAgentId}
-                    onChange={(e) => setFormAgentId(e.target.value)}
-                    className="w-full h-11 rounded-md border border-slate-300 bg-white px-3 text-brand-navy focus:outline-none focus:ring-2 focus:ring-brand-navy"
-                  >
-                    <option value="office">{t("sendToOffice")}</option>
-                    {uniqueAgents.length > 0 && (
-                      <optgroup label={t("shortlistAgentsGroup")}>
-                        {uniqueAgents.map((agent) => (
-                          <option key={agent.id} value={agent.id}>
-                            {agent.name}
-                          </option>
-                        ))}
-                      </optgroup>
-                    )}
-                    {allAgents.filter((allA) => !uniqueAgents.some((uA) => uA.id === allA.id))
-                      .length > 0 && (
-                      <optgroup label={t("otherAgentsGroup")}>
-                        {allAgents
-                          .filter((allA) => !uniqueAgents.some((uA) => uA.id === allA.id))
-                          .map((agent) => (
-                            <option key={agent.id} value={agent.id}>
-                              {agent.name}
-                            </option>
-                          ))}
-                      </optgroup>
-                    )}
-                  </select>
+                <div className="bg-slate-100/60 border border-slate-200/50 p-4 rounded-xl text-xs text-slate-600 flex items-start gap-2.5 leading-relaxed">
+                  <span className="text-base leading-none">ℹ️</span>
+                  <div>
+                    <span className="font-semibold text-slate-800">
+                      {locale === "es" ? "Enrutamiento inteligente directo: " : "Direct agent routing: "}
+                    </span>
+                    {t("contactFormSubheading")}
+                  </div>
                 </div>
 
                 <div className="flex flex-col gap-1.5">
@@ -744,8 +575,8 @@ export function ShortlistPageClient() {
 
           {/* Shortlist Success Screen */}
           {formSubmitted && (
-            <div className="bg-slate-50 border border-emerald-200 rounded-2xl p-6 md:p-8 mt-4 shadow-sm text-center">
-              <div className="w-16 h-16 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4 border border-emerald-200">
+            <div className="bg-slate-50 border border-emerald-200 rounded-2xl p-6 md:p-8 mt-4 shadow-sm text-center animate-in zoom-in-95 duration-300">
+              <div className="w-16 h-16 bg-emerald-100 rounded-full flex items-center justify-center mx-auto mb-4 border border-emerald-200 shadow-xs">
                 <svg
                   className="w-8 h-8 text-emerald-600"
                   fill="none"
@@ -764,66 +595,68 @@ export function ShortlistPageClient() {
               <h2 className="text-2xl font-bold text-slate-900 mb-2">{t("successHeading")}</h2>
               <p className="text-sm text-slate-600 max-w-md mx-auto mb-8">{t("successText")}</p>
 
-              {/* Recipient Details & Immediate WhatsApp / Email Fallbacks */}
-              <div className="bg-white border border-slate-200 rounded-2xl p-5 max-w-md mx-auto text-left shadow-xs mb-8">
-                <div className="flex gap-4 items-center">
-                  <div className="w-14 h-14 rounded-full overflow-hidden border border-slate-200 bg-slate-100 flex-shrink-0">
-                    <img
-                      src={
-                        submittedLeadAgent?.photoOptimizedUrl ||
-                        submittedLeadAgent?.photoUrl ||
-                        "/images/agent-placeholder.jpg"
-                      }
-                      alt={submittedLeadAgent?.name || "RE/MAX Altitud"}
-                      className="w-full h-full object-cover"
-                    />
-                  </div>
-                  <div>
-                    <h3 className="font-bold text-slate-900 text-base">
-                      {submittedLeadAgent?.name || "RE/MAX Altitud"}
-                    </h3>
-                    <p className="text-xs text-slate-500 mt-0.5">
-                      {submittedLeadAgent
-                        ? `${tRouting("languages")} ${submittedLeadAgent.languages}`
-                        : "Oficina Central"}
-                    </p>
-                  </div>
-                </div>
+              {/* Grid of notified agents & direct contact fallbacks */}
+              <div className="space-y-4 max-w-lg mx-auto text-left mb-8">
+                <p className="text-xs font-bold text-slate-400 uppercase tracking-wider text-center mb-2">
+                  {locale === "es" ? "Agentes Notificados" : "Listing Agents Notified"}
+                </p>
+                {agentGroups.map((group) => {
+                  const { agent, properties: groupProps } = group;
+                  const isOffice = !agent;
+                  const key = isOffice ? "office" : agent.id;
+                  const photoSrc = isOffice
+                    ? "/images/agent-placeholder.jpg"
+                    : agent.photoOptimizedUrl || agent.photoUrl || "/images/agent-placeholder.jpg";
+                  const agentName = isOffice ? "RE/MAX Altitud" : agent.name;
+                  const languages = isOffice ? "" : agent.languages;
 
-                <div className="flex flex-col sm:flex-row gap-3 mt-5">
-                  <button
-                    onClick={() =>
-                      handleContactAgent(
-                        submittedLeadAgent || {
-                          id: "office",
-                          name: "RE/MAX Altitud",
-                          whatsapp: "50688888888",
-                          email: "info@remax-altitud.cr",
-                        },
-                        "whatsapp",
-                      )
-                    }
-                    className="flex-1 inline-flex h-10 items-center justify-center rounded-md bg-emerald-600 hover:bg-emerald-700 text-white font-semibold text-sm px-4 shadow-sm transition-colors"
-                  >
-                    {submittedLeadAgent ? tRouting("contactWhatsApp") : "WhatsApp"}
-                  </button>
-                  <button
-                    onClick={() =>
-                      handleContactAgent(
-                        submittedLeadAgent || {
-                          id: "office",
-                          name: "RE/MAX Altitud",
-                          whatsapp: "50688888888",
-                          email: "info@remax-altitud.cr",
-                        },
-                        "email",
-                      )
-                    }
-                    className="flex-1 inline-flex h-10 items-center justify-center rounded-md border border-slate-300 text-slate-700 hover:bg-slate-100 font-semibold text-sm px-4 transition-colors"
-                  >
-                    {tRouting("contactEmail")}
-                  </button>
-                </div>
+                  return (
+                    <div
+                      key={key}
+                      className="bg-white border border-slate-200 rounded-2xl p-4 shadow-xs"
+                    >
+                      <div className="flex gap-4 items-center">
+                        <div className="w-12 h-12 rounded-full overflow-hidden border border-slate-200 bg-slate-100 flex-shrink-0">
+                          <img
+                            src={photoSrc}
+                            alt={agentName}
+                            className="w-full h-full object-cover"
+                          />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <h3 className="font-bold text-slate-900 text-sm leading-snug">
+                            {agentName}
+                          </h3>
+                          <p className="text-[11px] text-slate-500 mt-0.5">
+                            {isOffice
+                              ? (locale === "es" ? "Oficina Central" : "Central Office")
+                              : `${tRouting("languages")} ${languages}`}
+                          </p>
+                          <p className="text-[10px] text-slate-400 font-semibold mt-0.5">
+                            {locale === "es"
+                              ? `Asignado para ${groupProps.length} ${groupProps.length === 1 ? "propiedad" : "propiedades"}`
+                              : `Assigned for ${groupProps.length} ${groupProps.length === 1 ? "property" : "properties"}`}
+                          </p>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-col sm:flex-row gap-2 mt-4">
+                        <button
+                          onClick={() => handleContactAgent(agent, groupProps, "whatsapp")}
+                          className="flex-1 inline-flex h-9 items-center justify-center gap-1.5 rounded-lg bg-emerald-600 hover:bg-emerald-700 text-white font-semibold text-xs px-4 shadow-sm transition-colors"
+                        >
+                          WhatsApp
+                        </button>
+                        <button
+                          onClick={() => handleContactAgent(agent, groupProps, "email")}
+                          className="flex-1 inline-flex h-9 items-center justify-center gap-1.5 rounded-lg border border-slate-300 text-slate-700 hover:bg-slate-50 font-semibold text-xs px-4 transition-colors"
+                        >
+                          {tRouting("contactEmail")}
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
               </div>
 
               <button
@@ -879,9 +712,17 @@ export function ShortlistPageClient() {
         <AgentSelectionModal
           isOpen={isModalOpen}
           onClose={() => setIsModalOpen(false)}
-          agents={uniqueAgents}
-          activeCoordinatorId={activeCoordinator?.id || null}
-          onSelectAgent={handleSelectAgent}
+          agentGroups={agentGroups}
+          onContactAgent={handleContactAgent}
+          onOpenContactForm={() => {
+            setShowContactForm(true);
+            setTimeout(() => {
+              const formEl = document.getElementById("shortlist-contact-form");
+              if (formEl && typeof formEl.scrollIntoView === "function") {
+                formEl.scrollIntoView({ behavior: "smooth", block: "start" });
+              }
+            }, 100);
+          }}
           locale={locale}
         />
       )}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -850,7 +850,7 @@
     "sharedBanner": "Viewing a shared shortlist. Start saving properties to create your own!",
     "shareError": "Failed to generate share link. Copying direct listing links instead.",
     "contactFormHeading": "Contact an Agent",
-    "contactFormSubheading": "Send your saved properties to an agent or the office to coordinate a visit.",
+    "contactFormSubheading": "Your inquiries will be automatically split and sent directly to the listing agents of your saved properties.",
     "nameLabel": "Your Full Name",
     "namePlaceholder": "Enter your name",
     "emailLabel": "Email Address",
@@ -875,19 +875,19 @@
     "formSubmitError": "Failed to send form. Please try again."
   },
   "ShortlistRouting": {
-    "autoSuggestText": "{name} specializes in the areas you're exploring. They can show you all {count} properties.",
+    "autoSuggestText": "{name} represents properties you're exploring. Direct contact ensures the fastest planning.",
     "contactAgent": "Contact {name}",
-    "chooseDifferent": "Choose a different agent",
-    "modalTitle": "Select Your Coordinator Agent",
-    "educationInterstitial": "🏠 One agent, all your visits — your chosen agent will coordinate visits to all your saved properties, even those listed by other agents.",
+    "chooseDifferent": "Contact agents individually",
+    "modalTitle": "Contact Listing Agents",
+    "educationInterstitial": "🏠 Direct Agent Routing — To coordinate your visits, you will contact each listing agent directly for their properties. This ensures direct, fast, and accurate coordination!",
     "languages": "Languages Spoken:",
     "listings": "listings",
     "contactWhatsApp": "Contact via WhatsApp",
     "contactEmail": "Contact via Email",
-    "whatsappMessageIntro": "Hi {agentName}, I'm interested in these properties from my shortlist:",
+    "whatsappMessageIntro": "Hi {agentName}, I'm interested in these properties you represent from my shortlist:",
     "whatsappMessageOutro": "Could we coordinate a visit? Thank you.",
-    "emailSubject": "Inquiry about property shortlist from ALT-ALTITUD",
-    "emailBody": "Hi {agentName},\n\nI am interested in viewing the following saved properties from my shortlist:\n\n{list}\n\nCould you coordinate these visits for me?\n\nThank you!"
+    "emailSubject": "Inquiry about your listed properties from my shortlist",
+    "emailBody": "Hi {agentName},\n\nI am interested in viewing the following saved properties you represent:\n\n{list}\n\nCould we coordinate these visits?\n\nThank you!"
   },
   "AdminSync": {
     "dashboardTitle": "Sync Status & Monitoring",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -850,7 +850,7 @@
     "sharedBanner": "Viendo una lista compartida. ¡Comienza a guardar propiedades para crear la tuya!",
     "shareError": "Error al generar enlace de compartir. Copiando enlaces directos de propiedades.",
     "contactFormHeading": "Contactar a un Agente",
-    "contactFormSubheading": "Envía tus propiedades guardadas a un agente o a la oficina para coordinar tu visita.",
+    "contactFormSubheading": "Tus consultas se dividirán automáticamente y se enviarán directamente a los agentes a cargo de cada propiedad guardada.",
     "nameLabel": "Tu Nombre Completo",
     "namePlaceholder": "Ingresa tu nombre",
     "emailLabel": "Correo Electrónico",
@@ -875,19 +875,19 @@
     "formSubmitError": "Error al enviar el formulario. Por favor, inténtelo de nuevo."
   },
   "ShortlistRouting": {
-    "autoSuggestText": "{name} se especializa en las zonas que estás explorando. Puede mostrarte las {count} propiedades.",
+    "autoSuggestText": "{name} representa las propiedades que estás explorando. El contacto directo garantiza una planificación más rápida.",
     "contactAgent": "Contactar a {name}",
-    "chooseDifferent": "Elegir un agente diferente",
-    "modalTitle": "Selecciona tu Agente Coordinador",
-    "educationInterstitial": "🏠 Un solo agente, todas tus visitas — el agente que elijas coordinará las visitas a todas tus propiedades guardadas, incluso las listadas por otros agentes.",
+    "chooseDifferent": "Contactar agentes individualmente",
+    "modalTitle": "Contactar a los Agentes de las Propiedades",
+    "educationInterstitial": "🏠 Enrutamiento Directo a Agentes — Para coordinar tus visitas, contactarás directamente al agente a cargo de cada propiedad. ¡Esto asegura una coordinación directa, rápida y precisa!",
     "languages": "Idiomas hablados:",
     "listings": "propiedades",
     "contactWhatsApp": "Contactar por WhatsApp",
     "contactEmail": "Contactar por Correo",
-    "whatsappMessageIntro": "Hola {agentName}, me interesan estas propiedades de mi lista de favoritos:",
+    "whatsappMessageIntro": "Hola {agentName}, me interesan estas propiedades que representas de mi lista de favoritos:",
     "whatsappMessageOutro": "¿Podríamos coordinar una visita? Gracias.",
-    "emailSubject": "Consulta sobre lista de propiedades guardadas de ALT-ALTITUD",
-    "emailBody": "Hola {agentName},\n\nMe interesa visitar las siguientes propiedades de mi lista de favoritos:\n\n{list}\n\n¿Podríamos coordinar estas visitas?\n\n¡Gracias!"
+    "emailSubject": "Consulta sobre tus propiedades listadas de mi lista de favoritos",
+    "emailBody": "Hola {agentName},\n\nMe interesa visitar las siguientes propiedades que representas:\n\n{list}\n\n¿Podríamos coordinar estas visitas?\n\n¡Gracias!"
   },
   "AdminSync": {
     "dashboardTitle": "Estado de Sincronización",

--- a/tests/unit/shortlist/smart-routing.spec.tsx
+++ b/tests/unit/shortlist/smart-routing.spec.tsx
@@ -1,19 +1,16 @@
 /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars */
 /**
- * Story 7.4: Smart Agent Routing from Shortlist — Component & Routing Unit Tests
+ * Story 7.4: Direct Listing Agent Routing from Shortlist — Component & Routing Unit Tests
  * Component: src/components/shortlist/shortlist-page-client.tsx
  *
  * Covers:
- *   - AC #1: WhatsApp opens directly to the single agent when all properties belong to 1 agent.
- *   - AC #2: Majority agent suggestion panel displays with primary CTA and secondary "Choose a different agent" CTA.
- *   - AC #3: AgentSelectionModal displays for ties/even distribution, showing photo, name, languages, listing count, sorted by language match, and the education interstitial.
- *   - AC #4: Pre-populated WhatsApp message contains all property references.
- *   - AC #5: Lead creation POST request contains assigned_agent_id, shortlist_property_ids[], source, intent, UTMs, and user's language.
- *   - AC #7: AgentSelectionModal dynamic lazy loading asynchronously.
- *   - AC #8: Alternative email CTA triggers lead capture and mailto: link.
+ *   - WhatsApp opens directly to the single agent when all properties belong to 1 agent.
+ *   - Inquiry Modal displays properties grouped by listing agent when multiple agents are present.
+ *   - Pre-populated WhatsApp and Email messages contain only the specific agent's properties.
+ *   - Background lead capture is triggered with correct fields per agent group.
+ *   - Contact form automatically splits properties by agent and triggers parallel lead capture calls.
  *
  * Environment: jsdom (.spec.tsx → jsdom)
- * Marked with describe.skip for the TDD RED phase.
  */
 
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
@@ -31,24 +28,40 @@ vi.mock("next-intl", () => {
     shareShortlistCta: "Share my shortlist",
     whatsAppMessageHeader: "Hello, I'm interested in these properties from my shortlist:",
     shareMessageHeader: "Check out my property shortlist:",
+    contactFormHeading: "Contact an Agent",
+    contactFormSubheading: "Your inquiries will be automatically split and sent directly to the listing agents of your saved properties.",
+    nameLabel: "Your Full Name",
+    namePlaceholder: "Enter your name",
+    emailLabel: "Email Address",
+    emailPlaceholder: "you@example.com",
+    phoneLabel: "Phone / WhatsApp",
+    phonePlaceholder: "+506 8888-8888",
+    messageLabel: "Personal Message",
+    messagePlaceholder: "Tell us about your schedule preference...",
+    submitForm: "Send My Shortlist",
+    submittingForm: "Sending...",
+    successHeading: "Shortlist Sent Successfully!",
+    successText: "Your saved property list has been sent.",
+    backToShortlist: "Back to My List",
+    nameError: "Please enter your name",
+    emailError: "Please enter a valid email address",
+    phoneError: "Please enter a valid phone number (min. 7 digits)",
+    formSubmitError: "Failed to send form. Please try again.",
 
     // ShortlistRouting
-    autoSuggestText:
-      "{name} specializes in the areas you're exploring. They can show you all {count} properties.",
+    autoSuggestText: "{name} represents properties you're exploring. Direct contact ensures the fastest planning.",
     contactAgent: "Contact {name}",
-    chooseDifferent: "Choose a different agent",
-    modalTitle: "Select Your Coordinator Agent",
-    educationInterstitial:
-      "🏠 One agent, all your visits — your chosen agent will coordinate visits to all your saved properties, even those listed by other agents.",
+    chooseDifferent: "Contact agents individually",
+    modalTitle: "Contact Listing Agents",
+    educationInterstitial: "🏠 Direct Agent Routing — To coordinate your visits, you will contact each listing agent directly for their properties.",
     languages: "Languages Spoken:",
     listings: "listings",
     contactWhatsApp: "Contact via WhatsApp",
     contactEmail: "Contact via Email",
-    whatsappMessageIntro: "Hi {agentName}, I'm interested in these properties from my shortlist:",
+    whatsappMessageIntro: "Hi {agentName}, I'm interested in these properties you represent from my shortlist:",
     whatsappMessageOutro: "Could we coordinate a visit? Thank you.",
-    emailSubject: "Inquiry about property shortlist from ALT-ALTITUD",
-    emailBody:
-      "Hi {agentName},\n\nI am interested in viewing the following saved properties from my shortlist:\n\n{list}\n\nCould you coordinate these visits for me?\n\nThank you!",
+    emailSubject: "Inquiry about your listed properties from my shortlist",
+    emailBody: "Hi {agentName},\n\nI am interested in viewing the following saved properties you represent:\n\n{list}\n\nCould we coordinate these visits?\n\nThank you!",
   };
 
   return {
@@ -97,32 +110,42 @@ vi.mock("@/components/shortlist/modal-shimmer", () => ({
 
 // Mock AgentSelectionModal to avoid dynamic import async boundaries in jsdom
 vi.mock("@/components/shortlist/agent-selection-modal", () => ({
-  default: ({ isOpen, onClose, agents, activeCoordinatorId, onSelectAgent }: any) => {
+  default: ({ isOpen, onClose, agentGroups, onContactAgent, onOpenContactForm }: any) => {
     if (!isOpen) return null;
     return (
       <div data-testid="agent-selection-modal">
-        <h2>Select Your Coordinator Agent</h2>
+        <h2>Contact Listing Agents</h2>
         <div>
-          🏠 One agent, all your visits — your chosen agent will coordinate visits to all your saved
-          properties, even those listed by other agents.
+          🏠 Direct Agent Routing — To coordinate your visits, you will contact each listing agent directly for their properties.
         </div>
-        {agents.map((agent: any) => (
-          <button
-            key={agent.id}
-            onClick={() => {
-              onSelectAgent(agent);
-              onClose();
-            }}
-          >
-            {agent.name}
-          </button>
-        ))}
+        {agentGroups.map((group: any) => {
+          const name = group.agent ? group.agent.name : "RE/MAX Altitud";
+          return (
+            <div key={group.agent?.id || "office"} data-testid={`agent-group-${group.agent?.id || "office"}`}>
+              <span>{name}</span>
+              <button
+                onClick={() => {
+                  onContactAgent(group.agent, group.properties, "whatsapp");
+                }}
+              >
+                WhatsApp {name}
+              </button>
+              <button
+                onClick={() => {
+                  onContactAgent(group.agent, group.properties, "email");
+                }}
+              >
+                Email {name}
+              </button>
+            </div>
+          );
+        })}
       </div>
     );
   },
 }));
 
-describe("Story 7.4: Smart Agent Routing Unit Tests (RED PHASE)", () => {
+describe("Story 7.4: Direct Listing Agent Routing Unit Tests", () => {
   let spyOpen: any;
   let spyFetch: any;
 
@@ -133,6 +156,7 @@ describe("Story 7.4: Smart Agent Routing Unit Tests (RED PHASE)", () => {
     spyFetch = vi.spyOn(global, "fetch").mockImplementation(() =>
       Promise.resolve({
         ok: true,
+        status: 201,
         json: () => Promise.resolve({ leadId: "lead-123", assignedAgentId: "agent-1" }),
       } as any),
     );
@@ -145,7 +169,7 @@ describe("Story 7.4: Smart Agent Routing Unit Tests (RED PHASE)", () => {
     spyFetch.mockRestore();
   });
 
-  it("[P0] 7.4-UNIT-001: routes to single agent directly when all shortlisted properties belong to 1 agent (AC #1, #4, #5)", async () => {
+  it("[P0] 7.4-UNIT-001: routes to single agent directly when all shortlisted properties belong to 1 agent", async () => {
     mockUseShortlist.mockImplementation(() => ({
       isLoaded: true,
       shortlist: ["prop-1", "prop-2"],
@@ -168,7 +192,6 @@ describe("Story 7.4: Smart Agent Routing Unit Tests (RED PHASE)", () => {
       { id: "prop-2", titleEn: "House 2", apiId: "REF-002", agentId: "agent-1", agent: mockAgent },
     ]);
 
-    // Import Component dynamically under test
     const { ShortlistPageClient } = await import("@/components/shortlist/shortlist-page-client");
     const { findByText } = render(<ShortlistPageClient />);
 
@@ -194,7 +217,7 @@ describe("Story 7.4: Smart Agent Routing Unit Tests (RED PHASE)", () => {
     expect(whatsappUrl).toContain(encodeURIComponent("House 2 (Ref: REF-002)"));
   });
 
-  it("[P0] 7.4-UNIT-002: shows majority agent auto-suggest banner when one agent has majority (AC #2, #4, #5)", async () => {
+  it("[P0] 7.4-UNIT-002: opens Inquiry Modal showing properties grouped by agent when multiple listing agents are present", async () => {
     mockUseShortlist.mockImplementation(() => ({
       isLoaded: true,
       shortlist: ["prop-1", "prop-2", "prop-3"],
@@ -246,30 +269,40 @@ describe("Story 7.4: Smart Agent Routing Unit Tests (RED PHASE)", () => {
     ]);
 
     const { ShortlistPageClient } = await import("@/components/shortlist/shortlist-page-client");
-    const { findByText } = render(<ShortlistPageClient />);
+    const { findByText, getByTestId, getByText } = render(<ShortlistPageClient />);
 
     const askBtn = await findByText("Ask about these");
     fireEvent.click(askBtn);
 
-    // Should NOT open WhatsApp immediately
-    expect(spyOpen).not.toHaveBeenCalled();
+    // Should open modal
+    await waitFor(() => {
+      expect(getByText("Contact Listing Agents")).toBeTruthy();
+    });
 
-    // Should show auto-suggest box with specialized text
-    const textElement = await findByText(/Emma specializes in the areas you're exploring/);
-    expect(textElement).toBeTruthy();
+    // WhatsApp Emma button
+    const whatsappEmmaBtn = getByText("WhatsApp Emma");
+    fireEvent.click(whatsappEmmaBtn);
 
-    // Primary CTA to contact Emma
-    const contactCta = await findByText("Contact Emma");
-    fireEvent.click(contactCta);
-
-    // Triggers WhatsApp and lead capture
+    // Should fetch lead capture for Emma's properties only and open Emma's WhatsApp
     await waitFor(() => {
       expect(spyFetch).toHaveBeenCalledOnce();
       expect(spyOpen).toHaveBeenCalledOnce();
     });
+
+    const [fetchUrl, fetchConfig] = spyFetch.mock.calls[0];
+    expect(fetchUrl).toContain("/api/leads");
+    const body = JSON.parse(fetchConfig.body);
+    expect(body.assignedAgentId).toBe("agent-emma");
+    expect(body.shortlistPropertyIds).toEqual(["prop-1", "prop-2"]);
+
+    const whatsappUrl = spyOpen.mock.calls[0][0];
+    expect(whatsappUrl).toContain("wa.me/50688888888");
+    expect(whatsappUrl).toContain(encodeURIComponent("House 1 (Ref: REF-001)"));
+    expect(whatsappUrl).toContain(encodeURIComponent("House 2 (Ref: REF-002)"));
+    expect(whatsappUrl).not.toContain(encodeURIComponent("House 3"));
   });
 
-  it("[P0] 7.4-UNIT-003: shows AgentSelectionModal on tie/even distribution (AC #3, #7, #8)", async () => {
+  it("[P1] 7.4-UNIT-003: supports email contact fallback per agent group with mailto links", async () => {
     mockUseShortlist.mockImplementation(() => ({
       isLoaded: true,
       shortlist: ["prop-1", "prop-2"],
@@ -297,20 +330,8 @@ describe("Story 7.4: Smart Agent Routing Unit Tests (RED PHASE)", () => {
     };
 
     mockGetShortlistPropertiesWithAgents.mockResolvedValue([
-      {
-        id: "prop-1",
-        titleEn: "House 1",
-        apiId: "REF-001",
-        agentId: "agent-emma",
-        agent: agentEmma,
-      },
-      {
-        id: "prop-2",
-        titleEn: "House 2",
-        apiId: "REF-002",
-        agentId: "agent-gustavo",
-        agent: agentGustavo,
-      },
+      { id: "prop-1", titleEn: "House 1", apiId: "REF-001", agentId: "agent-emma", agent: agentEmma },
+      { id: "prop-2", titleEn: "House 2", apiId: "REF-002", agentId: "agent-gustavo", agent: agentGustavo },
     ]);
 
     const { ShortlistPageClient } = await import("@/components/shortlist/shortlist-page-client");
@@ -319,19 +340,32 @@ describe("Story 7.4: Smart Agent Routing Unit Tests (RED PHASE)", () => {
     const askBtn = await findByText("Ask about these");
     fireEvent.click(askBtn);
 
-    // Tie should launch modal directly (simulate click, modal open checks)
+    // Open Modal and click Email for Gustavo
     await waitFor(() => {
-      expect(getByText("Select Your Coordinator Agent")).toBeTruthy();
-      expect(getByText(/One agent, all your visits/)).toBeTruthy();
+      expect(getByText("Contact Listing Agents")).toBeTruthy();
     });
 
-    // Verify agents are listed
-    expect(getByText("Emma")).toBeTruthy();
-    expect(getByText("Gustavo")).toBeTruthy();
+    const emailGustavoBtn = getByText("Email Gustavo");
+    fireEvent.click(emailGustavoBtn);
+
+    await waitFor(() => {
+      expect(spyFetch).toHaveBeenCalledOnce();
+      expect(spyOpen).toHaveBeenCalledOnce();
+    });
+
+    const [fetchUrl, fetchConfig] = spyFetch.mock.calls[0];
+    const body = JSON.parse(fetchConfig.body);
+    expect(body.assignedAgentId).toBe("agent-gustavo");
+    expect(body.shortlistPropertyIds).toEqual(["prop-2"]);
+    expect(body.source).toBe("contact_form");
+
+    const mailtoUrl = spyOpen.mock.calls[0][0];
+    expect(mailtoUrl).toContain("mailto:gustavo@remax.com");
+    expect(mailtoUrl).toContain(encodeURIComponent("Inquiry about your listed properties from my shortlist"));
+    expect(mailtoUrl).toContain(encodeURIComponent("House 2 (Ref: REF-002)"));
   });
 
-  it("[P1] 7.4-UNIT-004: supports email alternative with lead capture (AC #8)", async () => {
-    localStorage.setItem("Altitud:chosenCoordinator", "agent-1");
+  it("[P0] 7.4-UNIT-004: unified contact form splits properties by agent and triggers parallel background POST /api/leads", async () => {
     mockUseShortlist.mockImplementation(() => ({
       isLoaded: true,
       shortlist: ["prop-1", "prop-2"],
@@ -340,8 +374,8 @@ describe("Story 7.4: Smart Agent Routing Unit Tests (RED PHASE)", () => {
       save: () => ({ success: true }),
     }));
 
-    const mockAgent = {
-      id: "agent-1",
+    const agentEmma = {
+      id: "agent-emma",
       name: "Emma",
       whatsapp: "50688888888",
       email: "emma@remax.com",
@@ -349,8 +383,8 @@ describe("Story 7.4: Smart Agent Routing Unit Tests (RED PHASE)", () => {
       listingCount: 5,
     };
 
-    const mockAgent2 = {
-      id: "agent-2",
+    const agentGustavo = {
+      id: "agent-gustavo",
       name: "Gustavo",
       whatsapp: "50677777777",
       email: "gustavo@remax.com",
@@ -359,36 +393,50 @@ describe("Story 7.4: Smart Agent Routing Unit Tests (RED PHASE)", () => {
     };
 
     mockGetShortlistPropertiesWithAgents.mockResolvedValue([
-      { id: "prop-1", titleEn: "House 1", apiId: "REF-001", agentId: "agent-1", agent: mockAgent },
-      { id: "prop-2", titleEn: "House 2", apiId: "REF-002", agentId: "agent-2", agent: mockAgent2 },
+      { id: "prop-1", titleEn: "House 1", apiId: "REF-001", agentId: "agent-emma", agent: agentEmma },
+      { id: "prop-2", titleEn: "House 2", apiId: "REF-002", agentId: "agent-gustavo", agent: agentGustavo },
     ]);
 
     const { ShortlistPageClient } = await import("@/components/shortlist/shortlist-page-client");
-    const { findByText } = render(<ShortlistPageClient />);
+    const { findByText, getByLabelText } = render(<ShortlistPageClient />);
 
-    const askBtn = await findByText("Ask about these");
-    fireEvent.click(askBtn);
+    // Toggle contact form
+    const toggleFormBtn = await findByText("Contact via Form");
+    fireEvent.click(toggleFormBtn);
 
-    const emailBtn = await findByText("Contact via Email");
-    fireEvent.click(emailBtn);
+    // Fill form fields
+    const nameInput = getByLabelText(/Your Full Name/);
+    const emailInput = getByLabelText(/Email Address/);
+    const phoneInput = getByLabelText(/Phone \/ WhatsApp/);
 
-    // Should fetch lead capture API with email_click source
+    fireEvent.change(nameInput, { target: { value: "John Doe" } });
+    fireEvent.change(emailInput, { target: { value: "john@example.com" } });
+    fireEvent.change(phoneInput, { target: { value: "+50688888888" } });
+
+    const submitBtn = await findByText("Send My Shortlist");
+    fireEvent.click(submitBtn);
+
+    // Verify three API requests are triggered (1 for shortlist share link, 2 in parallel for Emma and Gustavo leads)
     await waitFor(() => {
-      expect(spyFetch).toHaveBeenCalledOnce();
-      expect(spyOpen).toHaveBeenCalledOnce();
+      expect(spyFetch).toHaveBeenCalledTimes(3);
     });
 
-    const [fetchUrl, fetchConfig] = spyFetch.mock.calls[0];
-    expect(fetchUrl).toContain("/api/leads");
-    const body = JSON.parse(fetchConfig.body);
-    expect(body.assignedAgentId).toBe("agent-1");
-    expect(body.source).toBe("contact_form");
+    // The first call is to /api/shortlist
+    expect(spyFetch.mock.calls[0][0]).toContain("/api/shortlist");
 
-    // Should open mailto redirection
-    const mailtoUrl = spyOpen.mock.calls[0][0];
-    expect(mailtoUrl).toContain("mailto:emma@remax.com");
-    expect(mailtoUrl).toContain(
-      encodeURIComponent("Inquiry about property shortlist from ALT-ALTITUD"),
-    );
+    // The next two calls are to /api/leads
+    expect(spyFetch.mock.calls[1][0]).toContain("/api/leads");
+    expect(spyFetch.mock.calls[2][0]).toContain("/api/leads");
+
+    const body1 = JSON.parse(spyFetch.mock.calls[1][1].body);
+    const body2 = JSON.parse(spyFetch.mock.calls[2][1].body);
+
+    const agentIds = [body1.assignedAgentId, body2.assignedAgentId];
+    expect(agentIds).toContain("agent-emma");
+    expect(agentIds).toContain("agent-gustavo");
+
+    const shortlistIds = [body1.shortlistPropertyIds, body2.shortlistPropertyIds];
+    expect(shortlistIds).toContainEqual(["prop-1"]);
+    expect(shortlistIds).toContainEqual(["prop-2"]);
   });
 });


### PR DESCRIPTION
# Walkthrough — Listing Agent Routing from Shortlist

We have successfully migrated the shortlist inquiry system from a single "Coordinator Agent" model to a direct **"Listing Agent" routing paradigm**. 

Now, when a client has a shortlist of properties, inquiries go directly to the respective listing agent(s) of those properties. This ensures agents receive leads for their own properties directly without other agents randomly coordinating visits, fulfilling your requirements completely.

---

## Changes Made

### 1. Bilingual Localizations
- **[en.json](src/messages/en.json)** and **[es.json](src/messages/es.json)**:
  - Updated `Shortlist.contactFormSubheading` to explain that inquiries are split and sent directly to listing agents.
  - Refactored `ShortlistRouting` namespace keys (`modalTitle`, `educationInterstitial`, `whatsappMessageIntro`, etc.) to align with direct, split agent routing.

### 2. Direct Listing Agent Inquiry Modal
- **[agent-selection-modal.tsx](src/components/shortlist/agent-selection-modal.tsx)**:
  - Completely redesigned from a single-agent coordinator selector into a beautiful listing agent contact card list.
  - Displays shortlisted properties grouped by their listing agent with property thumbnail image, title, price, and reference code.
  - Equips each agent group with a direct emerald green "Contact via WhatsApp" button and a slate/border "Contact via Email" button.
  - Tracks client progress using a stateful contacted checker, displaying a satisfying green checkmark/badge ("Sent ✓" / "Enviado ✓") when contacted.

### 3. Shortlist Page Refactoring
- **[shortlist-page-client.tsx](src/components/shortlist/shortlist-page-client.tsx)**:
  - Grouped shortlisted properties by listing agent (supporting no-agent properties falling back to the RE/MAX Altitud office).
  - Configured the main "Ask about these" button to directly route via WhatsApp/Email when all properties belong to a single agent, and instantly launch the revamped modal when properties belong to multiple agents.
  - Removed the coordinator selection dropdown from the unified contact form.
  - Rewrote form submission logic to split inquiries on the client-side and trigger parallel `fetch("/api/leads")` requests, saving direct leads in the database for each listing agent.
  - Upgraded the success confirmation screen to display beautiful notified cards for all agents who received the inquiry.

### 4. Unit Tests Upgrades
- **[smart-routing.spec.tsx](tests/unit/shortlist/smart-routing.spec.tsx)**:
  - Upgraded all unit tests to match direct listing agent routing, asserting modal list grouping, individual agent triggers with subset properties, and parallel split leads submission on contact form submit.

---

## Verification Results

### Automated Unit Tests
Executed the entire Vitest shortlist test suite. All tests compile and pass perfectly with zero errors or unhandled promise rejections:

```text
 RUN  v4.1.6 /Users/alejandracastro/Desktop/remax-altitud

 ✓  jsdom  tests/unit/shortlist/shortlist-page.spec.tsx (7 tests) 62ms
 ✓  jsdom  tests/unit/shortlist/shared-shortlist-page.spec.tsx (3 tests) 29ms
 ✓  jsdom  tests/unit/shortlist/smart-routing.spec.tsx (4 tests) 309ms

 Test Files  3 passed (3)
      Tests  14 passed (14)
   Start at  11:28:25
   Duration  1.48s
```
