### PR TITLE
Fix : Currency Conversion, Search Layout & Unit Toggle Preference

### DIFF
--- a/src/components/listing/listing-detail-layout.tsx
+++ b/src/components/listing/listing-detail-layout.tsx
@@ -9,7 +9,7 @@
  */
 
 import { getTranslations } from "next-intl/server";
-import { convertArea } from "@/lib/utils/units";
+import { PropertySpecsSummary } from "@/components/listing/property-specs-summary";
 import { StickySpecsBar } from "@/components/listing/sticky-specs-bar";
 import { PropertyGalleryLoader } from "@/components/listing/property-gallery-loader";
 import { PropertyInquiryForm } from "@/components/listing/property-inquiry-form";
@@ -163,59 +163,16 @@ export async function ListingDetailLayout({
               </div>
 
               {/* Property specs summary */}
-              <div className="grid grid-cols-2 gap-4 rounded-xl border border-border p-6 md:grid-cols-4">
-                {property.priceUsd != null && (
-                  <div>
-                    <p className="text-xs font-medium uppercase tracking-wide text-text-muted">
-                      {t("specs.price")}
-                    </p>
-                    <p className="mt-1 text-lg font-bold text-brand-navy">
-                      ${property.priceUsd.toLocaleString("en-US")}
-                      {property.currency === "CRC" && originalPriceColones != null && (
-                        <span className="ml-2 text-sm font-medium text-text-muted">
-                          (₡{originalPriceColones.toLocaleString("es-CR")})
-                        </span>
-                      )}
-                    </p>
-                  </div>
-                )}
-                {property.bedrooms != null && (
-                  <div>
-                    <p className="text-xs font-medium uppercase tracking-wide text-text-muted">
-                      {t("specs.bedrooms", { count: property.bedrooms })}
-                    </p>
-                    <p className="mt-1 text-lg font-bold text-brand-navy">{property.bedrooms}</p>
-                  </div>
-                )}
-                {property.bathrooms != null && (
-                  <div>
-                    <p className="text-xs font-medium uppercase tracking-wide text-text-muted">
-                      {t("specs.bathrooms", { count: property.bathrooms })}
-                    </p>
-                    <p className="mt-1 text-lg font-bold text-brand-navy">{property.bathrooms}</p>
-                  </div>
-                )}
-                {property.lotSizeM2 != null && (
-                  <div>
-                    <p className="text-xs font-medium uppercase tracking-wide text-text-muted">
-                      {t("specs.lotSize")}
-                    </p>
-                    <p className="mt-1 text-lg font-bold text-brand-navy">
-                      {convertArea(property.lotSizeM2, "metric", locale, true)}
-                    </p>
-                  </div>
-                )}
-                {property.constructionM2 != null && (
-                  <div>
-                    <p className="text-xs font-medium uppercase tracking-wide text-text-muted">
-                      {t("specs.builtArea")}
-                    </p>
-                    <p className="mt-1 text-lg font-bold text-brand-navy">
-                      {convertArea(property.constructionM2, "metric", locale, false)}
-                    </p>
-                  </div>
-                )}
-              </div>
+              <PropertySpecsSummary
+                priceUsd={property.priceUsd}
+                bedrooms={property.bedrooms}
+                bathrooms={property.bathrooms}
+                lotSizeM2={property.lotSizeM2}
+                constructionM2={property.constructionM2}
+                locale={locale}
+                currency={property.currency}
+                originalPriceColones={originalPriceColones}
+              />
 
               {/* Description */}
               {description && (

--- a/src/components/listing/property-specs-summary.tsx
+++ b/src/components/listing/property-specs-summary.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+/**
+ * PropertySpecsSummary — Client Component
+ *
+ * Displays the property specs summary grid (price, beds, baths, lot size, built area)
+ * with unit-system-aware area conversion. Extracted from the Server Component
+ * ListingDetailLayout so it can read the user's localStorage unit preference
+ * via the useLocaleUnits hook.
+ */
+
+import { useTranslations } from "next-intl";
+import { useLocaleUnits } from "@/hooks/use-locale-units";
+
+interface PropertySpecsSummaryProps {
+  priceUsd: number | null;
+  bedrooms: number | null;
+  bathrooms: number | null;
+  lotSizeM2: number | null;
+  constructionM2: number | null;
+  locale: string;
+  currency?: string;
+  originalPriceColones?: number | null;
+}
+
+export function PropertySpecsSummary({
+  priceUsd,
+  bedrooms,
+  bathrooms,
+  lotSizeM2,
+  constructionM2,
+  locale,
+  currency,
+  originalPriceColones,
+}: PropertySpecsSummaryProps) {
+  const t = useTranslations("ListingDetail");
+  const { unitSystem, convertArea } = useLocaleUnits(locale);
+
+  return (
+    <div className="grid grid-cols-2 gap-4 rounded-xl border border-border p-6 md:grid-cols-4">
+      {priceUsd != null && (
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-text-muted">
+            {t("specs.price")}
+          </p>
+          <p className="mt-1 text-lg font-bold text-brand-navy">
+            ${priceUsd.toLocaleString("en-US")}
+            {currency === "CRC" && originalPriceColones != null && (
+              <span className="ml-2 text-sm font-medium text-text-muted">
+                (₡{originalPriceColones.toLocaleString("es-CR")})
+              </span>
+            )}
+          </p>
+        </div>
+      )}
+      {bedrooms != null && (
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-text-muted">
+            {t("specs.bedrooms", { count: bedrooms })}
+          </p>
+          <p className="mt-1 text-lg font-bold text-brand-navy">{bedrooms}</p>
+        </div>
+      )}
+      {bathrooms != null && (
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-text-muted">
+            {t("specs.bathrooms", { count: bathrooms })}
+          </p>
+          <p className="mt-1 text-lg font-bold text-brand-navy">{bathrooms}</p>
+        </div>
+      )}
+      {lotSizeM2 != null && (
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-text-muted">
+            {t("specs.lotSize")}
+          </p>
+          <p className="mt-1 text-lg font-bold text-brand-navy">
+            {convertArea(lotSizeM2, unitSystem, locale, true)}
+          </p>
+        </div>
+      )}
+      {constructionM2 != null && (
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-text-muted">
+            {t("specs.builtArea")}
+          </p>
+          <p className="mt-1 text-lg font-bold text-brand-navy">
+            {convertArea(constructionM2, unitSystem, locale, false)}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/map/map-property-popup.tsx
+++ b/src/components/map/map-property-popup.tsx
@@ -42,7 +42,12 @@ const ZMT_LABELS: Record<string, string> = {
   zmt_restricted: "ZMT Restricted",
 };
 
-export function MapPropertyPopup({ property, locale, onClose, unitSystem = "metric" }: MapPropertyPopupProps) {
+export function MapPropertyPopup({
+  property,
+  locale,
+  onClose,
+  unitSystem = "metric",
+}: MapPropertyPopupProps) {
   const title = locale === "es" ? property.titleEs : property.titleEn;
   const firstImage = property.images[0];
   const formattedPrice = property.priceUsd.toLocaleString("en-US", {
@@ -55,7 +60,8 @@ export function MapPropertyPopup({ property, locale, onClose, unitSystem = "metr
   const specs: string[] = [];
   if (property.bedrooms != null) specs.push(`${property.bedrooms} bed`);
   if (property.bathrooms != null) specs.push(`${property.bathrooms} bath`);
-  if (property.lotSizeM2 != null) specs.push(convertArea(property.lotSizeM2, unitSystem, locale, true));
+  if (property.lotSizeM2 != null)
+    specs.push(convertArea(property.lotSizeM2, unitSystem, locale, true));
 
   return (
     <Popup

--- a/src/components/map/map-property-popup.tsx
+++ b/src/components/map/map-property-popup.tsx
@@ -13,6 +13,7 @@ import Image from "next/image";
 import { Popup } from "react-map-gl";
 import { X } from "lucide-react";
 import { Link } from "@/i18n/navigation";
+import { convertArea, type UnitSystem } from "@/lib/utils/units";
 import type { OptimizedImage } from "@/types/images";
 
 interface MapPropertyPopupProps {
@@ -32,6 +33,7 @@ interface MapPropertyPopupProps {
   };
   locale: string;
   onClose: () => void;
+  unitSystem?: UnitSystem;
 }
 
 const ZMT_LABELS: Record<string, string> = {
@@ -40,7 +42,7 @@ const ZMT_LABELS: Record<string, string> = {
   zmt_restricted: "ZMT Restricted",
 };
 
-export function MapPropertyPopup({ property, locale, onClose }: MapPropertyPopupProps) {
+export function MapPropertyPopup({ property, locale, onClose, unitSystem = "metric" }: MapPropertyPopupProps) {
   const title = locale === "es" ? property.titleEs : property.titleEn;
   const firstImage = property.images[0];
   const formattedPrice = property.priceUsd.toLocaleString("en-US", {
@@ -53,7 +55,7 @@ export function MapPropertyPopup({ property, locale, onClose }: MapPropertyPopup
   const specs: string[] = [];
   if (property.bedrooms != null) specs.push(`${property.bedrooms} bed`);
   if (property.bathrooms != null) specs.push(`${property.bathrooms} bath`);
-  if (property.lotSizeM2 != null) specs.push(`${Math.round(property.lotSizeM2)} m²`);
+  if (property.lotSizeM2 != null) specs.push(convertArea(property.lotSizeM2, unitSystem, locale, true));
 
   return (
     <Popup

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -77,7 +77,13 @@ type PointFeature = GeoJSON.Feature<
 // Stable world bbox for initial cluster rendering before map bounds are known
 const INITIAL_BBOX: [number, number, number, number] = [-180, -85, 180, 85];
 
-export function MapView({ properties, locale, onBoundsChange, flyToTarget, unitSystem }: MapViewProps) {
+export function MapView({
+  properties,
+  locale,
+  onBoundsChange,
+  flyToTarget,
+  unitSystem,
+}: MapViewProps) {
   const mapRef = useRef<MapRef>(null);
   const { center, zoom, setCenter, setZoom, setBounds } = useMapStore();
   const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(null);

--- a/src/components/map/map-view.tsx
+++ b/src/components/map/map-view.tsx
@@ -22,6 +22,7 @@ import { MapClusterPin } from "@/components/map/map-cluster-pin";
 import { MapPricePin } from "@/components/map/map-price-pin";
 import { MapPropertyPopup } from "@/components/map/map-property-popup";
 import type { OptimizedImage } from "@/types/images";
+import type { UnitSystem } from "@/lib/utils/units";
 
 export type MapBounds = {
   north: number;
@@ -51,6 +52,8 @@ interface MapViewProps {
   onBoundsChange?: (bounds: MapBounds) => void;
   /** Story 3.8: When set, map flies to these coordinates with given zoom */
   flyToTarget?: { lat: number; lng: number; zoom?: number } | null;
+  /** Unit system preference for area display in popups */
+  unitSystem?: UnitSystem;
 }
 
 type ClusterFeature = GeoJSON.Feature<
@@ -74,7 +77,7 @@ type PointFeature = GeoJSON.Feature<
 // Stable world bbox for initial cluster rendering before map bounds are known
 const INITIAL_BBOX: [number, number, number, number] = [-180, -85, 180, 85];
 
-export function MapView({ properties, locale, onBoundsChange, flyToTarget }: MapViewProps) {
+export function MapView({ properties, locale, onBoundsChange, flyToTarget, unitSystem }: MapViewProps) {
   const mapRef = useRef<MapRef>(null);
   const { center, zoom, setCenter, setZoom, setBounds } = useMapStore();
   const [selectedPropertyId, setSelectedPropertyId] = useState<string | null>(null);
@@ -293,6 +296,7 @@ export function MapView({ properties, locale, onBoundsChange, flyToTarget }: Map
             property={selectedProperty}
             locale={locale}
             onClose={() => setSelectedPropertyId(null)}
+            unitSystem={unitSystem}
           />
         )}
       </MapboxMap>

--- a/src/components/search/split-view-layout.tsx
+++ b/src/components/search/split-view-layout.tsx
@@ -169,6 +169,7 @@ export function SplitViewLayout({
               locale={locale}
               onBoundsChange={handleBoundsChange}
               flyToTarget={flyToTarget}
+              unitSystem={unitSystem}
             />
           </div>
         </div>


### PR DESCRIPTION
# Fix: Currency Conversion, Search Layout & Unit Toggle Preference

## Overview

This PR bundles several interrelated fixes for the property search and listing experience:

1. **CRC Currency Conversion** — Fixed incorrect Colones price display where the card was showing the raw USD value as Colones instead of the original `ListPrice` from the API.
2. **Search Page Layout** — Fixed overflow and height issues causing the search page to not fill the viewport correctly.
3. **Listing Type Resolution** — Improved the property type detection with a multi-signal fallback system and bilingual (EN/ES) display labels.
4. **m²/ft² Unit Toggle** — Fixed the unit preference toggle so it is respected across **all** surfaces (map popups, listing detail pages), not just the search result cards.

## Changes

### Currency & Price Display
- **property-card.tsx** — Now correctly reads `apiRaw.ListPrice` as the original Colones price only when `currency === "CRC"`, and displays bilingual property type labels via a `TYPE_DISPLAY` lookup table.

### Search Layout
- **search-page-client.tsx** — Fixed viewport height class.
- **split-view-layout.tsx** — Now passes `unitSystem` to `MapView` so map popups respect the user's area unit preference.

### Listing Type Resolution
- **schemas/property.ts** — Enhanced listing type inference with multi-signal fallback (explicit fields → description keywords → title keywords → default "Sale").
- **retroactive-listing-type/route.ts** — [NEW] API route to retroactively fix listing types for existing properties in the database.

### Unit Toggle (m²/ft²) Preference System
- **map-property-popup.tsx** — Previously hardcoded `m²` for lot sizes. Now accepts a `unitSystem` prop and uses `convertArea()` for proper unit conversion.
- **map-view.tsx** — Now accepts and forwards `unitSystem` prop to `MapPropertyPopup`.
- **listing-detail-layout.tsx** — Replaced inline specs grid (which hardcoded `"metric"`) with the new `PropertySpecsSummary` Client Component.
- **property-specs-summary.tsx** — [NEW] Client Component extracted from the Server Component `ListingDetailLayout` so it can read the user's localStorage unit preference via `useLocaleUnits()` hook.

## Testing

- ✅ TypeScript compilation: `npx tsc --noEmit` — zero errors
- ✅ ESLint: zero new lint errors in changed files
- ✅ Production build: `npm run build` — compiled successfully
- ✅ Unit preference persists in localStorage under `"unit-preference"` key
- ✅ Toggling m²→ft² updates: search cards, map popups, listing detail specs, and sticky specs bar