### PR TITLE
Fix : RISE Community Migration Duplicate Key Failure

### DIFF
--- a/src/lib/db/migrations/0019_add_rise_community.sql
+++ b/src/lib/db/migrations/0019_add_rise_community.sql
@@ -18,4 +18,20 @@ INSERT INTO "communities" (
   ST_GeographyFromText('SRID=4326;POLYGON((-83.625 9.362, -83.618 9.362, -83.618 9.369, -83.625 9.369, -83.625 9.362))'),
   150000, 500000,
   '{"elevation": "1,000 meters (3,280 feet) / 1.000 metros (3.280 pies)", "airportDistance": "Airstrip on site, 20 mins to PZ Airport, 3 hours to SJO", "internet": "Fiber Optic / Fibra óptica", "developer": "David Comfort / New Earth Preservation S.A.", "established": "2022 (Note: Only selling to full-time families, no investors)", "amenities": ["Clubhouse", "Salt Pool / Piscina de sal", "Kinkára Retreat Center / Centro de Retiros Kinkára", "Waldorf-Inspired School / Escuela inspirada en Waldorf", "Private Airstrip / Pista de aterrizaje privada", "Commercial Areas / Áreas comerciales", "River with water holes / Río con pozas y cataratas", "Biking & Hiking Trails / Senderos para ciclismo y caminatas"]}'::jsonb
-);
+)
+ON CONFLICT ("slug") DO UPDATE SET
+  "area_id" = EXCLUDED.area_id,
+  "name" = EXCLUDED.name,
+  "tagline_en" = EXCLUDED.tagline_en,
+  "tagline_es" = EXCLUDED.tagline_es,
+  "description_en" = EXCLUDED.description_en,
+  "description_es" = EXCLUDED.description_es,
+  "hero_image_url" = EXCLUDED.hero_image_url,
+  "site_map_image_url" = EXCLUDED.site_map_image_url,
+  "latitude" = EXCLUDED.latitude,
+  "longitude" = EXCLUDED.longitude,
+  "geo_fence_coords" = EXCLUDED.geo_fence_coords,
+  "geo_fence" = EXCLUDED.geo_fence,
+  "price_min_usd" = EXCLUDED.price_min_usd,
+  "price_max_usd" = EXCLUDED.price_max_usd,
+  "quick_facts" = EXCLUDED.quick_facts;


### PR DESCRIPTION
# Fix RISE Community Migration Duplicate Key Failure

## Overview

Deploying the project to a brand-new PostgreSQL database failed during migration with a `duplicate key value violates unique constraint "communities_slug_unique"` error. The root cause was migration `0019_add_rise_community.sql` using a bare `INSERT` without `ON CONFLICT` handling, while an earlier migration (`0014_add_new_communities.sql`) had already inserted the same `rise-costa-rica` slug.

## Root Cause

Migration `0014_add_new_communities.sql` (journal idx 13) inserts the `rise-costa-rica` community with proper `ON CONFLICT ("slug") DO UPDATE SET ...` idempotency. Migration `0019_add_rise_community.sql` (journal idx 16) then attempts to insert the same slug again with updated data, but lacked any `ON CONFLICT` clause — causing a unique constraint violation on fresh deployments where both migrations run sequentially.

## Changes

### Modified: `src/lib/db/migrations/0019_add_rise_community.sql`

Added `ON CONFLICT ("slug") DO UPDATE SET ...` clause to the INSERT statement, matching the idempotent upsert pattern used by all other community seed migrations (`0014`, `0015`, `0016`). The UPDATE clause covers all mutable columns: `area_id`, `name`, `tagline_en/es`, `description_en/es`, `hero_image_url`, `site_map_image_url`, `latitude`, `longitude`, `geo_fence_coords`, `geo_fence`, `price_min_usd`, `price_max_usd`, and `quick_facts`.

## Testing

- **Lint**: 0 errors (29 pre-existing warnings)
- **TypeScript**: No type errors
- **Format**: All files properly formatted
- **Unit tests**: 1102 passed, 4 skipped (DB-gated, expected)
- **Build**: Compiled successfully (55/55 static pages)
- **Full migration audit**: Traced all 20 migrations in journal execution order against a blank database — no other blocking issues found