### PR TITLE
Fix : Correct migration timestamps to run skipped migrations

### DIFF
--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -117,35 +117,35 @@
     {
       "idx": 16,
       "version": "7",
-      "when": 1780452100000,
+      "when": 1780456000000,
       "tag": "0019_add_rise_community",
       "breakpoints": true
     },
     {
       "idx": 17,
       "version": "7",
-      "when": 1780452200000,
+      "when": 1780453000000,
       "tag": "0020_update_uvita_area_guide",
       "breakpoints": true
     },
     {
       "idx": 18,
       "version": "7",
-      "when": 1780452300000,
+      "when": 1780457000000,
       "tag": "0019_boring_sleepwalker",
       "breakpoints": true
     },
     {
       "idx": 19,
       "version": "7",
-      "when": 1780452400000,
+      "when": 1780454000000,
       "tag": "0019_update_featured_communities",
       "breakpoints": true
     },
     {
       "idx": 20,
       "version": "7",
-      "when": 1780452500000,
+      "when": 1780455000000,
       "tag": "0021_update_dominical_area_guide_tokenized",
       "breakpoints": true
     }


### PR DESCRIPTION
# Fix: Place Skipped Migrations After Highest Recorded Timestamp

## Problem
Three features on `dev.remax-altitud.cr` remain broken despite PR #249 and PR #250:
1. **New Listings** on homepage → "coming soon" placeholders
2. **Featured Communities** on homepage → "coming soon" placeholders  
3. **Search grid** → "No properties found" (map pins work fine)

## Why PR #250 Didn't Work

PR #250 made all migration timestamps monotonically increasing, but **lowered the timestamps below what was already recorded in the production database**. Drizzle's migration runner only executes migrations where `folderMillis > last_applied_created_at`. By lowering timestamps that had already been recorded with higher values, ALL migrations became permanently skipped.

## Root Cause (Drizzle internals)

Drizzle's migration logic (`pg-core/dialect.js`):
```js
const lastDbMigration = dbMigrations[0]; // SELECT ... ORDER BY created_at DESC LIMIT 1
for (const migration of migrations) {
  if (Number(lastDbMigration.created_at) < migration.folderMillis) {
    // execute + record
  }
}
```

Two migrations (`0019_add_rise_community` and `0019_boring_sleepwalker`) originally had `when` timestamps EARLIER than already-applied migrations, so they were never executed. The previous fix accidentally lowered ALL timestamps, making the problem worse.

## Fix

**Strategy**: Keep original timestamps for migrations that may have already been applied (idx 17, 19, 20). Move the two skipped migrations (idx 16 and 18) to timestamps AFTER the highest existing one (`1780455000000`):

| idx | Migration | Old `when` | New `when` | Why |
|-----|-----------|-----------|-----------|-----|
| 15 | `0016_add_villas_san_miguel` | `1780452000000` | `1780452000000` | Already applied, unchanged |
| **16** | **`0019_add_rise_community`** | `1780241309132` | **`1780456000000`** | **Was being skipped** |
| 17 | `0020_update_uvita_area_guide` | `1780453000000` | `1780453000000` | Restored to original |
| **18** | **`0019_boring_sleepwalker`** | `1780264761308` | **`1780457000000`** | **Was being skipped** |
| 19 | `0019_update_featured_communities` | `1780454000000` | `1780454000000` | Restored to original |
| 20 | `0021_update_dominical_area_guide_tokenized` | `1780455000000` | `1780455000000` | Restored to original |

## Why This Is Safe

- All migration SQL files have `IF NOT EXISTS`, `ON CONFLICT`, and idempotent `UPDATE` statements (from PR #249)
- If any of idx 17/19/20 re-run, they succeed harmlessly
- After successful execution, idx 18 (`1780457000000`) becomes the highest `created_at`, preventing any re-execution on subsequent deploys

## Verification
- ✅ TypeScript typecheck — 0 errors
- ✅ Prettier format check — all files pass
- ✅ Production build — compiled successfully

## After Merge
Redeploy/restart the Coolify container. The migration runner will execute the two previously-skipped migrations, adding the missing `listing_type` column to `properties` and community detail columns — fixing all three broken features.
