### PR TITLE
fix: resolve search page grid and homepage queries by replacing PostGIS geography filter and wrapping database queries in try-catch

### DIFF
--- a/src/app/actions/search-actions.ts
+++ b/src/app/actions/search-actions.ts
@@ -225,302 +225,304 @@ export async function searchProperties(
     // Sanitize page parameter — clamp to >= 1
     const safePage = Math.max(1, Math.floor(sanitizeNumber(page) ?? 1));
 
-  // If bounds are provided, filter properties inside the bounds
-  const safeBounds = bounds != null ? sanitizeBounds(bounds) : null;
+    // If bounds are provided, filter properties inside the bounds
+    const safeBounds = bounds != null ? sanitizeBounds(bounds) : null;
 
-  // Sanitize all numeric inputs (guard against NaN, Infinity — ADR-5 compliance)
-  const priceMin = sanitizeNumber(filters.priceMin);
-  const priceMax = sanitizeNumber(filters.priceMax);
-  const bedrooms = sanitizeNumber(filters.bedrooms);
-  const bathrooms = sanitizeNumber(filters.bathrooms);
-  const lotSizeMin = sanitizeNumber(filters.lotSizeMin);
-  const lotSizeMax = sanitizeNumber(filters.lotSizeMax);
+    // Sanitize all numeric inputs (guard against NaN, Infinity — ADR-5 compliance)
+    const priceMin = sanitizeNumber(filters.priceMin);
+    const priceMax = sanitizeNumber(filters.priceMax);
+    const bedrooms = sanitizeNumber(filters.bedrooms);
+    const bathrooms = sanitizeNumber(filters.bathrooms);
+    const lotSizeMin = sanitizeNumber(filters.lotSizeMin);
+    const lotSizeMax = sanitizeNumber(filters.lotSizeMax);
 
-  // Story 3.4: sanitize lifestyle tag array — server actions are publicly
-  // callable, so reject non-string entries, trim whitespace, drop empties,
-  // and cap the array length to bound the SQL parameter size. The hard cap
-  // is set well above the 5 known tags to allow future expansion without
-  // becoming a DoS surface.
-  const MAX_TAGS = 20;
-  const sanitizedTags = filters.tags
-    ?.filter((t): t is string => typeof t === "string")
-    .map((t) => t.trim())
-    .filter((t) => t.length > 0)
-    .slice(0, MAX_TAGS);
+    // Story 3.4: sanitize lifestyle tag array — server actions are publicly
+    // callable, so reject non-string entries, trim whitespace, drop empties,
+    // and cap the array length to bound the SQL parameter size. The hard cap
+    // is set well above the 5 known tags to allow future expansion without
+    // becoming a DoS surface.
+    const MAX_TAGS = 20;
+    const sanitizedTags = filters.tags
+      ?.filter((t): t is string => typeof t === "string")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0)
+      .slice(0, MAX_TAGS);
 
-  // Normalise inverted ranges defensively — an inverted range can only return
-  // zero rows, which surfaces as a confusing empty state. Swap silently rather
-  // than fail closed.
-  const safePriceMin =
-    priceMin !== undefined && priceMax !== undefined && priceMin > priceMax ? priceMax : priceMin;
-  const safePriceMax =
-    priceMin !== undefined && priceMax !== undefined && priceMin > priceMax ? priceMin : priceMax;
-  const safeLotMin =
-    lotSizeMin !== undefined && lotSizeMax !== undefined && lotSizeMin > lotSizeMax
-      ? lotSizeMax
-      : lotSizeMin;
-  const safeLotMax =
-    lotSizeMin !== undefined && lotSizeMax !== undefined && lotSizeMin > lotSizeMax
-      ? lotSizeMin
-      : lotSizeMax;
+    // Normalise inverted ranges defensively — an inverted range can only return
+    // zero rows, which surfaces as a confusing empty state. Swap silently rather
+    // than fail closed.
+    const safePriceMin =
+      priceMin !== undefined && priceMax !== undefined && priceMin > priceMax ? priceMax : priceMin;
+    const safePriceMax =
+      priceMin !== undefined && priceMax !== undefined && priceMin > priceMax ? priceMin : priceMax;
+    const safeLotMin =
+      lotSizeMin !== undefined && lotSizeMax !== undefined && lotSizeMin > lotSizeMax
+        ? lotSizeMax
+        : lotSizeMin;
+    const safeLotMax =
+      lotSizeMin !== undefined && lotSizeMax !== undefined && lotSizeMin > lotSizeMax
+        ? lotSizeMin
+        : lotSizeMax;
 
