### PR TITLE
Fix : Idempotent Migration and Defensive Query Error Handling

### DIFF
--- a/src/lib/db/migrations/0019_boring_sleepwalker.sql
+++ b/src/lib/db/migrations/0019_boring_sleepwalker.sql
@@ -1,4 +1,4 @@
-CREATE TABLE "shortlist_events" (
+CREATE TABLE IF NOT EXISTS "shortlist_events" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"property_id" uuid NOT NULL,
 	"locale" text NOT NULL,
@@ -6,13 +6,16 @@ CREATE TABLE "shortlist_events" (
 	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
-DROP INDEX "idx_properties_search";--> statement-breakpoint
-ALTER TABLE "properties" ADD COLUMN "listing_type" text DEFAULT 'Sale' NOT NULL;--> statement-breakpoint
-ALTER TABLE "communities" ADD COLUMN "property_types_en" text DEFAULT '' NOT NULL;--> statement-breakpoint
-ALTER TABLE "communities" ADD COLUMN "property_types_es" text DEFAULT '' NOT NULL;--> statement-breakpoint
-ALTER TABLE "communities" ADD COLUMN "size_min_m2" double precision;--> statement-breakpoint
-ALTER TABLE "communities" ADD COLUMN "size_max_m2" double precision;--> statement-breakpoint
-ALTER TABLE "shortlist_events" ADD CONSTRAINT "shortlist_events_property_id_properties_id_fk" FOREIGN KEY ("property_id") REFERENCES "public"."properties"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
-CREATE INDEX "idx_shortlist_events_prop_action" ON "shortlist_events" USING btree ("property_id","action","created_at");--> statement-breakpoint
-CREATE INDEX "idx_shortlist_events_created" ON "shortlist_events" USING btree ("created_at");--> statement-breakpoint
-CREATE INDEX "idx_properties_search" ON "properties" USING btree ("is_visible","property_type","price_usd","area_slug","listing_type") WHERE "properties"."is_visible" = true;
+DROP INDEX IF EXISTS "idx_properties_search";--> statement-breakpoint
+ALTER TABLE "properties" ADD COLUMN IF NOT EXISTS "listing_type" text DEFAULT 'Sale' NOT NULL;--> statement-breakpoint
+ALTER TABLE "communities" ADD COLUMN IF NOT EXISTS "property_types_en" text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE "communities" ADD COLUMN IF NOT EXISTS "property_types_es" text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE "communities" ADD COLUMN IF NOT EXISTS "size_min_m2" double precision;--> statement-breakpoint
+ALTER TABLE "communities" ADD COLUMN IF NOT EXISTS "size_max_m2" double precision;--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "shortlist_events" ADD CONSTRAINT "shortlist_events_property_id_properties_id_fk" FOREIGN KEY ("property_id") REFERENCES "public"."properties"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_shortlist_events_prop_action" ON "shortlist_events" USING btree ("property_id","action","created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_shortlist_events_created" ON "shortlist_events" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_properties_search" ON "properties" USING btree ("is_visible","property_type","price_usd","area_slug","listing_type") WHERE "properties"."is_visible" = true;

--- a/src/lib/db/queries/properties.ts
+++ b/src/lib/db/queries/properties.ts
@@ -850,22 +850,27 @@ export async function fetchShortlistAnalyticsData(filters: {
  * @param limit - Maximum number of properties to fetch (default 3)
  */
 export async function getFeaturedProperties(limit = 3): Promise<PropertySearchItem[]> {
-  const rows = await db
-    .select(propertySearchColumns)
-    .from(properties)
-    .where(and(eq(properties.isVisible, true), eq(properties.isFeatured, true)))
-    .orderBy(desc(properties.syncedAt))
-    .limit(limit);
-
-  if (rows.length === 0) {
-    const fallbackRows = await db
+  try {
+    const rows = await db
       .select(propertySearchColumns)
       .from(properties)
-      .where(eq(properties.isVisible, true))
+      .where(and(eq(properties.isVisible, true), eq(properties.isFeatured, true)))
       .orderBy(desc(properties.syncedAt))
       .limit(limit);
-    return fallbackRows.map(mapPropertyRowToSearchItem);
-  }
 
-  return rows.map(mapPropertyRowToSearchItem);
+    if (rows.length === 0) {
+      const fallbackRows = await db
+        .select(propertySearchColumns)
+        .from(properties)
+        .where(eq(properties.isVisible, true))
+        .orderBy(desc(properties.syncedAt))
+        .limit(limit);
+      return fallbackRows.map(mapPropertyRowToSearchItem);
+    }
+
+    return rows.map(mapPropertyRowToSearchItem);
+  } catch (error) {
+    console.error("getFeaturedProperties: DB query failed (missing column?):", error);
+    return [];
+  }
 }


### PR DESCRIPTION
# Fix Missing Database Columns

## Problem
Three features on `dev.remax-altitud.cr` are broken:
1. **New Listings** on the homepage → shows "coming soon" placeholders
2. **Featured Communities** on the homepage → shows "coming soon" placeholders
3. **Search grid** on `/en/search` → shows "No properties found" (but map pins work)

## Root Cause
Database migrations are stuck. Migration `0019_add_rise_community` (idx 16) failed on a duplicate key constraint, which blocked all subsequent migrations — including `0019_boring_sleepwalker` (idx 18) which adds:
- `listing_type` column to `properties`
- `property_types_en`, `property_types_es`, `size_min_m2`, `size_max_m2` columns to `communities`

The Drizzle ORM schema references these columns, so every query that touches them throws "column does not exist" and gets caught by try-catch blocks → empty results. The map works because `getPropertiesForMap()` hand-picks only original columns.

## Changes Made

### 1. Idempotent Migration SQL
**File**: `src/lib/db/migrations/0019_boring_sleepwalker.sql`

Added safety guards so the migration can re-run even if partially applied:

```diff
-CREATE TABLE "shortlist_events" (
+CREATE TABLE IF NOT EXISTS "shortlist_events" (

-DROP INDEX "idx_properties_search";
+DROP INDEX IF EXISTS "idx_properties_search";

-ALTER TABLE "properties" ADD COLUMN "listing_type" ...
+ALTER TABLE "properties" ADD COLUMN IF NOT EXISTS "listing_type" ...

-ALTER TABLE "communities" ADD COLUMN "property_types_en" ...
+ALTER TABLE "communities" ADD COLUMN IF NOT EXISTS "property_types_en" ...

-CREATE INDEX "idx_shortlist_events_prop_action" ...
+CREATE INDEX IF NOT EXISTS "idx_shortlist_events_prop_action" ...
```

Foreign key constraint wrapped in `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN NULL; END $$;`

### 2. Defensive Error Handling
**File**: `src/lib/db/queries/properties.ts`

Wrapped `getFeaturedProperties()` in try-catch to match the pattern used by all other query functions. Returns `[]` on DB error instead of crashing.

## Verification
- ✅ TypeScript typecheck — no errors
- ✅ Prettier format check — all files pass
- ✅ Production build — compiled successfully

## ⚠️ Critical Next Step

> **You need to redeploy/restart the Coolify container.** These code changes make the migration safe to re-run, but the migration runner only executes on container startup (`node dist/migrate.mjs && node server.js`). Once redeployed:
> 1. Migration idx 16 succeeds (RISE community ON CONFLICT fix already merged)
> 2. Migration idx 18 applies the missing columns
> 3. All three features start working