### PR TITLE
fix: search map pins, property grid, and full-map view

### DIFF
--- a/src/app/actions/map-actions.ts
+++ b/src/app/actions/map-actions.ts
@@ -18,7 +18,7 @@
  * @see _bmad-output/implementation-artifacts/3-2-interactive-map-with-property-pins.md Task 8
  */
 
-import { and, isNotNull, eq, sql } from "drizzle-orm";
+import { and, isNotNull, eq, gte, lte } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { properties } from "@/lib/db/schema";
 import { normalizePropertyImages } from "@/lib/utils/normalize-images";
@@ -71,8 +71,7 @@ function sanitizeBounds(bounds: RawBounds): RawBounds | null {
   const clampedEast = Math.min(180, Math.max(-180, east));
   const clampedWest = Math.min(180, Math.max(-180, west));
 
-  // Reject inverted / degenerate envelopes — these cause ST_MakeEnvelope to
-  // either return empty results or throw, depending on PostGIS version.
+  // Reject inverted / degenerate envelopes.
   if (clampedNorth <= clampedSouth || clampedEast <= clampedWest) {
     return null;
   }
@@ -94,11 +93,17 @@ export async function getPropertiesForMap(bounds?: RawBounds): Promise<MapProper
 
   const safeBounds = bounds != null ? sanitizeBounds(bounds) : null;
 
+  // Use simple lat/lng range comparisons instead of PostGIS geo operators.
+  // The `&&` operator with ST_MakeEnvelope doesn't work correctly on
+  // geography(Point, 4326) columns — it requires geometry type.
   const conditions =
     safeBounds != null
       ? and(
           baseConditions,
-          sql`${properties.geo} && ST_MakeEnvelope(${safeBounds.west}, ${safeBounds.south}, ${safeBounds.east}, ${safeBounds.north}, 4326)::geography`,
+          gte(properties.latitude, safeBounds.south),
+          lte(properties.latitude, safeBounds.north),
+          gte(properties.longitude, safeBounds.west),
+          lte(properties.longitude, safeBounds.east),
         )
       : baseConditions;
 

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,65 +1,14 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { checkDatabaseHealth } from "@/lib/db/health-check";
-import { searchProperties } from "@/app/actions/search-actions";
 
 export async function GET(req: NextRequest) {
   const dbHealth = await checkDatabaseHealth();
-
-  let searchResultPz: unknown = null;
-  let searchResultWide: unknown = null;
-  let errorMsg: string | null = null;
-  let errorDetail: unknown = null;
-
-  try {
-    // Pérez Zeledón bounds
-    const pzBounds = {
-      north: 9.5,
-      south: 9.2,
-      east: -83.5,
-      west: -83.8,
-    };
-    searchResultPz = await searchProperties({}, 1, pzBounds);
-
-    // Extremely wide bounds (should cover all of Costa Rica)
-    const wideBounds = {
-      north: 11.0,
-      south: 8.0,
-      east: -82.0,
-      west: -86.0,
-    };
-    searchResultWide = await searchProperties({}, 1, wideBounds);
-  } catch (err: unknown) {
-    const errorObject = err as Record<string, unknown>;
-    errorMsg = err instanceof Error ? err.message : String(err);
-    errorDetail = {
-      name: errorObject?.name,
-      code: errorObject?.code,
-      severity: errorObject?.severity,
-      detail: errorObject?.detail,
-      hint: errorObject?.hint,
-      position: errorObject?.position,
-      internalPosition: errorObject?.internalPosition,
-      internalQuery: errorObject?.internalQuery,
-      where: errorObject?.where,
-      schema: errorObject?.schema,
-      table: errorObject?.table,
-      column: errorObject?.column,
-      dataType: errorObject?.dataType,
-      constraint: errorObject?.constraint,
-    };
-  }
 
   const health = {
     status: dbHealth.connected ? "healthy" : "degraded",
     timestamp: new Date().toISOString(),
     checks: {
       database: dbHealth,
-    },
-    diagnostics: {
-      searchResultPz,
-      searchResultWide,
-      errorMsg,
-      errorDetail,
     },
   };
 

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -211,8 +211,27 @@ export function MapView({ properties, locale, onBoundsChange, flyToTarget }: Map
     }
   }, [flyToTarget]);
 
