### PR TITLE
Fix : CRC Currency Conversion and Search Layout

### DIFF
--- a/src/components/listing/listing-detail-layout.tsx
+++ b/src/components/listing/listing-detail-layout.tsx
@@ -68,7 +68,8 @@ export async function ListingDetailLayout({
   const images = normalizePropertyImages(property.images, title);
 
   const apiRaw = property.apiRaw as Record<string, unknown> | undefined;
-  const originalPriceColones = apiRaw?.ListPrice ? Number(apiRaw.ListPrice) : null;
+  const originalPriceColones =
+    property.currency === "CRC" && apiRaw?.ListPrice ? Number(apiRaw.ListPrice) : null;
 
   // ZMT badge
   const zmtVisual = property.zmtStatus ? ZMT_VISUAL[property.zmtStatus] : null;

--- a/src/components/property/property-card.tsx
+++ b/src/components/property/property-card.tsx
@@ -34,7 +34,18 @@ const BEACH_SLUGS = new Set([
 
 const MOUNTAIN_SLUGS = new Set(["perez-zeledon", "tinamastes-platanillo"]);
 
-const LAND_TYPES = new Set(["Lote", "Terreno", "Finca", "Lot", "Lot/Land", "Land", "Farm", "Ranch", "Rural area", "Terrenos"]);
+const LAND_TYPES = new Set([
+  "Lote",
+  "Terreno",
+  "Finca",
+  "Lot",
+  "Lot/Land",
+  "Land",
+  "Farm",
+  "Ranch",
+  "Rural area",
+  "Terrenos",
+]);
 
 /** Bi-directional property type display labels (EN ↔ ES) */
 const TYPE_DISPLAY: Record<string, { en: string; es: string }> = {

--- a/src/components/property/property-card.tsx
+++ b/src/components/property/property-card.tsx
@@ -34,7 +34,31 @@ const BEACH_SLUGS = new Set([
 
 const MOUNTAIN_SLUGS = new Set(["perez-zeledon", "tinamastes-platanillo"]);
 
-const LAND_TYPES = new Set(["Lote", "Terreno", "Finca"]);
+const LAND_TYPES = new Set(["Lote", "Terreno", "Finca", "Lot", "Lot/Land", "Land", "Farm", "Ranch", "Rural area", "Terrenos"]);
+
+/** Bi-directional property type display labels (EN ↔ ES) */
+const TYPE_DISPLAY: Record<string, { en: string; es: string }> = {
+  Casa: { en: "House", es: "Casa" },
+  House: { en: "House", es: "Casa" },
+  "House/Villa": { en: "House", es: "Casa" },
+  Residential: { en: "House", es: "Casa" },
+  Lote: { en: "Lot", es: "Lote" },
+  Lot: { en: "Lot", es: "Lote" },
+  "Lot/Land": { en: "Lot", es: "Lote" },
+  Land: { en: "Land", es: "Terreno" },
+  Terreno: { en: "Land", es: "Terreno" },
+  Terrenos: { en: "Land", es: "Terreno" },
+  Finca: { en: "Farm/Ranch", es: "Finca" },
+  Farm: { en: "Farm/Ranch", es: "Finca" },
+  Ranch: { en: "Farm/Ranch", es: "Finca" },
+  "Rural area": { en: "Farm/Ranch", es: "Finca" },
+  Apartamento: { en: "Apartment", es: "Apartamento" },
+  Apartment: { en: "Apartment", es: "Apartamento" },
+  Condominium: { en: "Condo", es: "Condominio" },
+  Condo: { en: "Condo", es: "Condominio" },
+  Comercial: { en: "Commercial", es: "Comercial" },
+  Commercial: { en: "Commercial", es: "Comercial" },
+};
 
 /**
  * Determine region from area slug.
@@ -196,7 +220,8 @@ export function PropertyCard({
   const usdPrice = formatUSD(property.priceUsd || 0, locale);
 
   const apiRaw = property.apiRaw as Record<string, unknown> | undefined;
-  const originalPriceColones = apiRaw?.ListPrice ? Number(apiRaw.ListPrice) : null;
+  const originalPriceColones =
+    property.currency === "CRC" && apiRaw?.ListPrice ? Number(apiRaw.ListPrice) : null;
 
   // Build the short description specs line
   const parts: string[] = [];
@@ -221,16 +246,10 @@ export function PropertyCard({
   }
 
   // Add translated property type
-  const typeTranslated =
-    locale === "es"
-      ? property.propertyType || "Propiedad"
-      : property.propertyType === "Casa"
-        ? "House"
-        : property.propertyType === "Lote"
-          ? "Lot"
-          : property.propertyType === "Finca"
-            ? "Farm/Ranch"
-            : property.propertyType;
+  const typeEntry = TYPE_DISPLAY[property.propertyType || ""];
+  const typeTranslated = typeEntry
+    ? typeEntry[locale === "es" ? "es" : "en"]
+    : property.propertyType || (locale === "es" ? "Propiedad" : "Property");
   parts.push(typeTranslated);
 
   const shortDescription = parts.join(" | ");

--- a/src/components/search/search-page-client.tsx
+++ b/src/components/search/search-page-client.tsx
@@ -153,7 +153,7 @@ export function SearchPageClient() {
   }, []);
 
   return (
-    <div className="flex flex-col overscroll-none h-[calc(100vh-var(--header-height))]">
+    <div className="flex flex-col overflow-hidden overscroll-none h-[calc(100vh-var(--header-height))]">
       <SearchFilterBar facets={facets} areas={areas} />
       <SplitViewLayout
         viewMode={viewMode}

--- a/src/components/search/split-view-layout.tsx
+++ b/src/components/search/split-view-layout.tsx
@@ -148,7 +148,7 @@ export function SplitViewLayout({
       )}
 
       {/* Split-view container */}
-      <div className="relative flex flex-row flex-1 min-h-0">
+      <div className="relative flex flex-row flex-1 min-h-0 h-full">
         {/* Map panel */}
         <div
           data-testid="map-panel"
@@ -184,7 +184,7 @@ export function SplitViewLayout({
             // Desktop: show in split/grid mode, hide in full-map mode
             gridHidden ? "lg:hidden" : mapHidden ? "lg:w-full lg:block" : "lg:w-[65%] lg:block",
             "overflow-y-auto",
-            "lg:h-full",
+            "h-full",
           )}
         >
           {/* Story 3.5: render PropertyGrid when filterProperties provided, else skeleton */}


### PR DESCRIPTION
# Fix Currency Conversion for CRC and Search Layout

## Overview

Fixes a critical bug where USD-listed properties showed incorrect prices when the user switched to Costa Rican Colones (CRC). Also includes search page layout overflow fixes and expanded bilingual property type labels.

## Changes

### Currency Conversion Bug Fix

#### `src/components/property/property-card.tsx`
- **Root cause**: `originalPriceColones` was unconditionally set from `apiRaw.ListPrice` regardless of the property's actual currency. For a USD $30,000 property, `ListPrice` = 30,000, so switching to CRC displayed ₡30,000 instead of ₡15,450,000.
- **Fix**: Only use `apiRaw.ListPrice` as the original colones price when `property.currency === "CRC"`. For USD properties, `null` is passed so the conversion formula (`priceUsd × 515`) kicks in.
- **Additional improvements**: Expanded `LAND_TYPES` set to include English API variants (`Lot`, `Land`, `Farm`, `Ranch`, `Rural area`, `Terrenos`). Added `TYPE_DISPLAY` bilingual lookup map for proper EN↔ES property type labels on cards.

#### `src/components/listing/listing-detail-layout.tsx`
- Same currency fix applied: only derive `originalPriceColones` from `apiRaw.ListPrice` when the property's stored currency is `"CRC"`.

### Search Page Layout Fixes

#### `src/components/search/search-page-client.tsx`
- Added `overflow-hidden` to the search page container to prevent scrollbar bleed.

#### `src/components/search/split-view-layout.tsx`
- Set `h-full` on the split-view flex container for consistent height.
- Changed cards panel height class from `lg:h-full` to `h-full` to work across all viewports.

## Testing

- TypeScript compilation verified with `npx tsc --noEmit` — zero errors.
- Production build verified with `npm run build`.
- Lint checked — no new lint issues in changed files.

| Currency | Before (bug) | After (fix) |
|----------|-------------|-------------|
| USD | $30,000 ✅ | $30,000 ✅ |
| EUR | €27,600 ✅ | €27,600 ✅ |
| CRC | ₡30,000 ❌ | ₡15,450,000 ✅ |