### PR TITLE
Fix : Correct out-of-order migration journal timestamps

### DIFF
--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -117,35 +117,35 @@
     {
       "idx": 16,
       "version": "7",
-      "when": 1780241309132,
+      "when": 1780452100000,
       "tag": "0019_add_rise_community",
       "breakpoints": true
     },
     {
       "idx": 17,
       "version": "7",
-      "when": 1780453000000,
+      "when": 1780452200000,
       "tag": "0020_update_uvita_area_guide",
       "breakpoints": true
     },
     {
       "idx": 18,
       "version": "7",
-      "when": 1780264761308,
+      "when": 1780452300000,
       "tag": "0019_boring_sleepwalker",
       "breakpoints": true
     },
     {
       "idx": 19,
       "version": "7",
-      "when": 1780454000000,
+      "when": 1780452400000,
       "tag": "0019_update_featured_communities",
       "breakpoints": true
     },
     {
       "idx": 20,
       "version": "7",
-      "when": 1780455000000,
+      "when": 1780452500000,
       "tag": "0021_update_dominical_area_guide_tokenized",
       "breakpoints": true
     }


### PR DESCRIPTION
# Fix Out-of-Order Migration Journal Timestamps

## Problem
Three features on `dev.remax-altitud.cr` are broken despite multiple redeploys:
1. **New Listings** on the homepage → shows "coming soon" placeholders
2. **Featured Communities** on the homepage → shows "coming soon" placeholders
3. **Search grid** on `/en/search` → shows "No properties found" (map pins work)

Previous fix (PR #249) made migration SQL idempotent with `IF NOT EXISTS` guards and added defensive try-catch, but the migrations were **never executing at all**.

## Root Cause

Drizzle ORM's migration runner determines which migrations to apply by comparing each migration's `folderMillis` (the `when` field in `_journal.json`) against the `created_at` of the last successfully applied migration. It only runs migrations where:

```js
Number(lastDbMigration.created_at) < migration.folderMillis
```

Two critical migrations had `when` timestamps that were **earlier** than an already-applied migration (idx 15), causing them to be **permanently skipped**:

| idx | Migration | `when` timestamp | Status |
|-----|-----------|-----------------|--------|
| 15 | `0016_add_villas_san_miguel` | `1780452000000` | ✅ Applied |
| **16** | **`0019_add_rise_community`** | **`1780241309132`** | ❌ **Skipped** (before idx 15!) |
| 17 | `0020_update_uvita_area_guide` | `1780453000000` | ✅ Runs |
| **18** | **`0019_boring_sleepwalker`** | **`1780264761308`** | ❌ **Skipped** (before idx 15!) |
| 19 | `0019_update_featured_communities` | `1780454000000` | ✅ Runs (but fails — depends on idx 18) |
| 20 | `0021_update_dominical_area_guide_tokenized` | `1780455000000` | ✅ Runs |

Migration idx 18 (`0019_boring_sleepwalker`) adds the `listing_type` column to `properties` and the `property_types_en/es`, `size_min_m2`, `size_max_m2` columns to `communities`. Without these columns, all queries using `propertySearchColumns` or `properties.listingType` fail silently via try-catch → empty results.

## Fix

**File**: `src/lib/db/migrations/meta/_journal.json`

Corrected the `when` timestamps to be monotonically increasing, ensuring all migrations run in journal order:

```diff
  idx 15: 1780452000000  (unchanged — already applied)
- idx 16: 1780241309132  → SKIPPED
+ idx 16: 1780452100000  → will now run after idx 15
- idx 17: 1780453000000
+ idx 17: 1780452200000  → preserves order
- idx 18: 1780264761308  → SKIPPED
+ idx 18: 1780452300000  → will now run after idx 17
- idx 19: 1780454000000
+ idx 19: 1780452400000
- idx 20: 1780455000000
+ idx 20: 1780452500000
```

## Why This Is Safe

- The SQL files themselves already have `IF NOT EXISTS` / `ON CONFLICT` guards (from PR #249), so re-running them against a partially-migrated database is safe.
- The Drizzle `__drizzle_migrations` table in the database only tracks the `created_at` of the last migration that ran — all migrations with `folderMillis` greater than that value will execute.
- The timestamps are only used for ordering comparisons, not for any semantic purpose.

## Verification
- ✅ TypeScript typecheck — 0 errors
- ✅ Prettier format check — all files pass
- ✅ Production build — compiled successfully

## After Merge
Redeploy/restart the Coolify container. On startup, `node dist/migrate.mjs` will:
1. See that the last applied migration has `created_at = 1780452000000`
2. Run idx 16 (`1780452100000`) — RISE community seed (ON CONFLICT safe)
3. Run idx 17 (`1780452200000`) — Uvita area guide update
4. Run idx 18 (`1780452300000`) — adds missing columns (`listing_type`, community details)
5. Run idx 19 (`1780452400000`) — updates featured community data
6. Run idx 20 (`1780452500000`) — Dominical tokenized area guide
7. All three broken features immediately start working