+  // Resize the Mapbox canvas when the container element changes size
+  // (e.g. switching between split 35% and full-map 100% views).
+  const containerRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = containerRef.current;
+    // ResizeObserver is available in all modern browsers but not in jsdom (test env)
+    if (!el || typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(() => {
+      // Defer resize to next frame so Mapbox reads the final container size
+      requestAnimationFrame(() => {
+        mapRef.current?.resize();
+      });
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <div
+      ref={containerRef}
       data-testid="map-container"
       aria-label="Property locations map"
       className="h-full w-full relative"

--- a/src/components/property/property-grid.tsx
+++ b/src/components/property/property-grid.tsx
@@ -44,10 +44,8 @@ export function PropertyGrid({
   const totalPages = Math.max(1, Math.ceil(totalCount / ITEMS_PER_PAGE));
   const showPagination = totalCount > ITEMS_PER_PAGE;
 
-  // Compute current page slice
-  const startIdx = (page - 1) * ITEMS_PER_PAGE;
-  const endIdx = startIdx + ITEMS_PER_PAGE;
-  const currentPageItems = properties.slice(startIdx, endIdx);
+  // Server Action (searchProperties) already returns only the current page's
+  // items via SQL LIMIT/OFFSET — no client-side slicing needed.
 
   const isFirstPage = page <= 1;
   const isLastPage = page >= totalPages;
@@ -60,7 +58,7 @@ export function PropertyGrid({
         className || "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
       )}
     >
-      {currentPageItems.map((property) => (
+      {properties.map((property) => (
         <PropertyCard
           key={property.id}
           property={property}
@@ -70,7 +68,7 @@ export function PropertyGrid({
       ))}
 
       {/* Empty state — Story 3.8: render NoResultsState with active filters */}
-      {currentPageItems.length === 0 && !isLoading && (
+      {properties.length === 0 && !isLoading && (
         <div className="col-span-full">
           <NoResultsState filters={filters ?? {}} />
         </div>

--- a/tests/unit/search/property-grid.spec.tsx
+++ b/tests/unit/search/property-grid.spec.tsx
@@ -299,10 +299,11 @@ describe("PropertyGrid — AC #2/#3/#4: responsive grid layout", () => {
   );
 
   it(
-    "[P0] renders exactly 20 cards (max per page) when more than 20 properties are passed",
+    "[P0] renders all cards passed by the server (server handles pagination via LIMIT/OFFSET)",
     () => {
-      // THIS TEST WILL FAIL — property-grid.tsx not yet implemented
-      const properties = makeProperties(25);
+      // Server Action returns only 20 items for page 1 via SQL LIMIT.
+      // PropertyGrid renders all items it receives — no client-side slicing.
+      const properties = makeProperties(20);
       render(<PropertyGrid properties={properties} locale="en" page={1} total={25} />);
 
       const cards = document.querySelectorAll('[data-testid="property-card"]');
@@ -311,10 +312,11 @@ describe("PropertyGrid — AC #2/#3/#4: responsive grid layout", () => {
   );
 
   it(
-    "[P1] renders second page of cards when page=2 and >20 properties passed",
+    "[P1] renders second page of cards (server sends only 5 remaining items for page 2)",
     () => {
-      // THIS TEST WILL FAIL — property-grid.tsx not yet implemented
-      const properties = makeProperties(25);
+      // Server Action returns only the remaining 5 items for page 2.
+      // PropertyGrid renders all items it receives — no client-side slicing.
+      const properties = makeProperties(5);
       render(
         <PropertyGrid
           properties={properties}
@@ -324,7 +326,7 @@ describe("PropertyGrid — AC #2/#3/#4: responsive grid layout", () => {
         />,
       );
 
-      // Page 2 should show the remaining 5 (properties 21-25)
+      // Page 2 should show exactly the 5 items the server returned
       const cards = document.querySelectorAll('[data-testid="property-card"]');
       expect(cards).toHaveLength(5);
     },


### PR DESCRIPTION
## Summary

Fixes three critical bugs on the search page:

### 1. 🗺️ Map pins not loading with bounds
**File:** `src/app/actions/map-actions.ts`
**Root cause:** The `&&` (bounding box overlap) PostGIS operator was used with a `geography(Point, 4326)` column, but `&&` only works with `geometry` type. Every bounds-filtered query failed silently.
**Fix:** Replaced with simple `gte`/`lte` on `latitude`/`longitude` columns (same pattern as `search-actions.ts`).

### 2. 📋 Property cards not showing in grid
**File:** `src/components/property/property-grid.tsx`
**Root cause:** Double pagination — `searchProperties` returns 20 items via SQL `LIMIT/OFFSET`, but `PropertyGrid` re-sliced client-side. Page 2+ showed empty.
**Fix:** Removed client-side `slice()` — server handles pagination.

### 3. 🗺️ Full map view not resizing
**File:** `src/components/map/map-view.tsx`
**Root cause:** Mapbox didn't resize its canvas when switching from Split (35%) to Full Map (100%).
**Fix:** Added `ResizeObserver` on the map container that calls `mapRef.current.resize()`.

### Cleanup
- **`src/app/api/health/route.ts`** — Removed diagnostic `searchProperties` calls
- **`tests/unit/search/property-grid.spec.tsx`** — Updated pagination tests for server-side model

### Verification
- ✅ TypeScript compiles cleanly
- ✅ Prettier format check passes
- ✅ All 1102 tests pass (90 files, 0 failures)