### PR TITLE
Feature : Add Communities Link to Footer and Improve Property Description Layout

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -56,6 +56,7 @@ function YoutubeIcon({ className }: { className?: string }) {
 const quickLinks = [
   { key: "properties", href: "/search" },
   { key: "ourAgents", href: "/agents" },
+  { key: "communities", href: "/communities" },
   { key: "vipBuyer", href: "/find-your-dream-property" },
   { key: "about", href: "/about" },
   { key: "contact", href: "/contact" },

--- a/src/components/listing/listing-detail-layout.tsx
+++ b/src/components/listing/listing-detail-layout.tsx
@@ -21,6 +21,7 @@ import type { Property } from "@/lib/db/schema/properties";
 import type { Agent } from "@/lib/db/schema/agents";
 import { normalizePropertyImages } from "@/lib/utils/normalize-images";
 import { getRegionFromAreaSlug } from "@/components/property/property-card";
+import { PropertyDescription } from "@/components/listing/property-description";
 
 // ZMT badge visual config (same as property-card.tsx)
 const ZMT_VISUAL: Record<string, { classes: string; icon: string }> = {
@@ -201,17 +202,11 @@ export async function ListingDetailLayout({
 
               {/* Description */}
               {description && (
-                <section aria-labelledby="description-heading">
-                  <h2 id="description-heading" className="mb-4 text-2xl font-bold text-brand-navy">
+                <section aria-labelledby="description-heading" className="space-y-4">
+                  <h2 id="description-heading" className="text-2xl font-bold text-brand-navy">
                     {t("description")}
                   </h2>
-                  <div className="prose prose-gray max-w-none">
-                    {description.split("\n").map((paragraph, i) => (
-                      <p key={i} className="mb-4 text-text-body leading-relaxed">
-                        {paragraph}
-                      </p>
-                    ))}
-                  </div>
+                  <PropertyDescription description={description} locale={locale} />
                 </section>
               )}
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -44,6 +44,7 @@
     "vipBuyer": "VIP Buyer Service",
     "contactUs": "Contact Us",
     "properties": "Properties",
+    "communities": "Communities",
     "areas": "Areas",
     "about": "About",
     "contact": "Contact",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -44,6 +44,7 @@
     "vipBuyer": "Servicio Comprador VIP",
     "contactUs": "Contáctanos",
     "properties": "Propiedades",
+    "communities": "Comunidades",
     "areas": "Zonas",
     "about": "Nosotros",
     "contact": "Contacto",

--- a/tests/unit/actions/shortlist-shares.spec.ts
+++ b/tests/unit/actions/shortlist-shares.spec.ts
@@ -41,6 +41,7 @@ vi.mock("drizzle-orm", () => {
     eq: vi.fn(),
     and: vi.fn(),
     inArray: vi.fn(),
+    or: vi.fn(),
     sql: vi.fn(),
   };
 });


### PR DESCRIPTION
# Add Communities Link to Footer and Improve Property Description Layout

Walkthrough of changes implemented in the feature branch.

## Overview
This pull request brings multiple enhancements and quality fixes to the platform:
1. Adds a direct link to the **Communities** page in the footer's Quick Links section, fully internationalized.
2. Refactors the property description section inside the listing details page to use a dedicated, clean, formatting-preserving `PropertyDescription` component.
3. Fixes database mock problems in `shortlist-shares` unit tests by properly mocking the `or` operator from `drizzle-orm`.

## Changes

### [Component: Shared Layout]
#### [MODIFY] footer.tsx
- Added `{ key: "communities", href: "/communities" }` inside the `quickLinks` array.

### [Component: Internationalization]
#### [MODIFY] es.json
- Added translation entry `"communities": "Comunidades"` in the `Footer` namespace.

#### [MODIFY] en.json
- Added translation entry `"communities": "Communities"` in the `Footer` namespace.

### [Component: Property Detail Page]
#### [MODIFY] listing-detail-layout.tsx
- Imported and integrated `PropertyDescription` to render description text dynamically and cleanly.

### [Component: Tests]
#### [MODIFY] shortlist-shares.spec.ts
- Mocked the `or` function inside the drizzle mock block, fixing unit test environment crashes.

## Testing
- **TypeScript & Type Checking**: Verified clean compilation using `npm run typecheck`.
- **Production Build**: Verified production build using `npm run build` which succeeded.
- **Unit Tests**: Executed the test suite with `npm run test` where 1098 unit tests passed cleanly.
