### PR TITLE
Feature : Area/Location System Redesign

### DIFF
--- a/src/app/actions/search-actions.ts
+++ b/src/app/actions/search-actions.ts
@@ -18,6 +18,7 @@ import type { SQL } from "drizzle-orm";
 import type { SearchFilters, SearchResult, PropertySearchItem, FilterFacets } from "@/types/search";
 import { mapPropertyRowToSearchItem, propertySearchColumns } from "@/lib/db/queries/properties";
 import { trackSearchInBackground } from "@/lib/services/tracking";
+import { getDistrictLabel } from "@/lib/locations";
 
 export type RawBounds = {
   north: number;
@@ -642,29 +643,8 @@ function formatAreaLabel(slug: string): string {
 
 /**
  * Format a sub-location slug into a display label.
- * Aligned with ALTITUD HUB locations.js — 12 districts of Pérez Zeledón
+ * Uses the shared locations module as single source of truth.
  */
 function formatSubLocationLabel(slug: string): string {
-  const knownSubLocations: Record<string, string> = {
-    "san-isidro": "San Isidro de El General",
-    "el-general": "El General",
-    "daniel-flores": "Daniel Flores",
-    rivas: "Rivas",
-    "san-pedro": "San Pedro",
-    platanares: "Platanares",
-    pejibaye: "Pejibaye",
-    cajon: "Cajón",
-    baru: "Barú",
-    "rio-nuevo": "Río Nuevo",
-    paramo: "Páramo",
-    "la-amistad": "La Amistad",
-  };
-
-  if (knownSubLocations[slug]) return knownSubLocations[slug];
-
-  // Fallback: title-case the slug
-  return slug
-    .split("-")
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
+  return getDistrictLabel(slug);
 }

--- a/src/components/property/property-card.tsx
+++ b/src/components/property/property-card.tsx
@@ -7,6 +7,7 @@ import { convertArea, type UnitSystem } from "@/lib/utils/units";
 import { PropertyPriceDisplay } from "@/components/property/property-price-display";
 import { formatUSD } from "@/lib/utils/currency";
 import type { PropertySearchItem } from "@/types/search";
+import { getDistrictLabel } from "@/lib/locations";
 
 interface PropertyCardProps {
   property: PropertySearchItem;
@@ -164,23 +165,12 @@ function getLandFeatures(property: PropertySearchItem, locale: string): string[]
 }
 
 /**
- * Known sub-location slug → display label mapping.
- * Aligned with ALTITUD HUB locations.js — 12 districts of Pérez Zeledón
+ * Get display label for a sub-location slug.
+ * Uses the shared locations module as single source of truth.
  */
-const SUB_LOCATION_LABELS: Record<string, string> = {
-  "san-isidro": "San Isidro de El General",
-  "el-general": "El General",
-  "daniel-flores": "Daniel Flores",
-  rivas: "Rivas",
-  "san-pedro": "San Pedro",
-  platanares: "Platanares",
-  pejibaye: "Pejibaye",
-  cajon: "Cajón",
-  baru: "Barú",
-  "rio-nuevo": "Río Nuevo",
-  paramo: "Páramo",
-  "la-amistad": "La Amistad",
-};
+function getSubLocationLabel(slug: string): string {
+  return getDistrictLabel(slug);
+}
 
 /**
  * Clean up an apiRaw.Location string for card display.
@@ -210,7 +200,7 @@ function getPropertyLocation(property: PropertySearchItem, locale: string): stri
   const subLocation = (apiRaw as Record<string, unknown> | undefined)?.subLocation as
     | string
     | undefined;
-  if (subLocation && SUB_LOCATION_LABELS[subLocation]) {
+  if (subLocation) {
     const parentLabel =
       areaSlug === "perez-zeledon"
         ? locale === "es"
@@ -220,7 +210,7 @@ function getPropertyLocation(property: PropertySearchItem, locale: string): stri
             ?.split("-")
             .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
             .join(" ") ?? "");
-    return `${SUB_LOCATION_LABELS[subLocation]}, ${parentLabel}`;
+    return `${getSubLocationLabel(subLocation)}, ${parentLabel}`;
   }
 
   // 2. Try apiRaw.Location — clean it up for display

--- a/src/components/search/filter-dropdown.tsx
+++ b/src/components/search/filter-dropdown.tsx
@@ -89,7 +89,7 @@ export function FilterDropdown({
           data-testid={testId}
           className={cn(
             // Base
-            "inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium",
+            "inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium",
             "transition-all duration-200 cursor-pointer whitespace-nowrap",
             // Focus
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/30 focus-visible:border-brand-blue",

--- a/src/components/search/price-filter-popover.tsx
+++ b/src/components/search/price-filter-popover.tsx
@@ -54,7 +54,7 @@ export function PriceFilterPopover({
           data-testid="price-filter-trigger"
           className={cn(
             // Base
-            "inline-flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm font-medium",
+            "inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium",
             "transition-all duration-200 cursor-pointer whitespace-nowrap",
             // Focus
             "focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/30 focus-visible:border-brand-blue",

--- a/src/components/search/search-filter-bar.tsx
+++ b/src/components/search/search-filter-bar.tsx
@@ -251,7 +251,7 @@ export function SearchFilterBar({
       {/* Filter bar wrapper */}
       <div
         data-testid="search-filter-bar"
-        className="sticky top-[var(--header-height)] z-10 py-2 md:py-3 bg-background border-b border-border flex flex-col"
+        className="sticky top-[var(--header-height)] z-10 py-1 md:py-1.5 bg-background border-b border-border flex flex-col"
       >
         <div className="flex items-stretch px-4 gap-3 h-full">
           {/* Mobile compact bar — visible below md breakpoint */}
@@ -285,7 +285,7 @@ export function SearchFilterBar({
           </Sheet>
 
           {/* Desktop/tablet filter controls — visible at md: and above */}
-          <div className="hidden md:flex flex-col gap-2 w-full">
+          <div className="hidden md:flex flex-col gap-1 w-full">
             {/* Row 1: Lifestyle Tags (compact, scrollable) */}
             <div className="w-full overflow-x-auto no-scrollbar">
               <LifestyleTagChips activeTags={filters.tags ?? []} onToggle={toggleTag} />

--- a/src/hooks/use-locale-units.ts
+++ b/src/hooks/use-locale-units.ts
@@ -1,72 +1,36 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
-import { detectDefaultUnitSystem, convertArea, type UnitSystem } from "@/lib/utils/units";
-
-const STORAGE_KEY = "unit-preference";
-
-/**
- * Safely read the stored unit preference. Returns null if localStorage is
- * unavailable (Safari private mode, sandboxed iframes, disabled storage).
- */
-function readStoredPreference(): UnitSystem | null {
-  try {
-    if (typeof window === "undefined") return null;
-    const stored = window.localStorage.getItem(STORAGE_KEY);
-    return stored === "metric" || stored === "imperial" ? stored : null;
-  } catch {
-    return null;
-  }
-}
+import { useEffect } from "react";
+import { useUnitStore } from "@/store/unit-store";
+import { convertArea } from "@/lib/utils/units";
 
 /**
- * Safely persist the unit preference. Silently swallows quota / disabled
- * storage errors — UI state remains in sync even if persistence fails.
- */
-function writeStoredPreference(value: UnitSystem): void {
-  try {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(STORAGE_KEY, value);
-  } catch {
-    /* noop — storage unavailable */
-  }
-}
-
-/**
- * Hook for locale-aware unit preference with localStorage persistence.
+ * Hook for locale-aware unit preference backed by a shared Zustand store.
+ *
+ * All components that call this hook share the same reactive state, so
+ * toggling in one place (e.g. UnitToggle in SearchFilterBar) instantly
+ * re-renders all consumers (PropertyCard, MapPopup, StickySpecsBar, etc.).
  *
  * Hydration safety:
- *   - Initial state always uses `detectDefaultUnitSystem(locale)` so the
- *     server-rendered HTML and the first client render match exactly.
- *   - After mount, a useEffect reads localStorage and reconciles the state
- *     to the user's stored preference. This avoids React hydration warnings
- *     at the cost of a one-paint flash for users with a non-default stored
- *     preference. (FOUC mitigation R-011 — accepted trade-off; hydration
- *     correctness is preferred over zero-flash.)
+ *   - The store initialises to `null`.  On first client render the
+ *     `useEffect` calls `initFromLocale`, which reads localStorage and
+ *     sets the correct value.  Until then, consumers see "metric" via
+ *     the `?? "metric"` fallback, matching the server-rendered HTML.
  *
  * Story 3.7 — AC #3, #4
  */
 export function useLocaleUnits(locale: string) {
-  const defaultSystem = detectDefaultUnitSystem(locale);
-  const [unitSystem, setUnitSystem] = useState<UnitSystem>(defaultSystem);
+  const unitSystemRaw = useUnitStore((s) => s.unitSystem);
+  const initFromLocale = useUnitStore((s) => s.initFromLocale);
+  const toggleUnits = useUnitStore((s) => s.toggleUnits);
 
-  // Reconcile with localStorage after mount (avoids SSR/CSR hydration mismatch).
+  // Reconcile with localStorage after mount (hydration-safe).
   useEffect(() => {
-    const stored = readStoredPreference();
-    if (stored && stored !== unitSystem) {
-      setUnitSystem(stored);
-    }
-    // Intentionally only runs once per mount — locale changes do not retrigger.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    initFromLocale(locale);
+  }, [initFromLocale, locale]);
 
-  const toggleUnits = useCallback(() => {
-    setUnitSystem((prev) => {
-      const next: UnitSystem = prev === "metric" ? "imperial" : "metric";
-      writeStoredPreference(next);
-      return next;
-    });
-  }, []);
+  // Before init, fall back to "metric" so SSR HTML matches first paint.
+  const unitSystem = unitSystemRaw ?? "metric";
 
   return { unitSystem, toggleUnits, convertArea } as const;
 }

--- a/src/lib/db/queries/properties.ts
+++ b/src/lib/db/queries/properties.ts
@@ -193,10 +193,7 @@ import { DISTRICT_KEYWORDS } from "@/lib/locations";
  * @param areaSlug  - The resolved main area slug (filters keywords to matching parent)
  * @returns Sub-location slug (e.g. "cajon") or null if not resolvable
  */
-export function resolveSubLocation(
-  location: string | null,
-  areaSlug: string,
-): string | null {
+export function resolveSubLocation(location: string | null, areaSlug: string): string | null {
   if (!location || location.trim().length === 0) return null;
 
   const loc = location.toLowerCase();

--- a/src/lib/db/queries/properties.ts
+++ b/src/lib/db/queries/properties.ts
@@ -179,6 +179,38 @@ export function resolveAreaSlug(raw: {
   return "dominical";
 }
 
+// ─── Sub-Location Resolution ──────────────────────────────────────────────
+// Uses the shared locations module (src/lib/locations.ts) as single source of truth.
+// Aligned with ALTITUD HUB locations.js — Cantón → Distrito hierarchy.
+
+import { DISTRICT_KEYWORDS } from "@/lib/locations";
+
+/**
+ * Resolves a sub-location (district) slug from the RECONNECT API's Location field.
+ * Uses the shared DISTRICT_KEYWORDS from locations.ts for matching.
+ *
+ * @param location  - The Location string from the RECONNECT API (e.g. "Cajón de Pérez Zeledón")
+ * @param areaSlug  - The resolved main area slug (filters keywords to matching parent)
+ * @returns Sub-location slug (e.g. "cajon") or null if not resolvable
+ */
+export function resolveSubLocation(
+  location: string | null,
+  areaSlug: string,
+): string | null {
+  if (!location || location.trim().length === 0) return null;
+
+  const loc = location.toLowerCase();
+
+  for (const { keyword, slug, parent } of DISTRICT_KEYWORDS) {
+    // Only match keywords whose parent matches the resolved area
+    if (parent === areaSlug && loc.includes(keyword)) {
+      return slug;
+    }
+  }
+
+  return null;
+}
+
 export async function upsertProperty(
   raw: RawProperty,
   officeId: string,
@@ -195,6 +227,7 @@ export async function upsertProperty(
 
   const resolvedAreaSlug = resolveAreaSlug(raw);
   const resolvedAreaId = await getAreaIdBySlug(resolvedAreaSlug);
+  const resolvedSubLocation = resolveSubLocation(raw.location, resolvedAreaSlug);
 
   const values = {
     apiId: raw.apiId,
@@ -221,6 +254,7 @@ export async function upsertProperty(
     agentId,
     areaId: resolvedAreaId,
     areaSlug: resolvedAreaSlug,
+    subLocation: resolvedSubLocation,
     communityId: null,
     lifestyleTags: [],
     zmtStatus: "titled" as const,
@@ -252,6 +286,7 @@ export async function upsertProperty(
     agentId: values.agentId,
     areaId: resolvedAreaId,
     areaSlug: resolvedAreaSlug,
+    subLocation: resolvedSubLocation,
     communityId: sql`CASE 
       WHEN ${properties.latitude} IS DISTINCT FROM ${values.latitude} 
         OR ${properties.longitude} IS DISTINCT FROM ${values.longitude} 

--- a/src/lib/db/scripts/analyze-locations.ts
+++ b/src/lib/db/scripts/analyze-locations.ts
@@ -46,11 +46,11 @@ async function main() {
   console.log("─".repeat(120));
   console.log(
     "Location".padEnd(45) +
-    "LocID".padEnd(8) +
-    "State".padEnd(15) +
-    "StID".padEnd(6) +
-    "Current Area".padEnd(25) +
-    "Count"
+      "LocID".padEnd(8) +
+      "State".padEnd(15) +
+      "StID".padEnd(6) +
+      "Current Area".padEnd(25) +
+      "Count",
   );
   console.log("─".repeat(120));
 
@@ -58,17 +58,17 @@ async function main() {
     const r = row as Record<string, unknown>;
     console.log(
       String(r.location ?? "(null)").padEnd(45) +
-      String(r.location_id ?? "").padEnd(8) +
-      String(r.state ?? "").padEnd(15) +
-      String(r.state_id ?? "").padEnd(6) +
-      String(r.area_slug ?? "").padEnd(25) +
-      String(r.property_count)
+        String(r.location_id ?? "").padEnd(8) +
+        String(r.state ?? "").padEnd(15) +
+        String(r.state_id ?? "").padEnd(6) +
+        String(r.area_slug ?? "").padEnd(25) +
+        String(r.property_count),
     );
   }
 
   // Show LocationId → Location mapping (the API's own IDs)
   console.log("\n\n📋 LocationId → Location mapping (RECONNECT's IDs):\n");
-  
+
   const idMap = await db.execute(sql`
     SELECT 
       api_raw->>'LocationId' AS location_id,
@@ -82,7 +82,9 @@ async function main() {
 
   for (const row of idMap) {
     const r = row as Record<string, unknown>;
-    console.log(`  ID ${String(r.location_id).padEnd(6)} → ${String(r.location).padEnd(50)} (${r.cnt} properties)`);
+    console.log(
+      `  ID ${String(r.location_id).padEnd(6)} → ${String(r.location).padEnd(50)} (${r.cnt} properties)`,
+    );
   }
 
   await client.end();

--- a/src/lib/db/scripts/analyze-locations.ts
+++ b/src/lib/db/scripts/analyze-locations.ts
@@ -1,0 +1,95 @@
+/**
+ * Quick diagnostic: dump all distinct Location + LocationId values from apiRaw
+ * to understand the RECONNECT API's location taxonomy.
+ * Run: npx tsx src/lib/db/scripts/analyze-locations.ts
+ */
+import { config } from "dotenv";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { sql } from "drizzle-orm";
+
+config({ path: ".env.local" });
+config({ path: ".env.development.local" });
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  console.error("No DATABASE_URL found in environment");
+  process.exit(1);
+}
+
+const client = postgres(connectionString, { prepare: false, max: 1 });
+const db = drizzle(client);
+
+async function main() {
+  console.log("🔍 RECONNECT API Location taxonomy analysis\n");
+
+  const rows = await db.execute(sql`
+    SELECT 
+      api_raw->>'Location' AS location,
+      api_raw->>'LocationId' AS location_id,
+      api_raw->>'StateDepProv' AS state,
+      api_raw->>'StateDepProvId' AS state_id,
+      area_slug,
+      COUNT(*) AS property_count
+    FROM properties
+    WHERE is_visible = true
+    GROUP BY 
+      api_raw->>'Location', 
+      api_raw->>'LocationId',
+      api_raw->>'StateDepProv',
+      api_raw->>'StateDepProvId',
+      area_slug
+    ORDER BY area_slug, property_count DESC
+  `);
+
+  console.log(`Found ${rows.length} distinct Location combinations.\n`);
+  console.log("─".repeat(120));
+  console.log(
+    "Location".padEnd(45) +
+    "LocID".padEnd(8) +
+    "State".padEnd(15) +
+    "StID".padEnd(6) +
+    "Current Area".padEnd(25) +
+    "Count"
+  );
+  console.log("─".repeat(120));
+
+  for (const row of rows) {
+    const r = row as Record<string, unknown>;
+    console.log(
+      String(r.location ?? "(null)").padEnd(45) +
+      String(r.location_id ?? "").padEnd(8) +
+      String(r.state ?? "").padEnd(15) +
+      String(r.state_id ?? "").padEnd(6) +
+      String(r.area_slug ?? "").padEnd(25) +
+      String(r.property_count)
+    );
+  }
+
+  // Show LocationId → Location mapping (the API's own IDs)
+  console.log("\n\n📋 LocationId → Location mapping (RECONNECT's IDs):\n");
+  
+  const idMap = await db.execute(sql`
+    SELECT 
+      api_raw->>'LocationId' AS location_id,
+      api_raw->>'Location' AS location,
+      COUNT(*) AS cnt
+    FROM properties
+    WHERE api_raw->>'LocationId' IS NOT NULL
+    GROUP BY api_raw->>'LocationId', api_raw->>'Location'
+    ORDER BY (api_raw->>'LocationId')::int
+  `);
+
+  for (const row of idMap) {
+    const r = row as Record<string, unknown>;
+    console.log(`  ID ${String(r.location_id).padEnd(6)} → ${String(r.location).padEnd(50)} (${r.cnt} properties)`);
+  }
+
+  await client.end();
+  console.log("\n✨ Done!");
+}
+
+main().catch((err) => {
+  console.error("Failed:", err);
+  process.exit(1);
+});

--- a/src/lib/db/scripts/populate-sub-locations.ts
+++ b/src/lib/db/scripts/populate-sub-locations.ts
@@ -31,12 +31,7 @@ async function main() {
       titleEn: properties.titleEn,
     })
     .from(properties)
-    .where(
-      and(
-        eq(properties.areaSlug, "perez-zeledon"),
-        isNull(properties.subLocation),
-      ),
-    );
+    .where(and(eq(properties.areaSlug, "perez-zeledon"), isNull(properties.subLocation)));
 
   console.log(`Found ${pzProperties.length} PZ properties without sub_location.\n`);
 
@@ -93,12 +88,7 @@ async function main() {
       count: sql<number>`count(*)::int`,
     })
     .from(properties)
-    .where(
-      and(
-        eq(properties.areaSlug, "perez-zeledon"),
-        isNotNull(properties.subLocation),
-      ),
-    )
+    .where(and(eq(properties.areaSlug, "perez-zeledon"), isNotNull(properties.subLocation)))
     .groupBy(properties.subLocation);
 
   if (counts.length > 0) {

--- a/src/lib/db/scripts/populate-sub-locations.ts
+++ b/src/lib/db/scripts/populate-sub-locations.ts
@@ -1,0 +1,118 @@
+import { config } from "dotenv";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { eq, and, isNull, isNotNull, sql } from "drizzle-orm";
+import { properties } from "../schema/properties";
+import { resolveSubLocation } from "../queries/properties";
+
+config({ path: ".env.local" });
+config({ path: ".env" });
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  console.error("No DATABASE_URL found in environment");
+  process.exit(1);
+}
+
+const client = postgres(connectionString, { prepare: false, max: 1 });
+const db = drizzle(client);
+
+async function main() {
+  console.log("🔍 Populating sub_location from apiRaw.Location for Pérez Zeledón properties...\n");
+
+  // Fetch all PZ properties that don't have a sub_location yet
+  const pzProperties = await db
+    .select({
+      id: properties.id,
+      slug: properties.slug,
+      areaSlug: properties.areaSlug,
+      subLocation: properties.subLocation,
+      apiRaw: properties.apiRaw,
+      titleEn: properties.titleEn,
+    })
+    .from(properties)
+    .where(
+      and(
+        eq(properties.areaSlug, "perez-zeledon"),
+        isNull(properties.subLocation),
+      ),
+    );
+
+  console.log(`Found ${pzProperties.length} PZ properties without sub_location.\n`);
+
+  let updated = 0;
+  let skipped = 0;
+  const unmapped: string[] = [];
+
+  for (const prop of pzProperties) {
+    const apiRaw = prop.apiRaw as Record<string, unknown> | null;
+    const location = typeof apiRaw?.Location === "string" ? apiRaw.Location : null;
+
+    if (!location) {
+      skipped++;
+      continue;
+    }
+
+    // Use the same resolveSubLocation() from the sync pipeline (single source of truth)
+    const subLocationSlug = resolveSubLocation(location, "perez-zeledon");
+
+    if (subLocationSlug) {
+      await db
+        .update(properties)
+        .set({ subLocation: subLocationSlug })
+        .where(eq(properties.id, prop.id));
+
+      console.log(`  ✅ ${prop.slug}: "${location}" → ${subLocationSlug}`);
+      updated++;
+    } else {
+      // Could not map — log for review
+      if (!unmapped.includes(location)) {
+        unmapped.push(location);
+      }
+      skipped++;
+    }
+  }
+
+  console.log(`\n📊 Results:`);
+  console.log(`  Updated: ${updated}`);
+  console.log(`  Skipped: ${skipped} (no Location or unmapped)`);
+  console.log(`  Total PZ properties: ${pzProperties.length}`);
+
+  if (unmapped.length > 0) {
+    console.log(`\n⚠️  Unmapped Location values (${unmapped.length}):`);
+    for (const loc of unmapped) {
+      console.log(`    - "${loc}"`);
+    }
+    console.log("\n  Add these to PZ_DISTRICT_KEYWORDS in properties.ts if they should be mapped.");
+  }
+
+  // Show a count of properties per sub_location after update
+  const counts = await db
+    .select({
+      subLocation: properties.subLocation,
+      count: sql<number>`count(*)::int`,
+    })
+    .from(properties)
+    .where(
+      and(
+        eq(properties.areaSlug, "perez-zeledon"),
+        isNotNull(properties.subLocation),
+      ),
+    )
+    .groupBy(properties.subLocation);
+
+  if (counts.length > 0) {
+    console.log("\n📍 Properties per sub-location:");
+    for (const row of counts) {
+      console.log(`    ${row.subLocation}: ${row.count}`);
+    }
+  }
+
+  await client.end();
+  console.log("\n✨ Done!");
+}
+
+main().catch((err) => {
+  console.error("Failed to populate sub_location:", err);
+  process.exit(1);
+});

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -38,28 +38,78 @@ export interface Canton {
 // ─── Pérez Zeledón — 12 Districts ───────────────────────────────────────────
 
 const PZ_DISTRICTS: District[] = [
-  { slug: "san-isidro", label: "San Isidro de El General", parentSlug: "perez-zeledon", coords: [9.3787, -83.7008, 14] },
-  { slug: "el-general", label: "El General", parentSlug: "perez-zeledon", coords: [9.355, -83.655, 14] },
-  { slug: "daniel-flores", label: "Daniel Flores", parentSlug: "perez-zeledon", coords: [9.345, -83.68, 14] },
+  {
+    slug: "san-isidro",
+    label: "San Isidro de El General",
+    parentSlug: "perez-zeledon",
+    coords: [9.3787, -83.7008, 14],
+  },
+  {
+    slug: "el-general",
+    label: "El General",
+    parentSlug: "perez-zeledon",
+    coords: [9.355, -83.655, 14],
+  },
+  {
+    slug: "daniel-flores",
+    label: "Daniel Flores",
+    parentSlug: "perez-zeledon",
+    coords: [9.345, -83.68, 14],
+  },
   { slug: "rivas", label: "Rivas", parentSlug: "perez-zeledon", coords: [9.465, -83.685, 13] },
-  { slug: "san-pedro", label: "San Pedro", parentSlug: "perez-zeledon", coords: [9.315, -83.63, 13] },
-  { slug: "platanares", label: "Platanares", parentSlug: "perez-zeledon", coords: [9.31, -83.72, 13] },
+  {
+    slug: "san-pedro",
+    label: "San Pedro",
+    parentSlug: "perez-zeledon",
+    coords: [9.315, -83.63, 13],
+  },
+  {
+    slug: "platanares",
+    label: "Platanares",
+    parentSlug: "perez-zeledon",
+    coords: [9.31, -83.72, 13],
+  },
   { slug: "pejibaye", label: "Pejibaye", parentSlug: "perez-zeledon", coords: [9.28, -83.59, 13] },
   { slug: "cajon", label: "Cajón", parentSlug: "perez-zeledon", coords: [9.22, -83.61, 13] },
   { slug: "baru", label: "Barú", parentSlug: "perez-zeledon", coords: [9.29, -83.81, 13] },
-  { slug: "rio-nuevo", label: "Río Nuevo", parentSlug: "perez-zeledon", coords: [9.305, -83.77, 13] },
+  {
+    slug: "rio-nuevo",
+    label: "Río Nuevo",
+    parentSlug: "perez-zeledon",
+    coords: [9.305, -83.77, 13],
+  },
   { slug: "paramo", label: "Páramo", parentSlug: "perez-zeledon", coords: [9.51, -83.72, 13] },
-  { slug: "la-amistad", label: "La Amistad", parentSlug: "perez-zeledon", coords: [9.31, -83.52, 12] },
+  {
+    slug: "la-amistad",
+    label: "La Amistad",
+    parentSlug: "perez-zeledon",
+    coords: [9.31, -83.52, 12],
+  },
 ];
 
 // ─── Osa (Dominical–Uvita) — 6 Districts ───────────────────────────────────
 
 const OSA_DISTRICTS: District[] = [
-  { slug: "bahia-ballena", label: "Bahía Ballena", parentSlug: "dominical", coords: [9.155, -83.745, 14] },
-  { slug: "puerto-cortes", label: "Puerto Cortés", parentSlug: "ojochal", coords: [8.96, -83.53, 13] },
+  {
+    slug: "bahia-ballena",
+    label: "Bahía Ballena",
+    parentSlug: "dominical",
+    coords: [9.155, -83.745, 14],
+  },
+  {
+    slug: "puerto-cortes",
+    label: "Puerto Cortés",
+    parentSlug: "ojochal",
+    coords: [8.96, -83.53, 13],
+  },
   { slug: "palmar", label: "Palmar", parentSlug: "ojochal", coords: [8.95, -83.47, 13] },
   { slug: "sierpe", label: "Sierpe", parentSlug: "ojochal", coords: [8.87, -83.48, 13] },
-  { slug: "piedras-blancas", label: "Piedras Blancas", parentSlug: "ojochal", coords: [8.78, -83.35, 13] },
+  {
+    slug: "piedras-blancas",
+    label: "Piedras Blancas",
+    parentSlug: "ojochal",
+    coords: [8.78, -83.35, 13],
+  },
   { slug: "bahia-drake", label: "Bahía Drake", parentSlug: "ojochal", coords: [8.7, -83.55, 13] },
 ];
 
@@ -69,7 +119,12 @@ const QUEPOS_DISTRICTS: District[] = [
   { slug: "quepos-centro", label: "Quepos", parentSlug: "quepos", coords: [9.431, -84.162, 14] },
   { slug: "savegre", label: "Savegre", parentSlug: "quepos", coords: [9.32, -83.91, 13] },
   { slug: "naranjito", label: "Naranjito", parentSlug: "quepos", coords: [9.41, -84.07, 13] },
-  { slug: "manuel-antonio", label: "Manuel Antonio", parentSlug: "quepos", coords: [9.392, -84.14, 14] },
+  {
+    slug: "manuel-antonio",
+    label: "Manuel Antonio",
+    parentSlug: "quepos",
+    coords: [9.392, -84.14, 14],
+  },
 ];
 
 // ─── Full Canton Registry ───────────────────────────────────────────────────

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -1,0 +1,166 @@
+/**
+ * ACM Locations — Shared location hierarchy for RE/MAX Altitud ecosystem.
+ *
+ * Source of truth: ALTITUD HUB locations.js
+ * Structure: Cantón → Distrito → Poblado/Barrio
+ *
+ * This module is used by:
+ * - Sync pipeline (resolveSubLocation) to auto-tag properties on ingest
+ * - Search combobox (AreaSearchCombobox) for hierarchical area selection
+ * - Property cards (getPropertyLocation) for display labels
+ *
+ * When RECONNECT API sends Location = "Cajón de Pérez Zeledón, San José",
+ * we match "Cajón" → district slug "cajon" under parent "perez-zeledon".
+ */
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface District {
+  /** URL-safe slug for the district (e.g. "cajon") */
+  slug: string;
+  /** Display label (e.g. "Cajón") */
+  label: string;
+  /** Parent area slug this district belongs to (e.g. "perez-zeledon") */
+  parentSlug: string;
+  /** Coordinates [lat, lng, zoom] for map centering */
+  coords?: [number, number, number];
+}
+
+export interface Canton {
+  /** Display label (e.g. "Pérez Zeledón") */
+  label: string;
+  /** Area slug used in the website (e.g. "perez-zeledon") */
+  areaSlug: string;
+  /** Districts within this cantón */
+  districts: District[];
+}
+
+// ─── Pérez Zeledón — 12 Districts ───────────────────────────────────────────
+
+const PZ_DISTRICTS: District[] = [
+  { slug: "san-isidro", label: "San Isidro de El General", parentSlug: "perez-zeledon", coords: [9.3787, -83.7008, 14] },
+  { slug: "el-general", label: "El General", parentSlug: "perez-zeledon", coords: [9.355, -83.655, 14] },
+  { slug: "daniel-flores", label: "Daniel Flores", parentSlug: "perez-zeledon", coords: [9.345, -83.68, 14] },
+  { slug: "rivas", label: "Rivas", parentSlug: "perez-zeledon", coords: [9.465, -83.685, 13] },
+  { slug: "san-pedro", label: "San Pedro", parentSlug: "perez-zeledon", coords: [9.315, -83.63, 13] },
+  { slug: "platanares", label: "Platanares", parentSlug: "perez-zeledon", coords: [9.31, -83.72, 13] },
+  { slug: "pejibaye", label: "Pejibaye", parentSlug: "perez-zeledon", coords: [9.28, -83.59, 13] },
+  { slug: "cajon", label: "Cajón", parentSlug: "perez-zeledon", coords: [9.22, -83.61, 13] },
+  { slug: "baru", label: "Barú", parentSlug: "perez-zeledon", coords: [9.29, -83.81, 13] },
+  { slug: "rio-nuevo", label: "Río Nuevo", parentSlug: "perez-zeledon", coords: [9.305, -83.77, 13] },
+  { slug: "paramo", label: "Páramo", parentSlug: "perez-zeledon", coords: [9.51, -83.72, 13] },
+  { slug: "la-amistad", label: "La Amistad", parentSlug: "perez-zeledon", coords: [9.31, -83.52, 12] },
+];
+
+// ─── Osa (Dominical–Uvita) — 6 Districts ───────────────────────────────────
+
+const OSA_DISTRICTS: District[] = [
+  { slug: "bahia-ballena", label: "Bahía Ballena", parentSlug: "dominical", coords: [9.155, -83.745, 14] },
+  { slug: "puerto-cortes", label: "Puerto Cortés", parentSlug: "ojochal", coords: [8.96, -83.53, 13] },
+  { slug: "palmar", label: "Palmar", parentSlug: "ojochal", coords: [8.95, -83.47, 13] },
+  { slug: "sierpe", label: "Sierpe", parentSlug: "ojochal", coords: [8.87, -83.48, 13] },
+  { slug: "piedras-blancas", label: "Piedras Blancas", parentSlug: "ojochal", coords: [8.78, -83.35, 13] },
+  { slug: "bahia-drake", label: "Bahía Drake", parentSlug: "ojochal", coords: [8.7, -83.55, 13] },
+];
+
+// ─── Quepos — 4 Districts ───────────────────────────────────────────────────
+
+const QUEPOS_DISTRICTS: District[] = [
+  { slug: "quepos-centro", label: "Quepos", parentSlug: "quepos", coords: [9.431, -84.162, 14] },
+  { slug: "savegre", label: "Savegre", parentSlug: "quepos", coords: [9.32, -83.91, 13] },
+  { slug: "naranjito", label: "Naranjito", parentSlug: "quepos", coords: [9.41, -84.07, 13] },
+  { slug: "manuel-antonio", label: "Manuel Antonio", parentSlug: "quepos", coords: [9.392, -84.14, 14] },
+];
+
+// ─── Full Canton Registry ───────────────────────────────────────────────────
+
+export const ACM_CANTONS: Canton[] = [
+  {
+    label: "Pérez Zeledón",
+    areaSlug: "perez-zeledon",
+    districts: PZ_DISTRICTS,
+  },
+  {
+    label: "Osa (Dominical–Uvita)",
+    areaSlug: "dominical",
+    districts: OSA_DISTRICTS,
+  },
+  {
+    label: "Quepos",
+    areaSlug: "quepos",
+    districts: QUEPOS_DISTRICTS,
+  },
+];
+
+// ─── Exports for convenience ────────────────────────────────────────────────
+
+/** All districts across all cantons */
+export const ALL_DISTRICTS: District[] = ACM_CANTONS.flatMap((c) => c.districts);
+
+/** Quick slug → District lookup */
+export const DISTRICT_BY_SLUG: Record<string, District> = Object.fromEntries(
+  ALL_DISTRICTS.map((d) => [d.slug, d]),
+);
+
+/** Get display label for a district slug, or title-case fallback */
+export function getDistrictLabel(slug: string): string {
+  const d = DISTRICT_BY_SLUG[slug];
+  if (d) return d.label;
+  // Fallback: title-case the slug
+  return slug
+    .split("-")
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/** Get parent area slug for a district */
+export function getDistrictParent(slug: string): string | null {
+  return DISTRICT_BY_SLUG[slug]?.parentSlug ?? null;
+}
+
+// ─── Keyword Matching (for resolving API Location strings) ──────────────────
+
+/**
+ * Maps keyword strings → district slugs for text-based resolution.
+ * Ordered longest-first so "San Isidro de El General" matches before "San Isidro".
+ */
+export const DISTRICT_KEYWORDS: { keyword: string; slug: string; parent: string }[] = [
+  // PZ — longest first
+  { keyword: "san isidro de el general", slug: "san-isidro", parent: "perez-zeledon" },
+  { keyword: "san gerardo de rivas", slug: "rivas", parent: "perez-zeledon" },
+  { keyword: "daniel flores", slug: "daniel-flores", parent: "perez-zeledon" },
+  { keyword: "general viejo", slug: "el-general", parent: "perez-zeledon" },
+  { keyword: "río nuevo", slug: "rio-nuevo", parent: "perez-zeledon" },
+  { keyword: "rio nuevo", slug: "rio-nuevo", parent: "perez-zeledon" },
+  { keyword: "la amistad", slug: "la-amistad", parent: "perez-zeledon" },
+  { keyword: "san gerardo", slug: "rivas", parent: "perez-zeledon" },
+  { keyword: "san isidro", slug: "san-isidro", parent: "perez-zeledon" },
+  { keyword: "el general", slug: "el-general", parent: "perez-zeledon" },
+  { keyword: "san pedro", slug: "san-pedro", parent: "perez-zeledon" },
+  { keyword: "platanares", slug: "platanares", parent: "perez-zeledon" },
+  { keyword: "tinamastes", slug: "baru", parent: "perez-zeledon" },
+  { keyword: "tinamaste", slug: "baru", parent: "perez-zeledon" },
+  { keyword: "pejibaye", slug: "pejibaye", parent: "perez-zeledon" },
+  { keyword: "chimirol", slug: "rivas", parent: "perez-zeledon" },
+  { keyword: "páramo", slug: "paramo", parent: "perez-zeledon" },
+  { keyword: "paramo", slug: "paramo", parent: "perez-zeledon" },
+  { keyword: "cajón", slug: "cajon", parent: "perez-zeledon" },
+  { keyword: "cajon", slug: "cajon", parent: "perez-zeledon" },
+  { keyword: "rivas", slug: "rivas", parent: "perez-zeledon" },
+  { keyword: "barú", slug: "baru", parent: "perez-zeledon" },
+  { keyword: "baru", slug: "baru", parent: "perez-zeledon" },
+  // Osa
+  { keyword: "bahía ballena", slug: "bahia-ballena", parent: "dominical" },
+  { keyword: "bahia ballena", slug: "bahia-ballena", parent: "dominical" },
+  { keyword: "puerto cortés", slug: "puerto-cortes", parent: "ojochal" },
+  { keyword: "puerto cortes", slug: "puerto-cortes", parent: "ojochal" },
+  { keyword: "piedras blancas", slug: "piedras-blancas", parent: "ojochal" },
+  { keyword: "bahía drake", slug: "bahia-drake", parent: "ojochal" },
+  { keyword: "bahia drake", slug: "bahia-drake", parent: "ojochal" },
+  { keyword: "sierpe", slug: "sierpe", parent: "ojochal" },
+  { keyword: "palmar", slug: "palmar", parent: "ojochal" },
+  // Quepos
+  { keyword: "manuel antonio", slug: "manuel-antonio", parent: "quepos" },
+  { keyword: "naranjito", slug: "naranjito", parent: "quepos" },
+  { keyword: "savegre", slug: "savegre", parent: "quepos" },
+];

--- a/src/store/unit-store.ts
+++ b/src/store/unit-store.ts
@@ -1,0 +1,68 @@
+/**
+ * Zustand store for area-unit preference (m² / ft²).
+ *
+ * Replaces the per-component useState approach in useLocaleUnits so that
+ * every consumer (UnitToggle, SplitViewLayout, PropertyCard, MapPopup, …)
+ * shares a single reactive value.  Toggling in one component instantly
+ * re-renders all others.
+ *
+ * Persistence: localStorage key "unit-preference".
+ *
+ * Hydration safety: the store initialises with a `null` sentinel.
+ * `initFromLocale(locale)` must be called once (client-side) to reconcile
+ * with localStorage.  Until that call, consumers fall back to "metric".
+ *
+ * IMPORTANT: This file MUST NOT have a "use client" directive.
+ * Zustand stores are plain TypeScript modules.
+ */
+
+import { create } from "zustand";
+import { detectDefaultUnitSystem, type UnitSystem } from "@/lib/utils/units";
+
+const STORAGE_KEY = "unit-preference";
+
+function readStoredPreference(): UnitSystem | null {
+  try {
+    if (typeof window === "undefined") return null;
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    return stored === "metric" || stored === "imperial" ? stored : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredPreference(value: UnitSystem): void {
+  try {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(STORAGE_KEY, value);
+  } catch {
+    /* noop — storage unavailable */
+  }
+}
+
+export interface UnitStore {
+  /** Current unit system. `null` means "not yet initialised". */
+  unitSystem: UnitSystem | null;
+  /** Initialise from locale default + localStorage override. Idempotent. */
+  initFromLocale: (locale: string) => void;
+  /** Toggle between metric ↔ imperial, persist to localStorage. */
+  toggleUnits: () => void;
+}
+
+export const useUnitStore = create<UnitStore>()((set, get) => ({
+  unitSystem: null,
+
+  initFromLocale: (locale: string) => {
+    // Only initialise once — subsequent calls are no-ops.
+    if (get().unitSystem !== null) return;
+    const stored = readStoredPreference();
+    set({ unitSystem: stored ?? detectDefaultUnitSystem(locale) });
+  },
+
+  toggleUnits: () => {
+    const current = get().unitSystem ?? "metric";
+    const next: UnitSystem = current === "metric" ? "imperial" : "metric";
+    writeStoredPreference(next);
+    set({ unitSystem: next });
+  },
+}));


### PR DESCRIPTION
# Area/Location System Redesign

## Problem
Pérez Zeledón is a huge canton with 12 districts, but the system treated it as one flat area. Property cards all showed "Pérez Zeledón" even when the API had specific locations like "Cajón" or "Rivas". The area dropdown could not scale to many locations.

## Architecture: Single Source of Truth

The core of this redesign is `src/lib/locations.ts` — a **shared module** that replaces all the scattered, hardcoded district mappings across the codebase. It mirrors the ALTITUD HUB's `acm-locations.js` so both systems stay in sync.

The module exports:
- `ACM_CANTONS` — Full hierarchy (Cantón → Distrito with coords)
- `ALL_DISTRICTS` — Flat list of all districts
- `DISTRICT_BY_SLUG` — Quick slug → District lookup
- `getDistrictLabel(slug)` — Display label for any district slug
- `DISTRICT_KEYWORDS` — Keyword → slug mapping for text-based resolution

---

## What Changed

### New Shared Locations Module
`src/lib/locations.ts` — 22 districts across 3 cantons:
- **Pérez Zeledón**: 12 districts (San Isidro, El General, Daniel Flores, Rivas, San Pedro, Platanares, Pejibaye, Cajón, Barú, Río Nuevo, Páramo, La Amistad)
- **Osa**: 6 districts (Bahía Ballena, Puerto Cortés, Palmar, Sierpe, Piedras Blancas, Bahía Drake)
- **Quepos**: 4 districts (Quepos, Savegre, Naranjito, Manuel Antonio)

### RECONNECT API Sync Integration
`src/lib/db/queries/properties.ts` — `resolveSubLocation()` now:
- Imports `DISTRICT_KEYWORDS` from the shared module
- Resolves sub-locations for **all areas** (PZ, Osa, Quepos) — not just PZ
- Runs automatically on every sync via `upsertProperty()`
- Sets `sub_location` in both `values` (insert) and `mutableSet` (update)

### New Searchable Combobox
`src/components/search/area-search-combobox.tsx` — type-to-filter, grouped by region, keyboard nav, dark/light themes.

### Search Backend
`src/app/actions/search-actions.ts` — `formatSubLocationLabel` now uses `getDistrictLabel()` from the shared module.

### Property Cards
`src/components/property/property-card.tsx` — `getSubLocationLabel()` uses `getDistrictLabel()` from the shared module. Shows "Cajón, Pérez Zeledón" instead of just "Pérez Zeledón".

### Database Schema
- `src/lib/db/schema/properties.ts`: Added `subLocation` column
- `src/lib/db/migrations/0022_add_sub_location.sql`: Migration SQL

---

## Files That No Longer Have Hardcoded Location Data

| File | Before | After |
|------|--------|-------|
| `search-actions.ts` | 12-entry `knownSubLocations` map | `getDistrictLabel(slug)` |
| `property-card.tsx` | 12-entry `SUB_LOCATION_LABELS` map | `getDistrictLabel(slug)` |
| `properties.ts` (queries) | 23-entry `PZ_DISTRICT_KEYWORDS` array | `DISTRICT_KEYWORDS` import |

---

## Post-Merge Steps

> **Run the migration + populate data** (in order):
> 1. Apply migration: `0022_add_sub_location.sql`
> 2. Populate existing data: `npx tsx src/lib/db/scripts/populate-sub-locations.ts`

After that, every future sync will automatically set `sub_location` via the updated `upsertProperty()`.

## Verification
- ✅ `npx tsc --noEmit` — zero errors
- ✅ `npm run build` — compiled successfully
- Manual testing needed: start dev server and verify combobox + card labels
