### PR TITLE
Fix : Fixing Language & Currency Selector Dropdown Alignment

### DIFF
--- a/src/components/layout/desktop-nav.tsx
+++ b/src/components/layout/desktop-nav.tsx
@@ -35,7 +35,7 @@ export function DesktopNav() {
 
   return (
     <nav className="hidden items-center gap-0.5 lg:flex xl:gap-1" aria-label={t("mainNav")}>
-      <NavigationMenu delayDuration={150} skipDelayDuration={300}>
+      <NavigationMenu delayDuration={150} skipDelayDuration={300} viewport={false}>
         <NavigationMenuList className="flex items-center gap-0.5 xl:gap-1">
           {mainNavItems.map((item) => (
             <NavigationMenuItem key={item.href}>
@@ -62,7 +62,7 @@ export function DesktopNav() {
                 {locale.toUpperCase()} / {currency}
               </span>
             </NavigationMenuTrigger>
-            <NavigationMenuContent className="z-50">
+            <NavigationMenuContent className="z-50 md:left-auto md:right-0">
               <div className="w-[260px] p-4 space-y-4 bg-white rounded-lg shadow-lg border border-brand-warm/20">
                 <div className="space-y-1.5">
                   <h4 className="text-xs font-semibold uppercase tracking-wider text-brand-navy/60">


### PR DESCRIPTION
We identified and resolved the layout bug causing the unified preferences ("EN / USD") dropdown menu to align and open far on the left of the screen instead of positioning itself correctly beneath the dropdown trigger button.

## Changes Made

### Navigation & Dropdown Positioning

#### [MODIFY] desktop-nav.tsx
- Disabled the shared/centered navigation menu viewport by setting `viewport={false}` on the `<NavigationMenu>` component. This renders all dropdown containers inline directly within their respective `NavigationMenuItem` parent containers instead of using the shared, centered viewport.
- Added custom alignment classes `md:left-auto md:right-0` to the Preferences `<NavigationMenuContent>` component:
  ```diff
  - <NavigationMenuContent className="z-50">
  + <NavigationMenuContent className="z-50 md:left-auto md:right-0">
  ```
- This ensures that the dropdown aligns its right edge exactly with the right edge of the "EN / USD" trigger button, positioning it perfectly and preventing any leftward layout shifts or screen overflow.

## Verification

- **Production Build**: Successfully ran a production build via `npm run build` to ensure the compilation and static generation process compiles without any TypeScript or bundling issues.