### PR TITLE
fix: Shortlist query UUID & apiId compatibility with client-side auto-migration

### DIFF
--- a/src/app/actions/shortlist-actions.ts
+++ b/src/app/actions/shortlist-actions.ts
@@ -17,8 +17,12 @@ import { getAllAgents } from "@/lib/db/queries/agents";
 export async function getShortlistProperties(ids: string[]): Promise<PropertySearchItem[]> {
   if (!ids || ids.length === 0) return [];
 
-  const uuids = ids.filter((id) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id));
-  const apiIds = ids.filter((id) => !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id));
+  const uuids = ids.filter((id) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id),
+  );
+  const apiIds = ids.filter(
+    (id) => !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id),
+  );
 
   const conditions = [];
   if (uuids.length > 0) conditions.push(inArray(properties.id, uuids));
@@ -115,8 +119,12 @@ import { normalizePropertyImages } from "@/lib/utils/normalize-images";
 export async function getShortlistPropertiesWithAgents(ids: string[]): Promise<any[]> {
   if (!ids || ids.length === 0) return [];
 
-  const uuids = ids.filter((id) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id));
-  const apiIds = ids.filter((id) => !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id));
+  const uuids = ids.filter((id) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id),
+  );
+  const apiIds = ids.filter(
+    (id) => !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id),
+  );
 
   const conditions = [];
   if (uuids.length > 0) conditions.push(inArray(properties.id, uuids));

--- a/src/app/actions/shortlist-actions.ts
+++ b/src/app/actions/shortlist-actions.ts
@@ -4,7 +4,7 @@
 import { db } from "@/lib/db/client";
 import { properties } from "@/lib/db/schema/properties";
 import { shortlistShares } from "@/lib/db/schema/shortlist-shares";
-import { inArray, eq, and } from "drizzle-orm";
+import { inArray, eq, and, or } from "drizzle-orm";
 import { mapPropertyRowToSearchItem, propertySearchColumns } from "@/lib/db/queries/properties";
 import type { PropertySearchItem } from "@/types/search";
 import { randomBytes } from "crypto";
@@ -17,10 +17,19 @@ import { getAllAgents } from "@/lib/db/queries/agents";
 export async function getShortlistProperties(ids: string[]): Promise<PropertySearchItem[]> {
   if (!ids || ids.length === 0) return [];
 
+  const uuids = ids.filter((id) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id));
+  const apiIds = ids.filter((id) => !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id));
+
+  const conditions = [];
+  if (uuids.length > 0) conditions.push(inArray(properties.id, uuids));
+  if (apiIds.length > 0) conditions.push(inArray(properties.apiId, apiIds));
+
+  if (conditions.length === 0) return [];
+
   const rows = await db
     .select(propertySearchColumns)
     .from(properties)
-    .where(and(inArray(properties.id, ids), eq(properties.isVisible, true)));
+    .where(and(or(...conditions), eq(properties.isVisible, true)));
 
   return rows.map(mapPropertyRowToSearchItem);
 }
@@ -106,6 +115,15 @@ import { normalizePropertyImages } from "@/lib/utils/normalize-images";
 export async function getShortlistPropertiesWithAgents(ids: string[]): Promise<any[]> {
   if (!ids || ids.length === 0) return [];
 
+  const uuids = ids.filter((id) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id));
+  const apiIds = ids.filter((id) => !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id));
+
+  const conditions = [];
+  if (uuids.length > 0) conditions.push(inArray(properties.id, uuids));
+  if (apiIds.length > 0) conditions.push(inArray(properties.apiId, apiIds));
+
+  if (conditions.length === 0) return [];
+
   const rows = await db
     .select({
       properties: {
@@ -135,7 +153,7 @@ export async function getShortlistPropertiesWithAgents(ids: string[]): Promise<a
     })
     .from(properties)
     .leftJoin(agents, eq(properties.agentId, agents.id))
-    .where(and(inArray(properties.id, ids), eq(properties.isVisible, true)));
+    .where(and(or(...conditions), eq(properties.isVisible, true)));
 
   return rows.map((row) => ({
     id: row.properties.id,

--- a/src/components/shortlist/shortlist-page-client.tsx
+++ b/src/components/shortlist/shortlist-page-client.tsx
@@ -82,6 +82,27 @@ export function ShortlistPageClient() {
     getShortlistPropertiesWithAgents(shortlist)
       .then((data) => {
         setProperties(data);
+
+        // Auto-migration: if any returned property has its apiId saved in local storage instead of its UUID id,
+        // replace it with its UUID id so that local storage is fully migrated and consistent.
+        let migrated = false;
+        const currentShortlist = [...shortlist];
+
+        data.forEach((p) => {
+          if (p.apiId && currentShortlist.includes(p.apiId)) {
+            const idx = currentShortlist.indexOf(p.apiId);
+            if (idx > -1) {
+              currentShortlist[idx] = p.id; // Replace apiId with uuid
+              migrated = true;
+            }
+          }
+        });
+
+        if (migrated) {
+          window.localStorage.setItem("remax-altitud-shortlist", JSON.stringify(currentShortlist));
+          // Dispatch event to update the header heart badge count
+          window.dispatchEvent(new Event("shortlist-change"));
+        }
       })
       .catch((err) => {
         console.error("Error fetching shortlist properties with agents:", err);


### PR DESCRIPTION
This Pull Request implements a robust, backwards-compatible, and transparent migration layer to fix the bug where clients who previously saved properties using `apiId` values saw an empty shortlist page.

---

## Changes Made

### 1. Database & Server-Side Compatibility
- Modified the server actions `getShortlistProperties` and `getShortlistPropertiesWithAgents` in `shortlist-actions.ts`:
  - It now automatically separates UUIDs and API IDs using regex.
  - Queries the database for both types using an `or` conditional clause.
  - Successfully returns properties saved under either format.

### 2. Client-Side Auto-Migration
- Updated the client-side shortlist loader `ShortlistPageClient` in `shortlist-page-client.tsx`:
  - When properties are returned from the server, the component checks if any of them are saved in local storage under their old text `apiId` format.
  - Automatically replaces any `apiId` in the local storage array with its corresponding database UUID `id`.
  - Dispatches a custom event to immediately sync the header heart badge count.

This permanently cleans up local storage for any existing users, fixes the "Remove" button, and makes all previously saved items render correctly on the shortlist page!
