### PR TITLE
Feature : Finca/Lote Search Improvements and CRC Currency Preference Support

### DIFF
--- a/src/app/actions/search-actions.ts
+++ b/src/app/actions/search-actions.ts
@@ -86,15 +86,15 @@ const TYPE_EQUIVALENTS: Record<string, string[]> = {
   apartment: ["Apartamento", "Apartment", "Condominium", "Condo"],
   condo: ["Apartamento", "Apartment", "Condominium", "Condo"],
   condominio: ["Apartamento", "Apartment", "Condominium", "Condo"],
-  lote: ["Lote", "Lot", "Land", "Lot/Land"],
-  lot: ["Lote", "Lot", "Land", "Lot/Land"],
-  terreno: ["Terreno", "Terrenos", "Land", "Lot", "Lot/Land"],
-  land: ["Terreno", "Terrenos", "Land", "Lot", "Lot/Land"],
+  lote: ["Lote", "Lot", "Land", "Lot/Land", "Terreno", "Terrenos", "Finca", "Farm", "Ranch", "Rural area"],
+  lot: ["Lote", "Lot", "Land", "Lot/Land", "Terreno", "Terrenos", "Finca", "Farm", "Ranch", "Rural area"],
+  terreno: ["Terreno", "Terrenos", "Land", "Lot", "Lot/Land", "Lote", "Finca", "Farm", "Ranch", "Rural area"],
+  land: ["Terreno", "Terrenos", "Land", "Lot", "Lot/Land", "Lote", "Finca", "Farm", "Ranch", "Rural area"],
   comercial: ["Comercial", "Commercial", "Business"],
   commercial: ["Comercial", "Commercial", "Business"],
-  finca: ["Finca", "Farm", "Ranch", "Rural area"],
-  farm: ["Finca", "Farm", "Ranch", "Rural area"],
-  ranch: ["Finca", "Farm", "Ranch", "Rural area"],
+  finca: ["Finca", "Farm", "Ranch", "Rural area", "Lote", "Lot", "Land", "Lot/Land", "Terreno", "Terrenos"],
+  farm: ["Finca", "Farm", "Ranch", "Rural area", "Lote", "Lot", "Land", "Lot/Land", "Terreno", "Terrenos"],
+  ranch: ["Finca", "Farm", "Ranch", "Rural area", "Lote", "Lot", "Land", "Lot/Land", "Terreno", "Terrenos"],
 };
 
 const DB_TYPE_TO_SPANISH: Record<string, string> = {

--- a/src/components/home/hero-search-shell.tsx
+++ b/src/components/home/hero-search-shell.tsx
@@ -210,7 +210,7 @@ function parseQuery(queryText: string): Record<string, string> {
   }
 
   // 4b. Hectares parsing (e.g. "1 hectare", "2 hectares", "5 ha", "una hectarea")
-  const hectareRegex = /\b(\d+(?:\.\d+)?|una|dos|tres|cinco)\s*(?:hectareas?|hectáreas?|ha)\b/gi;
+  const hectareRegex = /\b(\d+(?:\.\d+)?|una|dos|tres|cinco)\s*(?:hectareas?|hectáreas?|hecatreas?|hetareas?|hecteras?|ha)\b/gi;
   const hectareMatch = normalized.match(hectareRegex);
   if (hectareMatch) {
     const matchedStr = hectareMatch[0].toLowerCase();

--- a/src/components/layout/currency-toggle.tsx
+++ b/src/components/layout/currency-toggle.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useLocaleCurrency } from "@/hooks/use-locale-currency";
+import type { CurrencyCode } from "@/store/currency-store";
+
+interface CurrencyToggleProps {
+  variant?: "light" | "dark" | "header";
+}
+
+export function CurrencyToggle({ variant = "header" }: CurrencyToggleProps) {
+  const { currency, setCurrency } = useLocaleCurrency();
+
+  const baseClasses =
+    variant === "dark"
+      ? "text-text-on-dark"
+      : variant === "header"
+        ? "text-white/90"
+        : "text-text-primary";
+
+  const currencies: CurrencyCode[] = ["USD", "EUR", "CRC"];
+
+  return (
+    <div
+      className={`flex items-center gap-1.5 text-xs md:text-sm ${baseClasses}`}
+      role="group"
+      aria-label="Select currency"
+    >
+      {currencies.map((code, index) => {
+        const isActive = code === currency;
+        return (
+          <span key={code} className="flex items-center gap-1.5">
+            <button
+              type="button"
+              className={
+                isActive
+                  ? "font-bold text-brand-gold underline"
+                  : "opacity-70 transition-opacity duration-[var(--duration-fast)] hover:opacity-100 hover:text-white"
+              }
+              aria-current={isActive ? "true" : undefined}
+              aria-label={code}
+              onClick={() => setCurrency(code)}
+            >
+              {code}
+            </button>
+            {index < currencies.length - 1 && (
+              <span aria-hidden="true" className="opacity-30">
+                |
+              </span>
+            )}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/layout/desktop-nav.tsx
+++ b/src/components/layout/desktop-nav.tsx
@@ -15,6 +15,7 @@ import { cn } from "@/lib/utils";
 import { mainNavItems, type NavItem } from "@/lib/navigation";
 import { Button } from "@/components/ui/button";
 import { LanguageToggle } from "@/components/layout/language-toggle";
+import { CurrencyToggle } from "@/components/layout/currency-toggle";
 import {
   NavigationMenu,
   NavigationMenuList,
@@ -45,8 +46,9 @@ export function DesktopNav() {
           ))}
         </NavigationMenuList>
       </NavigationMenu>
-      <div className="ml-2 border-l border-white/20 pl-3">
+      <div className="ml-2 border-l border-white/20 pl-3 flex items-center gap-4">
         <LanguageToggle />
+        <CurrencyToggle />
       </div>
     </nav>
   );

--- a/src/components/layout/mobile-nav.tsx
+++ b/src/components/layout/mobile-nav.tsx
@@ -19,6 +19,7 @@ import { cn } from "@/lib/utils";
 import { mainNavItems, mobileOnlyItems, type NavItem } from "@/lib/navigation";
 import { Button } from "@/components/ui/button";
 import { LanguageToggle } from "@/components/layout/language-toggle";
+import { CurrencyToggle } from "@/components/layout/currency-toggle";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from "@/components/ui/sheet";
 
 export function MobileNav() {
@@ -91,8 +92,9 @@ export function MobileNav() {
             </ul>
           </nav>
 
-          <SheetFooter className="border-t border-brand-warm px-4 pt-4">
+          <SheetFooter className="border-t border-brand-warm px-4 pt-4 flex flex-row items-center justify-between">
             <LanguageToggle variant="light" />
+            <CurrencyToggle variant="light" />
           </SheetFooter>
         </SheetContent>
       </Sheet>

--- a/src/components/property/property-card.tsx
+++ b/src/components/property/property-card.tsx
@@ -1,10 +1,13 @@
+"use client";
+
 import Link from "next/link";
 import { PropertyImage } from "@/components/property/property-image";
 import { useTranslations } from "next-intl";
 import { SaveButton } from "@/components/shortlist/save-button";
 import { ShareButton } from "@/components/property/share-button";
 import { convertArea, type UnitSystem } from "@/lib/utils/units";
-import { formatUSD, formatEUR, isNonUSLocale } from "@/lib/utils/currency";
+import { PropertyPriceDisplay } from "@/components/property/property-price-display";
+import { formatUSD } from "@/lib/utils/currency";
 import type { PropertySearchItem } from "@/types/search";
 
 interface PropertyCardProps {
@@ -140,22 +143,12 @@ export function PropertyCard({
           className={`flex flex-col gap-2 ${isCompact ? "p-3" : "p-4"} ${isHorizontal ? "w-[60%]" : ""}`}
         >
           {/* Price */}
-          <p
-            data-testid="property-price"
-            className="font-bold text-xl text-[--color-accent] flex flex-wrap items-baseline gap-1.5"
-          >
-            <span>{usdPrice}</span>
-            {property.currency === "CRC" && originalPriceColones != null && (
-              <span className="text-xs font-semibold text-muted-foreground">
-                (₡{originalPriceColones.toLocaleString("es-CR")})
-              </span>
-            )}
-          </p>
-          {isNonUSLocale(locale) && (
-            <p data-testid="property-price-eur" className="text-xs text-muted-foreground">
-              ≈ {formatEUR(property.priceUsd, locale)}
-            </p>
-          )}
+          <PropertyPriceDisplay
+            priceUsd={property.priceUsd || 0}
+            originalCurrency={property.currency}
+            originalPriceColones={originalPriceColones}
+            locale={locale}
+          />
 
           {/* Title */}
           <h3

--- a/src/components/property/property-price-display.tsx
+++ b/src/components/property/property-price-display.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useLocaleCurrency } from "@/hooks/use-locale-currency";
+import { formatUSD, formatEUR, isNonUSLocale } from "@/lib/utils/currency";
+
+interface PropertyPriceDisplayProps {
+  priceUsd: number;
+  originalCurrency?: string | null;
+  originalPriceColones?: number | null;
+  locale: string;
+  variant?: "card" | "detail" | "simple";
+  className?: string;
+}
+
+export function PropertyPriceDisplay({
+  priceUsd,
+  originalCurrency,
+  originalPriceColones,
+  locale,
+  variant = "card",
+  className,
+}: PropertyPriceDisplayProps) {
+  const { currency, formatPrice } = useLocaleCurrency();
+
+  const primaryPrice = formatPrice(priceUsd, originalPriceColones);
+  const isCrcOriginal = originalCurrency === "CRC" && originalPriceColones != null && originalPriceColones > 0;
+
+  // Render simple variant
+  if (variant === "simple") {
+    return <span className={className}>{primaryPrice}</span>;
+  }
+
+  // Render detail page variant
+  if (variant === "detail") {
+    return (
+      <div className={className}>
+        <p className="mt-1 text-lg md:text-xl font-bold text-brand-navy flex flex-wrap items-baseline gap-1.5">
+          <span>{primaryPrice}</span>
+
+          {/* If the active currency is CRC, show approximate USD conversion */}
+          {currency === "CRC" && (
+            <span className="text-xs font-semibold text-text-muted">
+              (≈ {formatUSD(priceUsd, locale)})
+            </span>
+          )}
+
+          {/* If the active currency is EUR, show approximate USD conversion */}
+          {currency === "EUR" && (
+            <span className="text-xs font-semibold text-text-muted">
+              (≈ {formatUSD(priceUsd, locale)})
+            </span>
+          )}
+
+          {/* If the active currency is USD, show original Colones if CRC original */}
+          {currency === "USD" && isCrcOriginal && (
+            <span className="text-xs font-semibold text-text-muted">
+              (₡{originalPriceColones!.toLocaleString("es-CR")})
+            </span>
+          )}
+        </p>
+
+        {/* Auxiliary EUR conversion if active is USD and locale is non-US */}
+        {currency === "USD" && isNonUSLocale(locale) && (
+          <p data-testid="property-price-eur" className="text-xs text-text-muted mt-0.5">
+            ≈ {formatEUR(priceUsd, locale)}
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // Render card variant (default)
+  return (
+    <div className={className}>
+      <p
+        data-testid="property-price"
+        className="font-bold text-xl text-[--color-accent] flex flex-wrap items-baseline gap-1.5"
+      >
+        <span>{primaryPrice}</span>
+
+        {/* If the active currency is CRC, show approximate USD conversion */}
+        {currency === "CRC" && (
+          <span className="text-xs font-semibold text-muted-foreground">
+            (≈ {formatUSD(priceUsd, locale)})
+          </span>
+        )}
+
+        {/* If the active currency is EUR, show approximate USD conversion */}
+        {currency === "EUR" && (
+          <span className="text-xs font-semibold text-muted-foreground">
+            (≈ {formatUSD(priceUsd, locale)})
+          </span>
+        )}
+
+        {/* If the active currency is USD and property is originally in CRC, show Colones */}
+        {currency === "USD" && isCrcOriginal && (
+          <span className="text-xs font-semibold text-muted-foreground">
+            (₡{originalPriceColones!.toLocaleString("es-CR")})
+          </span>
+        )}
+      </p>
+
+      {/* Auxiliary EUR conversion if active is USD and locale is non-US */}
+      {currency === "USD" && isNonUSLocale(locale) && (
+        <p data-testid="property-price-eur" className="text-xs text-muted-foreground">
+          ≈ {formatEUR(priceUsd, locale)}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/use-locale-currency.ts
+++ b/src/hooks/use-locale-currency.ts
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+import { useLocale } from "next-intl";
+import { useCurrencyStore, type CurrencyCode } from "@/store/currency-store";
+import { formatUSD, formatEUR, formatCRC, getCrcToUsdRate } from "@/lib/utils/currency";
+
+export function useLocaleCurrency() {
+  const locale = useLocale();
+  const { currency, setCurrency, isHydrated, setHydrated } = useCurrencyStore();
+
+  useEffect(() => {
+    if (!isHydrated) {
+      try {
+        const stored = window.localStorage.getItem("currency-preference") as CurrencyCode | null;
+        if (stored === "USD" || stored === "EUR" || stored === "CRC") {
+          setCurrency(stored);
+        }
+      } catch {
+        // ignore storage availability errors
+      }
+      setHydrated(true);
+    }
+  }, [isHydrated, setCurrency, setHydrated]);
+
+  // If not hydrated yet, default to USD to avoid hydration mismatches
+  const activeCurrency = isHydrated ? currency : "USD";
+
+  const formatPrice = (priceUsd: number, originalPriceColones?: number | null): string => {
+    if (activeCurrency === "EUR") {
+      return formatEUR(priceUsd, locale);
+    }
+    if (activeCurrency === "CRC") {
+      if (originalPriceColones != null && originalPriceColones > 0) {
+        return formatCRC(originalPriceColones, locale);
+      }
+      const crcPrice = Math.round(priceUsd * getCrcToUsdRate());
+      return formatCRC(crcPrice, locale);
+    }
+    // Default USD
+    return formatUSD(priceUsd, locale);
+  };
+
+  return {
+    currency: activeCurrency,
+    setCurrency,
+    formatPrice,
+    locale,
+  } as const;
+}

--- a/src/lib/utils/currency.ts
+++ b/src/lib/utils/currency.ts
@@ -35,7 +35,7 @@ export function getCrcToUsdRate(): number {
  * Safely build a currency Intl.NumberFormat. Falls back to 'en-US' on a
  * malformed locale tag (Intl throws RangeError on invalid BCP-47 input).
  */
-function safeCurrencyFormatter(locale: string, currency: "USD" | "EUR"): Intl.NumberFormat {
+function safeCurrencyFormatter(locale: string, currency: "USD" | "EUR" | "CRC"): Intl.NumberFormat {
   const opts: Intl.NumberFormatOptions = {
     style: "currency",
     currency,
@@ -44,7 +44,7 @@ function safeCurrencyFormatter(locale: string, currency: "USD" | "EUR"): Intl.Nu
   try {
     return new Intl.NumberFormat(locale, opts);
   } catch {
-    return new Intl.NumberFormat("en-US", opts);
+    return new Intl.NumberFormat(currency === "CRC" ? "es-CR" : "en-US", opts);
   }
 }
 
@@ -70,6 +70,17 @@ export function formatEUR(price: number, locale: string): string {
   if (!Number.isFinite(price)) return "—";
   const eur = Math.round(price * EUR_RATE);
   return safeCurrencyFormatter(locale, "EUR").format(eur);
+}
+
+/**
+ * Format a CRC price for the given locale using Intl.NumberFormat.
+ *
+ * Examples:
+ *   formatCRC(185000, 'es-CR') → "₡185.000"
+ */
+export function formatCRC(price: number, locale: string): string {
+  if (!Number.isFinite(price)) return "—";
+  return safeCurrencyFormatter(locale, "CRC").format(price);
 }
 
 /**

--- a/src/store/currency-store.ts
+++ b/src/store/currency-store.ts
@@ -1,0 +1,26 @@
+import { create } from "zustand";
+
+export type CurrencyCode = "USD" | "EUR" | "CRC";
+
+export type CurrencyStore = {
+  currency: CurrencyCode;
+  setCurrency: (currency: CurrencyCode) => void;
+  isHydrated: boolean;
+  setHydrated: (hydrated: boolean) => void;
+};
+
+export const useCurrencyStore = create<CurrencyStore>()((set) => ({
+  currency: "USD",
+  setCurrency: (currency) => {
+    set({ currency });
+    if (typeof window !== "undefined") {
+      try {
+        window.localStorage.setItem("currency-preference", currency);
+      } catch {
+        // ignore storage quota/errors
+      }
+    }
+  },
+  isHydrated: false,
+  setHydrated: (hydrated) => set({ isHydrated: hydrated }),
+}));


### PR DESCRIPTION
# Finca/Lote Search Improvements and CRC Currency Preference Support

This Pull Request introduces two high-value improvements to the RE/MAX Altitud platform:
1. **Finca/Lote Search Robustness**: Enhances the query parser to be robust against common Spanish spelling typos of "hectáreas" and groups vacant lots, land, and farms/ranches as mutual search equivalents.
2. **CRC Currency Support**: Implements a complete multi-currency preference system (USD/EUR/CRC) with automatic hydration, dynamic conversions, and custom formatting.

## Overview

### 1. Finca/Lote Search Robustness
* **Typo-Robust Hectare Parsing**: The home search query parser now correctly recognizes and extracts land size for common typing variations of "hectáreas" (such as `hecatreas`, `hetareas`, and `hecteras`) instead of treating them as unparsed text keywords.
* **Mutual Land Search Equivalents**: Groups `Lote` (Lot), `Terreno` (Land), and `Finca` (Farm/Ranch) under mutual `TYPE_EQUIVALENTS` on the server search action. Searching or filtering by any of these categories now surfaces matching results from all three, which mirrors real-world buyer expectations in the Zona Sur region of Costa Rica.

### 2. Multi-Currency Support (USD, EUR, CRC)
* **Zustand Currency Store**: Stores the active currency preference (`USD`, `EUR`, `CRC`) in local storage with automatic state hydration on the client side.
* **Locale Currency Hook**: Dynamically formats prices in the active currency with local currency formatting. If a property is originally priced in CRC, it shows the original colones price for USD buyers, and approximate USD conversions for CRC/EUR buyers.
* **Price Display Component**: A highly customizable `PropertyPriceDisplay` component that automatically adapts its layout and display properties for cards, property details, and inline views.
* **Interactive Toggle**: Seamlessly integrates a premium currency toggle into the main desktop and mobile navigation headers.

---

## Changes

### Search & Query Parsing
* **search-actions.ts** (`src/app/actions/search-actions.ts`)
  * Groups `"Lote"`, `"Terreno"`, and `"Finca"` (and their English counterparts) into a single mutual equivalents array so land searches cross-reference all three categories.
* **hero-search-shell.tsx** (`src/components/home/hero-search-shell.tsx`)
  * Extended `hectareRegex` to support typos like `hecatreas`, `hetareas`, and `hecteras`.

### Currency Formatting & Store
* **currency.ts** (`src/lib/utils/currency.ts`)
  * Added `formatCRC` supporting Costa Rican Colones formatting with appropriate currency symbol (₡) and decimals.
* **currency-store.ts** (`src/store/currency-store.ts`)
  * Implemented client preference persistence via Zustand.
* **use-locale-currency.ts** (`src/hooks/use-locale-currency.ts`)
  * Created custom hook handling active locale, conversion math (e.g. CRC to USD rate), and formatting fallbacks.

### UI & Components Integration
* **property-price-display.tsx** (`src/components/property/property-price-display.tsx`)
  * Renders prices in card, detail, or simple views with optional auxiliary conversions for approximate price transparency.
* **currency-toggle.tsx** (`src/components/layout/currency-toggle.tsx`)
  * interactive header toggle.
* **desktop-nav.tsx** (`src/components/layout/desktop-nav.tsx`)
  * Integrated currency selector next to language toggle.
* **mobile-nav.tsx** (`src/components/layout/mobile-nav.tsx`)
  * Integrated currency selector for mobile layouts.
* **property-card.tsx** (`src/components/property/property-card.tsx`)
  * Replaced static USD formatting with `PropertyPriceDisplay` card variant.

---

## Testing

* **Unit Testing**: Ran `npm test` successfully passing 100% of tests (1098 passed, 4 skipped).
* **Production Build Compilation**: Ran `npm run build` and compiled the optimized static output successfully with zero errors.
* **Manual Verification**: Verified that typing `"finca 2 hetareas"` correctly parses the 2 hectares size and redirects to the search grid containing all large lots, land, and farms matching the area.
