### PR TITLE
Fix : Search Page Scroll, Lot Size Display, Currency Conversion & Listing Type

### DIFF
--- a/src/app/api/retroactive-listing-type/route.ts
+++ b/src/app/api/retroactive-listing-type/route.ts
@@ -1,0 +1,120 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db/client";
+import { properties } from "@/lib/db/schema/properties";
+import { eq } from "drizzle-orm";
+
+// Force dynamic rendering — this route must never be statically generated.
+export const dynamic = "force-dynamic";
+
+/**
+ * Resolves listing type from raw API data and title heuristics.
+ * Mirrors the logic in src/lib/sync/schemas/property.ts → resolveListingType()
+ * but operates on the stored apiRaw JSONB column.
+ */
+function resolveListingTypeFromRaw(apiRaw: Record<string, unknown>, titleEn: string, titleEs: string): "Sale" | "Lease" {
+  // 1. ContractType_en
+  const ctEn = typeof apiRaw.ContractType_en === "string" ? apiRaw.ContractType_en.trim() : null;
+  if (ctEn) {
+    if (/lease|rent/i.test(ctEn)) return "Lease";
+    if (/sale|sell/i.test(ctEn)) return "Sale";
+  }
+
+  // 2. ContractType_es
+  const ctEs = typeof apiRaw.ContractType_es === "string" ? apiRaw.ContractType_es.trim() : null;
+  if (ctEs) {
+    if (/alquiler|arriendo|renta/i.test(ctEs)) return "Lease";
+    if (/venta/i.test(ctEs)) return "Sale";
+  }
+
+  // 3. ListingContractType numeric ID
+  const lcType = typeof apiRaw.ListingContractType === "number" ? apiRaw.ListingContractType : null;
+  if (lcType === 2) return "Lease";
+  if (lcType === 1) return "Sale";
+
+  // 4. Title heuristic
+  const titleText = `${titleEn} ${titleEs}`.toLowerCase();
+  if (/\bfor rent\b|\bfor lease\b|\brental\b|\balquiler\b|\barriendo\b|\ben renta\b/.test(titleText)) {
+    return "Lease";
+  }
+
+  return "Sale";
+}
+
+/**
+ * GET /api/retroactive-listing-type
+ *
+ * Retroactively fixes listing_type for all properties by re-evaluating
+ * the raw API data and title heuristics. This fixes properties that were
+ * incorrectly classified as "Sale" when they are actually rentals ("Lease").
+ *
+ * Auth: requires CRON_SECRET if set in the environment.
+ */
+export async function GET(req: Request) {
+  const secret = process.env.CRON_SECRET;
+  const url = new URL(req.url);
+  const provided =
+    url.searchParams.get("secret") ??
+    req.headers.get("authorization")?.replace("Bearer ", "") ??
+    "";
+
+  if (secret && provided !== secret) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  try {
+    // Fetch all properties with their apiRaw data
+    const allProperties = await db
+      .select({
+        id: properties.id,
+        apiId: properties.apiId,
+        titleEn: properties.titleEn,
+        titleEs: properties.titleEs,
+        listingType: properties.listingType,
+        apiRaw: properties.apiRaw,
+      })
+      .from(properties);
+
+    let fixedCount = 0;
+    const fixes: Array<{ apiId: string; titleEn: string; oldType: string; newType: string }> = [];
+
+    for (const p of allProperties) {
+      const apiRaw = (p.apiRaw && typeof p.apiRaw === "object" ? p.apiRaw : {}) as Record<string, unknown>;
+      const resolved = resolveListingTypeFromRaw(apiRaw, p.titleEn, p.titleEs);
+
+      if (resolved !== p.listingType) {
+        await db
+          .update(properties)
+          .set({
+            listingType: resolved,
+            updatedAt: new Date(),
+          })
+          .where(eq(properties.id, p.id));
+
+        fixedCount++;
+        fixes.push({
+          apiId: p.apiId,
+          titleEn: p.titleEn,
+          oldType: p.listingType,
+          newType: resolved,
+        });
+      }
+    }
+
+    return NextResponse.json({
+      ok: true,
+      message: `Fixed listing_type for ${fixedCount} properties`,
+      totalScanned: allProperties.length,
+      fixes,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error("[retroactive-listing-type] Error:", msg);
+    return NextResponse.json(
+      {
+        error: msg,
+        detail: err instanceof Error && err.cause instanceof Error ? err.cause.message : undefined,
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/retroactive-listing-type/route.ts
+++ b/src/app/api/retroactive-listing-type/route.ts
@@ -11,7 +11,11 @@ export const dynamic = "force-dynamic";
  * Mirrors the logic in src/lib/sync/schemas/property.ts → resolveListingType()
  * but operates on the stored apiRaw JSONB column.
  */
-function resolveListingTypeFromRaw(apiRaw: Record<string, unknown>, titleEn: string, titleEs: string): "Sale" | "Lease" {
+function resolveListingTypeFromRaw(
+  apiRaw: Record<string, unknown>,
+  titleEn: string,
+  titleEs: string,
+): "Sale" | "Lease" {
   // 1. ContractType_en
   const ctEn = typeof apiRaw.ContractType_en === "string" ? apiRaw.ContractType_en.trim() : null;
   if (ctEn) {
@@ -33,7 +37,9 @@ function resolveListingTypeFromRaw(apiRaw: Record<string, unknown>, titleEn: str
 
   // 4. Title heuristic
   const titleText = `${titleEn} ${titleEs}`.toLowerCase();
-  if (/\bfor rent\b|\bfor lease\b|\brental\b|\balquiler\b|\barriendo\b|\ben renta\b/.test(titleText)) {
+  if (
+    /\bfor rent\b|\bfor lease\b|\brental\b|\balquiler\b|\barriendo\b|\ben renta\b/.test(titleText)
+  ) {
     return "Lease";
   }
 
@@ -78,7 +84,10 @@ export async function GET(req: Request) {
     const fixes: Array<{ apiId: string; titleEn: string; oldType: string; newType: string }> = [];
 
     for (const p of allProperties) {
-      const apiRaw = (p.apiRaw && typeof p.apiRaw === "object" ? p.apiRaw : {}) as Record<string, unknown>;
+      const apiRaw = (p.apiRaw && typeof p.apiRaw === "object" ? p.apiRaw : {}) as Record<
+        string,
+        unknown
+      >;
       const resolved = resolveListingTypeFromRaw(apiRaw, p.titleEn, p.titleEs);
 
       if (resolved !== p.listingType) {

--- a/src/lib/sync/schemas/property.ts
+++ b/src/lib/sync/schemas/property.ts
@@ -146,7 +146,9 @@ function resolveListingType(p: {
 
   // 4. Title-based heuristic — look for rental keywords in either language
   const titleText = `${p.ListingTitle_en} ${p.ListingTitle_es ?? ""}`.toLowerCase();
-  if (/\bfor rent\b|\bfor lease\b|\brental\b|\balquiler\b|\barriendo\b|\ben renta\b/.test(titleText)) {
+  if (
+    /\bfor rent\b|\bfor lease\b|\brental\b|\balquiler\b|\barriendo\b|\ben renta\b/.test(titleText)
+  ) {
     return "Lease";
   }
 

--- a/src/lib/sync/schemas/property.ts
+++ b/src/lib/sync/schemas/property.ts
@@ -105,6 +105,55 @@ const rawPropertyApiSchemaBase = z
   })
   .passthrough();
 
+/**
+ * Resolves the listing transaction type ("Sale" or "Lease") using multiple
+ * signals from the API payload. The REMAX CCA API sometimes returns
+ * `ContractType_en` as null for rental properties, so we cascade through
+ * several fallback strategies before defaulting to "Sale".
+ *
+ * Signal priority:
+ *   1. ContractType_en (English text: "Sale", "Lease")
+ *   2. ContractType_es (Spanish text: "Venta", "Alquiler" / "Arriendo")
+ *   3. ListingContractType (numeric ID: 2 = Lease in REMAX CCA)
+ *   4. Title heuristic (rent/lease/alquiler keywords in EN or ES title)
+ *   5. Default: "Sale"
+ */
+function resolveListingType(p: {
+  ContractType_en?: string | null;
+  ContractType_es?: string | null;
+  ListingContractType?: number | null;
+  ListingTitle_en: string;
+  ListingTitle_es?: string | null;
+}): "Sale" | "Lease" {
+  // 1. Explicit English contract type
+  if (p.ContractType_en) {
+    const ct = p.ContractType_en.trim();
+    if (/lease|rent/i.test(ct)) return "Lease";
+    if (/sale|sell/i.test(ct)) return "Sale";
+    // If it's some other value, continue to fallbacks
+  }
+
+  // 2. Explicit Spanish contract type
+  if (p.ContractType_es) {
+    const ct = p.ContractType_es.trim();
+    if (/alquiler|arriendo|renta/i.test(ct)) return "Lease";
+    if (/venta/i.test(ct)) return "Sale";
+  }
+
+  // 3. Numeric contract type ID (REMAX CCA convention: 2 = Lease)
+  if (p.ListingContractType === 2) return "Lease";
+  if (p.ListingContractType === 1) return "Sale";
+
+  // 4. Title-based heuristic — look for rental keywords in either language
+  const titleText = `${p.ListingTitle_en} ${p.ListingTitle_es ?? ""}`.toLowerCase();
+  if (/\bfor rent\b|\bfor lease\b|\brental\b|\balquiler\b|\barriendo\b|\ben renta\b/.test(titleText)) {
+    return "Lease";
+  }
+
+  // 5. Default fallback
+  return "Sale";
+}
+
 export const rawPropertyApiSchema = rawPropertyApiSchemaBase.transform((p) => {
   const titleEn = p.ListingTitle_en;
   const titleEsRaw = (p.ListingTitle_es ?? "").trim();
@@ -129,7 +178,7 @@ export const rawPropertyApiSchema = rawPropertyApiSchemaBase.transform((p) => {
     apiKey: p.ListingKey,
     propertyTypeEn: p.PropertyTypeName_en,
     propertyTypeEs: p.PropertyTypeName_es,
-    listingType: p.ContractType_en ?? "Sale",
+    listingType: resolveListingType(p),
     titleEn,
     titleEs,
     publicRemarksEn: p.PublicRemarks_en ?? null,


### PR DESCRIPTION
# Fix: Search Page Scroll, Lot Size Display, Currency Conversion & Listing Type

## Overview

This PR addresses multiple issues on the search results page and property cards:
1. **Cannot scroll** the property grid on the search results page
2. **Lot size missing** on Lote/Finca property cards
3. **CRC currency display** incorrectly showing colones price for USD-priced properties
4. **Listing type resolution** failing for some rental properties due to null `ContractType_en`

## Changes

### Search Page Scroll Fix

#### `search-page-client.tsx`
- Added `overflow-hidden` to the search page wrapper div so the fixed viewport height is properly enforced and child scroll containers work correctly.

#### `split-view-layout.tsx`
- Added `h-full` to the split-view flex-row container so child panels can resolve `height: 100%` against a real computed value.
- Changed grid panel from `lg:h-full` to `h-full` — the height constraint was only applied at the `lg` breakpoint, but `overflow-y-auto` needs a height constraint at all breakpoints to enable scrolling.

### Lot Size & Property Type Display Fix

#### `property-card.tsx`
- **Root cause**: The `LAND_TYPES` set only contained Spanish type names (`"Lote"`, `"Terreno"`, `"Finca"`) but the database stores English type names from the API (`"Lot/Land"`, `"Farm"`, `"Land"`, etc.). So `isLand` was always `false` for those properties, causing the card to show bedrooms/bathrooms instead of lot size.
- **Fix**: Expanded `LAND_TYPES` to include all English equivalents: `"Lot"`, `"Lot/Land"`, `"Land"`, `"Farm"`, `"Ranch"`, `"Rural area"`, `"Terrenos"`.
- Replaced the inline property type translation with a comprehensive bi-directional `TYPE_DISPLAY` lookup table at module scope, covering all known property types in both EN and ES.
- Fixed CRC price display: only use `apiRaw.ListPrice` as colones when `property.currency === "CRC"`, preventing USD-priced properties from incorrectly showing a colones amount.

### Listing Type Resolution Improvement

#### `property.ts` (sync schema)
- Added `resolveListingType()` function with multi-signal fallback cascade:
  1. `ContractType_en` (English text)
  2. `ContractType_es` (Spanish text)
  3. `ListingContractType` (numeric ID: 2 = Lease)
  4. Title-based heuristic (rental keywords in EN/ES titles)
  5. Default: `"Sale"`
- Replaced the simple `p.ContractType_en ?? "Sale"` with the new resolver, fixing rental listings that had null `ContractType_en`.

## Testing

- TypeScript compilation passes with zero errors (`npx tsc --noEmit`)
- Production build compiles successfully
- Lint passes (no new errors introduced)