-  // Build keyword search conditions with feature synonym expansion
-  let searchCondition: SQL | undefined = undefined;
-  if (filters.q && filters.q.trim().length > 0) {
-    const queryTerm = filters.q.trim();
+    // Build keyword search conditions with feature synonym expansion
+    let searchCondition: SQL | undefined = undefined;
+    if (filters.q && filters.q.trim().length > 0) {
+      const queryTerm = filters.q.trim();
 
-    // Define synonym expansion groups
-    const SYNONYM_GROUPS = [
-      {
-        keywords: /r[ií]o|river|quebrada|creek|stream/i,
-        synonyms: ["rio", "río", "river", "quebrada", "creek", "stream"],
-      },
-      {
-        keywords: /waterfall|cascada|catarata/i,
-        synonyms: ["waterfall", "waterfalls", "cascada", "cascadas", "catarata", "cataratas"],
-      },
-      {
-        keywords: /view|vista|panorama|mirador|paisaje/i,
-        synonyms: [
-          "view",
-          "views",
-          "vista",
-          "vistas",
-          "panorama",
-          "panorámica",
-          "panoramica",
-          "mirador",
-          "paisaje",
-        ],
-      },
-      {
-        keywords: /beach|playa|ocean|sea|mar|oc[eé]ano/i,
-        synonyms: ["beach", "playa", "ocean", "sea", "mar", "océano", "oceano", "costa"],
-      },
-    ];
+      // Define synonym expansion groups
+      const SYNONYM_GROUPS = [
+        {
+          keywords: /r[ií]o|river|quebrada|creek|stream/i,
+          synonyms: ["rio", "río", "river", "quebrada", "creek", "stream"],
+        },
+        {
+          keywords: /waterfall|cascada|catarata/i,
+          synonyms: ["waterfall", "waterfalls", "cascada", "cascadas", "catarata", "cataratas"],
+        },
+        {
+          keywords: /view|vista|panorama|mirador|paisaje/i,
+          synonyms: [
+            "view",
+            "views",
+            "vista",
+            "vistas",
+            "panorama",
+            "panorámica",
+            "panoramica",
+            "mirador",
+            "paisaje",
+          ],
+        },
+        {
+          keywords: /beach|playa|ocean|sea|mar|oc[eé]ano/i,
+          synonyms: ["beach", "playa", "ocean", "sea", "mar", "océano", "oceano", "costa"],
+        },
+      ];
 
-    const QUERY_STOP_WORDS = new Set([
-      "con",
-      "de",
-      "in",
-      "with",
-      "and",
-      "a",
-      "en",
-      "la",
-      "el",
-      "un",
-      "una",
-      "for",
-      "para",
-      "los",
-      "las",
-      "del",
-      "y",
-      "o",
-      "or",
-      "to",
-      "at",
-      "by",
-      "of",
-    ]);
+      const QUERY_STOP_WORDS = new Set([
+        "con",
+        "de",
+        "in",
+        "with",
+        "and",
+        "a",
+        "en",
+        "la",
+        "el",
+        "un",
+        "una",
+        "for",
+        "para",
+        "los",
+        "las",
+        "del",
+        "y",
+        "o",
+        "or",
+        "to",
+        "at",
+        "by",
+        "of",
+      ]);
 
-    // Split by whitespace and punctuation, map to lowercase and filter out stop words
-    const tokens = queryTerm
-      .split(/[\s,.\-/?!|;:]+/)
-      .map((t) => t.toLowerCase())
-      .filter((t) => t.length > 0 && !QUERY_STOP_WORDS.has(t));
+      // Split by whitespace and punctuation, map to lowercase and filter out stop words
+      const tokens = queryTerm
+        .split(/[\s,.\-/?!|;:]+/)
+        .map((t) => t.toLowerCase())
+        .filter((t) => t.length > 0 && !QUERY_STOP_WORDS.has(t));
 
-    if (tokens.length > 0) {
-      const tokenConditions = tokens.map((token) => {
-        const matchedGroup = SYNONYM_GROUPS.find((group) => group.keywords.test(token));
-        if (matchedGroup) {
-          const escapedSynonyms = matchedGroup.synonyms.map(escapeRegex);
-          const pattern = `\\y(${escapedSynonyms.join("|")})\\y`;
-          return or(
-            sql`${properties.titleEn} ~* ${pattern}`,
-            sql`${properties.titleEs} ~* ${pattern}`,
-            sql`${properties.descriptionEn} ~* ${pattern}`,
-            sql`${properties.descriptionEs} ~* ${pattern}`,
-            sql`${communities.name} ~* ${pattern}`,
-          );
-        } else {
-          const escapedToken = escapeRegex(token);
-          const pattern = `\\y(${escapedToken})\\y`;
-          return or(
-            sql`${properties.titleEn} ~* ${pattern}`,
-            sql`${properties.titleEs} ~* ${pattern}`,
-            sql`${properties.descriptionEn} ~* ${pattern}`,
-            sql`${properties.descriptionEs} ~* ${pattern}`,
-            sql`${communities.name} ~* ${pattern}`,
-          );
-        }
-      });
-      searchCondition = and(...tokenConditions);
+      if (tokens.length > 0) {
+        const tokenConditions = tokens.map((token) => {
+          const matchedGroup = SYNONYM_GROUPS.find((group) => group.keywords.test(token));
+          if (matchedGroup) {
+            const escapedSynonyms = matchedGroup.synonyms.map(escapeRegex);
+            const pattern = `\\y(${escapedSynonyms.join("|")})\\y`;
+            return or(
+              sql`${properties.titleEn} ~* ${pattern}`,
+              sql`${properties.titleEs} ~* ${pattern}`,
+              sql`${properties.descriptionEn} ~* ${pattern}`,
+              sql`${properties.descriptionEs} ~* ${pattern}`,
+              sql`${communities.name} ~* ${pattern}`,
+            );
+          } else {
+            const escapedToken = escapeRegex(token);
+            const pattern = `\\y(${escapedToken})\\y`;
+            return or(
+              sql`${properties.titleEn} ~* ${pattern}`,
+              sql`${properties.titleEs} ~* ${pattern}`,
+              sql`${properties.descriptionEn} ~* ${pattern}`,
+              sql`${properties.descriptionEs} ~* ${pattern}`,
+              sql`${communities.name} ~* ${pattern}`,
+            );
+          }
+        });
+        searchCondition = and(...tokenConditions);
+      }
     }
-  }
 
-  // Build a per-dimension condition map so we can compose facet WHERE clauses
-  // that exclude the dimension being faceted. Each entry is the SQL filter
-  // that would be applied if that dimension is set.
-  const dimConditions: Record<string, SQL | undefined> = {
-    visible: eq(properties.isVisible, true),
-    type: filters.type
-      ? inArray(properties.propertyType, getPropertyTypeEquivalents(filters.type))
-      : undefined,
-    listingType: filters.listingType ? eq(properties.listingType, filters.listingType) : undefined,
-    priceMin: safePriceMin !== undefined ? gte(properties.priceUsd, safePriceMin) : undefined,
-    priceMax: safePriceMax !== undefined ? lte(properties.priceUsd, safePriceMax) : undefined,
-    bedrooms: bedrooms !== undefined ? gte(properties.bedrooms, bedrooms) : undefined,
-    bathrooms: bathrooms !== undefined ? gte(properties.bathrooms, bathrooms) : undefined,
-    lotSizeMin: safeLotMin !== undefined ? gte(properties.lotSizeM2, safeLotMin) : undefined,
-    lotSizeMax: safeLotMax !== undefined ? lte(properties.lotSizeM2, safeLotMax) : undefined,
-    areaSlug: filters.areaSlug ? eq(properties.areaSlug, filters.areaSlug) : undefined,
-    // Story 3.4: lifestyle tag OR filter using PostgreSQL && (overlap) operator on GIN-indexed array
-    // The && operator returns rows where lifestyleTags and the filter array share at least one element
-    tags: sanitizedTags?.length
-      ? sql`${properties.lifestyleTags} && ARRAY[${sql.join(sanitizedTags, sql`, `)}]::text[]`
-      : undefined,
-    q: searchCondition,
-    bounds:
-      safeBounds != null
-        ? and(
-            gte(properties.latitude, safeBounds.south),
-            lte(properties.latitude, safeBounds.north),
-            gte(properties.longitude, safeBounds.west),
-            lte(properties.longitude, safeBounds.east),
-          )
+    // Build a per-dimension condition map so we can compose facet WHERE clauses
+    // that exclude the dimension being faceted. Each entry is the SQL filter
+    // that would be applied if that dimension is set.
+    const dimConditions: Record<string, SQL | undefined> = {
+      visible: eq(properties.isVisible, true),
+      type: filters.type
+        ? inArray(properties.propertyType, getPropertyTypeEquivalents(filters.type))
         : undefined,
-  };
+      listingType: filters.listingType
+        ? eq(properties.listingType, filters.listingType)
+        : undefined,
+      priceMin: safePriceMin !== undefined ? gte(properties.priceUsd, safePriceMin) : undefined,
+      priceMax: safePriceMax !== undefined ? lte(properties.priceUsd, safePriceMax) : undefined,
+      bedrooms: bedrooms !== undefined ? gte(properties.bedrooms, bedrooms) : undefined,
+      bathrooms: bathrooms !== undefined ? gte(properties.bathrooms, bathrooms) : undefined,
+      lotSizeMin: safeLotMin !== undefined ? gte(properties.lotSizeM2, safeLotMin) : undefined,
+      lotSizeMax: safeLotMax !== undefined ? lte(properties.lotSizeM2, safeLotMax) : undefined,
+      areaSlug: filters.areaSlug ? eq(properties.areaSlug, filters.areaSlug) : undefined,
+      // Story 3.4: lifestyle tag OR filter using PostgreSQL && (overlap) operator on GIN-indexed array
+      // The && operator returns rows where lifestyleTags and the filter array share at least one element
+      tags: sanitizedTags?.length
+        ? sql`${properties.lifestyleTags} && ARRAY[${sql.join(sanitizedTags, sql`, `)}]::text[]`
+        : undefined,
+      q: searchCondition,
+      bounds:
+        safeBounds != null
+          ? and(
+              gte(properties.latitude, safeBounds.south),
+              lte(properties.latitude, safeBounds.north),
+              gte(properties.longitude, safeBounds.west),
+              lte(properties.longitude, safeBounds.east),
+            )
+          : undefined,
+    };
 
-  // Compose conditions for the main query — every set dimension applies.
-  const conditions = Object.values(dimConditions).filter(
-    (c): c is NonNullable<typeof c> => c !== undefined,
-  );
+    // Compose conditions for the main query — every set dimension applies.
+    const conditions = Object.values(dimConditions).filter(
+      (c): c is NonNullable<typeof c> => c !== undefined,
+    );
 
-  // Determine sort order
-  let orderByClause;
-  if (filters.sort === "price_asc") {
-    orderByClause = asc(properties.priceUsd);
-  } else if (filters.sort === "price_desc") {
-    orderByClause = desc(properties.priceUsd);
-  } else {
-    // Default: newest first
-    orderByClause = desc(properties.createdAt);
-  }
+    // Determine sort order
+    let orderByClause;
+    if (filters.sort === "price_asc") {
+      orderByClause = asc(properties.priceUsd);
+    } else if (filters.sort === "price_desc") {
+      orderByClause = desc(properties.priceUsd);
+    } else {
+      // Default: newest first
+      orderByClause = desc(properties.createdAt);
+    }
 
-  const whereClause = and(...conditions);
+    const whereClause = and(...conditions);
 
-  // Main properties query — limit 20 per page with offset for pagination (Story 3.5)
-  const rows = await db
-    .select(propertySearchColumns)
-    .from(properties)
-    .leftJoin(communities, eq(properties.communityId, communities.id))
-    .where(whereClause)
-    .orderBy(orderByClause)
-    .limit(20)
-    .offset((safePage - 1) * 20);
+    // Main properties query — limit 20 per page with offset for pagination (Story 3.5)
+    const rows = await db
+      .select(propertySearchColumns)
+      .from(properties)
+      .leftJoin(communities, eq(properties.communityId, communities.id))
+      .where(whereClause)
+      .orderBy(orderByClause)
+      .limit(20)
+      .offset((safePage - 1) * 20);
 
-  const propertyItems: PropertySearchItem[] = rows.map((row) => mapPropertyRowToSearchItem(row));
+    const propertyItems: PropertySearchItem[] = rows.map((row) => mapPropertyRowToSearchItem(row));
 
-  // Facets queries — aggregation for filter count display ("Casa (12)") — AC #6
-  // Each facet dimension is computed with all OTHER dimensions applied so that
-  // the counts reflect what the user would see if they switched that
-  // dimension's value (spec: "current filter set excluding the dimension being
-  // faceted").
-  function facetWhere(excludeKey: string) {
-    const subset = Object.entries(dimConditions)
-      .filter(([k, v]) => k !== excludeKey && v !== undefined)
-      .map(([, v]) => v as NonNullable<typeof v>);
-    return and(...subset);
-  }
+    // Facets queries — aggregation for filter count display ("Casa (12)") — AC #6
+    // Each facet dimension is computed with all OTHER dimensions applied so that
+    // the counts reflect what the user would see if they switched that
+    // dimension's value (spec: "current filter set excluding the dimension being
+    // faceted").
+    function facetWhere(excludeKey: string) {
+      const subset = Object.entries(dimConditions)
+        .filter(([k, v]) => k !== excludeKey && v !== undefined)
+        .map(([, v]) => v as NonNullable<typeof v>);
+      return and(...subset);
+    }
 
-  // byType: apply every filter except `type` so user can see counts of other
-  // types matching the rest of their criteria.
-  const byTypeRows = await db
-    .select({
-      value: properties.propertyType,
-      count: sql<number>`cast(count(*) as integer)`,
-    })
-    .from(properties)
-    .leftJoin(communities, eq(properties.communityId, communities.id))
-    .where(facetWhere("type"))
-    .groupBy(properties.propertyType);
+    // byType: apply every filter except `type` so user can see counts of other
+    // types matching the rest of their criteria.
+    const byTypeRows = await db
+      .select({
+        value: properties.propertyType,
+        count: sql<number>`cast(count(*) as integer)`,
+      })
+      .from(properties)
+      .leftJoin(communities, eq(properties.communityId, communities.id))
+      .where(facetWhere("type"))
+      .groupBy(properties.propertyType);
 
-  // byBedrooms: apply every filter except `bedrooms`
-  const byBedroomsRows = await db
-    .select({
-      value: properties.bedrooms,
-      count: sql<number>`cast(count(*) as integer)`,
-    })
-    .from(properties)
-    .leftJoin(communities, eq(properties.communityId, communities.id))
-    .where(and(facetWhere("bedrooms"), isNotNull(properties.bedrooms)))
-    .groupBy(properties.bedrooms);
+    // byBedrooms: apply every filter except `bedrooms`
+    const byBedroomsRows = await db
+      .select({
+        value: properties.bedrooms,
+        count: sql<number>`cast(count(*) as integer)`,
+      })
+      .from(properties)
+      .leftJoin(communities, eq(properties.communityId, communities.id))
+      .where(and(facetWhere("bedrooms"), isNotNull(properties.bedrooms)))
+      .groupBy(properties.bedrooms);
 
-  // byBathrooms: apply every filter except `bathrooms`
-  const byBathroomsRows = await db
-    .select({
-      value: properties.bathrooms,
-      count: sql<number>`cast(count(*) as integer)`,
-    })
-    .from(properties)
-    .leftJoin(communities, eq(properties.communityId, communities.id))
-    .where(and(facetWhere("bathrooms"), isNotNull(properties.bathrooms)))
-    .groupBy(properties.bathrooms);
+    // byBathrooms: apply every filter except `bathrooms`
+    const byBathroomsRows = await db
+      .select({
+        value: properties.bathrooms,
+        count: sql<number>`cast(count(*) as integer)`,
+      })
+      .from(properties)
+      .leftJoin(communities, eq(properties.communityId, communities.id))
+      .where(and(facetWhere("bathrooms"), isNotNull(properties.bathrooms)))
+      .groupBy(properties.bathrooms);
 
-  // byListingType: apply every filter except `listingType`
-  const byListingTypeRows = await db
-    .select({
-      value: properties.listingType,
-      count: sql<number>`cast(count(*) as integer)`,
-    })
-    .from(properties)
-    .leftJoin(communities, eq(properties.communityId, communities.id))
-    .where(and(facetWhere("listingType"), isNotNull(properties.listingType)))
-    .groupBy(properties.listingType);
+    // byListingType: apply every filter except `listingType`
+    const byListingTypeRows = await db
+      .select({
+        value: properties.listingType,
+        count: sql<number>`cast(count(*) as integer)`,
+      })
+      .from(properties)
+      .leftJoin(communities, eq(properties.communityId, communities.id))
+      .where(and(facetWhere("listingType"), isNotNull(properties.listingType)))
+      .groupBy(properties.listingType);
 
-  // Total count — separate aggregation so `total` reflects the true result
-  // count (not just the page slice). Pagination is Story 3.5.
-  const totalRows = await db
-    .select({ count: sql<number>`cast(count(*) as integer)` })
-    .from(properties)
-    .leftJoin(communities, eq(properties.communityId, communities.id))
-    .where(whereClause);
-  const total = totalRows[0]?.count ?? propertyItems.length;
+    // Total count — separate aggregation so `total` reflects the true result
+    // count (not just the page slice). Pagination is Story 3.5.
+    const totalRows = await db
+      .select({ count: sql<number>`cast(count(*) as integer)` })
+      .from(properties)
+      .leftJoin(communities, eq(properties.communityId, communities.id))
+      .where(whereClause);
+    const total = totalRows[0]?.count ?? propertyItems.length;
 
-  const spanishTypeCounts: Record<string, number> = {};
-  for (const row of byTypeRows) {
-    if (row.value === null) continue;
-    const spanishType = DB_TYPE_TO_SPANISH[row.value] || row.value;
-    spanishTypeCounts[spanishType] = (spanishTypeCounts[spanishType] || 0) + row.count;
-  }
-  const byTypeFacets = Object.entries(spanishTypeCounts).map(([value, count]) => ({
-    value,
-    count,
-  }));
+    const spanishTypeCounts: Record<string, number> = {};
+    for (const row of byTypeRows) {
+      if (row.value === null) continue;
+      const spanishType = DB_TYPE_TO_SPANISH[row.value] || row.value;
+      spanishTypeCounts[spanishType] = (spanishTypeCounts[spanishType] || 0) + row.count;
+    }
+    const byTypeFacets = Object.entries(spanishTypeCounts).map(([value, count]) => ({
+      value,
+      count,
+    }));
 
-  const facets: FilterFacets = {
-    byType: byTypeFacets,
-    byBedrooms: byBedroomsRows
-      .filter((r) => r.value !== null)
-      .map((r) => ({ value: r.value as number, count: r.count })),
-    byBathrooms: byBathroomsRows
-      .filter((r) => r.value !== null)
-      .map((r) => ({ value: r.value as number, count: r.count })),
-    byListingType: byListingTypeRows
-      .filter((r) => r.value !== null)
-      .map((r) => ({ value: r.value as string, count: r.count })),
-  };
+    const facets: FilterFacets = {
+      byType: byTypeFacets,
+      byBedrooms: byBedroomsRows
+        .filter((r) => r.value !== null)
+        .map((r) => ({ value: r.value as number, count: r.count })),
+      byBathrooms: byBathroomsRows
+        .filter((r) => r.value !== null)
+        .map((r) => ({ value: r.value as number, count: r.count })),
+      byListingType: byListingTypeRows
+        .filter((r) => r.value !== null)
+        .map((r) => ({ value: r.value as string, count: r.count })),
+    };
 
-  // Trigger tracking asynchronously in the background (fire and forget)
-  const searchMode = filters.q ? "smart" : "traditional";
-  trackSearchInBackground({
-    rawQuery: filters.q,
-    parsedFilters: filters,
-    searchMode,
-    resultsCount: total,
-  });
+    // Trigger tracking asynchronously in the background (fire and forget)
+    const searchMode = filters.q ? "smart" : "traditional";
+    trackSearchInBackground({
+      rawQuery: filters.q,
+      parsedFilters: filters,
+      searchMode,
+      resultsCount: total,
+    });
 
     return {
       properties: propertyItems,

--- a/src/app/actions/search-actions.ts
+++ b/src/app/actions/search-actions.ts
@@ -221,8 +221,9 @@ export async function searchProperties(
   page = 1,
   bounds?: RawBounds,
 ): Promise<SearchResult> {
-  // Sanitize page parameter — clamp to >= 1
-  const safePage = Math.max(1, Math.floor(sanitizeNumber(page) ?? 1));
+  try {
+    // Sanitize page parameter — clamp to >= 1
+    const safePage = Math.max(1, Math.floor(sanitizeNumber(page) ?? 1));
 
   // If bounds are provided, filter properties inside the bounds
   const safeBounds = bounds != null ? sanitizeBounds(bounds) : null;
@@ -383,7 +384,12 @@ export async function searchProperties(
     q: searchCondition,
     bounds:
       safeBounds != null
-        ? sql`${properties.geo} && ST_MakeEnvelope(${safeBounds.west}, ${safeBounds.south}, ${safeBounds.east}, ${safeBounds.north}, 4326)::geography`
+        ? and(
+            gte(properties.latitude, safeBounds.south),
+            lte(properties.latitude, safeBounds.north),
+            gte(properties.longitude, safeBounds.west),
+            lte(properties.longitude, safeBounds.east),
+          )
         : undefined,
   };
 
@@ -516,11 +522,24 @@ export async function searchProperties(
     resultsCount: total,
   });
 
-  return {
-    properties: propertyItems,
-    total,
-    facets,
-  };
+    return {
+      properties: propertyItems,
+      total,
+      facets,
+    };
+  } catch (error) {
+    console.error("Database query failed in searchProperties:", error);
+    return {
+      properties: [],
+      total: 0,
+      facets: {
+        byType: [],
+        byBedrooms: [],
+        byBathrooms: [],
+        byListingType: [],
+      },
+    };
+  }
 }
 
 /**
@@ -530,19 +549,24 @@ export async function searchProperties(
  * AC #7
  */
 export async function getAvailableAreas(): Promise<{ slug: string; label: string }[]> {
-  const rows = await db
-    .select({ areaSlug: properties.areaSlug })
-    .from(properties)
-    .where(and(eq(properties.isVisible, true), isNotNull(properties.areaSlug)))
-    .groupBy(properties.areaSlug);
+  try {
+    const rows = await db
+      .select({ areaSlug: properties.areaSlug })
+      .from(properties)
+      .where(and(eq(properties.isVisible, true), isNotNull(properties.areaSlug)))
+      .groupBy(properties.areaSlug);
 
-  return rows
-    .filter((r): r is { areaSlug: string } => r.areaSlug !== null && r.areaSlug !== "")
-    .map((r) => ({
-      slug: r.areaSlug,
-      label: formatAreaLabel(r.areaSlug),
-    }))
-    .sort((a, b) => a.label.localeCompare(b.label));
+    return rows
+      .filter((r): r is { areaSlug: string } => r.areaSlug !== null && r.areaSlug !== "")
+      .map((r) => ({
+        slug: r.areaSlug,
+        label: formatAreaLabel(r.areaSlug),
+      }))
+      .sort((a, b) => a.label.localeCompare(b.label));
+  } catch (error) {
+    console.error("Database query failed in getAvailableAreas:", error);
+    return [];
+  }
 }
 
 /**


### PR DESCRIPTION
This PR fixes three critical bugs where listings were not displaying on dev.remax-altitud.cr:

1. **Search Page Grid failure**: Replaced the PostGIS geography overlap operator `&&` (which was causing database exceptions on the server due to coordinate type incompatibilities) with standard, robust lat/lng range comparisons (`gte` and `lte` on `latitude` and `longitude` columns), matching the pattern used successfully in `getPropertiesForMap`.
2. **Resilient Server Actions**: Wrapped the database queries in `searchProperties` and `getAvailableAreas` in try-catch blocks to prevent unhandled database exceptions from completely crashing Server Actions.
3. **Homepage Sections (New Listings & Featured Communities)**: Once this PR is merged, Coolify will build and deploy the container successfully. Since Sebastian's `ON CONFLICT` fix is now present, the migration runner will successfully apply all remaining migrations (such as `0019_boring_sleepwalker.sql` which adds the `listing_type` and community property columns). This will immediately resolve the New Listings and Featured Communities missing columns issue on the homepage.