### PR TITLE
Feature : Search Bar Redesign & Filter Enhancements

### DIFF
--- a/src/app/actions/search-actions.ts
+++ b/src/app/actions/search-actions.ts
@@ -184,7 +184,7 @@ const DB_TYPE_TO_SPANISH: Record<string, string> = {
   Condo: "Apartamento",
   Lot: "Lote",
   "Lot/Land": "Lote",
-  Land: "Terreno",
+  Land: "Lote",
   Commercial: "Comercial",
   Farm: "Finca",
   Ranch: "Finca",

--- a/src/components/home/hero-search-shell.tsx
+++ b/src/components/home/hero-search-shell.tsx
@@ -125,8 +125,8 @@ const TYPE_KEYWORDS: Record<string, string> = {
   condominio: "Apartamento",
   lote: "Lote",
   lot: "Lote",
-  terreno: "Terreno",
-  land: "Terreno",
+  terreno: "Lote",
+  land: "Lote",
   comercial: "Comercial",
   commercial: "Comercial",
   finca: "Finca",
@@ -137,8 +137,7 @@ const TYPE_KEYWORDS: Record<string, string> = {
 const TYPE_LABELS: Record<string, { en: string; es: string }> = {
   Casa: { en: "House", es: "Casa" },
   Apartamento: { en: "Apartment", es: "Apartamento" },
-  Lote: { en: "Lot", es: "Lote" },
-  Terreno: { en: "Land", es: "Terreno" },
+  Lote: { en: "Lot / Land", es: "Lote / Terreno" },
   Comercial: { en: "Commercial", es: "Comercial" },
   Finca: { en: "Farm", es: "Finca" },
 };
@@ -209,7 +208,7 @@ const FEATURE_KEYWORDS: Record<string, { q: string; label: { en: string; es: str
   jardin: { q: "garden jardín jardin", label: { en: "Garden", es: "Jardín" } },
 };
 
-const PROPERTY_TYPES = ["Casa", "Apartamento", "Lote", "Terreno", "Comercial", "Finca"];
+const PROPERTY_TYPES = ["Casa", "Apartamento", "Lote", "Comercial", "Finca"];
 
 // Sub-location keyword → slug mapping for smart search
 // Aligned with ALTITUD HUB locations.js — 12 districts of Pérez Zeledón

--- a/src/components/search/search-command-palette.tsx
+++ b/src/components/search/search-command-palette.tsx
@@ -192,8 +192,8 @@ const TYPE_KEYWORDS: Record<string, string> = {
   condominio: "Apartamento",
   lote: "Lote",
   lot: "Lote",
-  terreno: "Terreno",
-  land: "Terreno",
+  terreno: "Lote",
+  land: "Lote",
   comercial: "Comercial",
   commercial: "Comercial",
   finca: "Finca",
@@ -204,8 +204,7 @@ const TYPE_KEYWORDS: Record<string, string> = {
 const TYPE_LABELS: Record<string, { en: string; es: string }> = {
   Casa: { en: "House", es: "Casa" },
   Apartamento: { en: "Apartment", es: "Apartamento" },
-  Lote: { en: "Lot", es: "Lote" },
-  Terreno: { en: "Land", es: "Terreno" },
+  Lote: { en: "Lot / Land", es: "Lote / Terreno" },
   Comercial: { en: "Commercial", es: "Comercial" },
   Finca: { en: "Farm", es: "Finca" },
 };

--- a/src/components/search/search-filter-bar.tsx
+++ b/src/components/search/search-filter-bar.tsx
@@ -38,7 +38,7 @@ import type { FilterFacets } from "@/types/search";
 /** Property types that are land/lot — hides bedrooms and bathrooms (AC #2) */
 const LAND_TYPES = ["Lote", "Terreno", "Finca"];
 
-const PROPERTY_TYPES = ["Casa", "Apartamento", "Lote", "Terreno", "Comercial", "Finca"];
+const PROPERTY_TYPES = ["Casa", "Apartamento", "Lote", "Comercial", "Finca"];
 
 const BEDROOM_OPTIONS = [1, 2, 3, 4, 5];
 const BATHROOM_OPTIONS = [1, 2, 3, 4];
@@ -83,10 +83,23 @@ export function SearchFilterBar({
   const priceValue: [number, number] = [filters.priceMin ?? 0, filters.priceMax ?? 5_000_000];
 
   /** Get facet count label for a property type, e.g. "Casa (12)" */
+  /** Display label for a property type — "Lote" renders as "Lote / Terreno" */
+  function typeDisplayName(type: string): string {
+    return type === "Lote" ? "Lote / Terreno" : type;
+  }
+
   function typeLabel(type: string): string {
-    if (!facets) return type;
+    const display = typeDisplayName(type);
+    if (!facets) return display;
+    if (type === "Lote") {
+      // Combine Lote + Terreno facet counts
+      const loteCount = facets.byType.find((f) => f.value === "Lote")?.count ?? 0;
+      const terrenoCount = facets.byType.find((f) => f.value === "Terreno")?.count ?? 0;
+      const total = loteCount + terrenoCount;
+      return total > 0 ? `${display} (${total})` : display;
+    }
     const facet = facets.byType.find((f) => f.value === type);
-    return facet ? `${type} (${facet.count})` : type;
+    return facet ? `${display} (${facet.count})` : display;
   }
 
   /** Build options for the Listing Type dropdown */
@@ -97,11 +110,19 @@ export function SearchFilterBar({
 
   /** Build options for the Property Type dropdown */
   const propertyTypeOptions = PROPERTY_TYPES.map((type) => {
-    const facet = facets?.byType.find((f) => f.value === type);
+    let count: number | undefined;
+    if (type === "Lote") {
+      const loteCount = facets?.byType.find((f) => f.value === "Lote")?.count ?? 0;
+      const terrenoCount = facets?.byType.find((f) => f.value === "Terreno")?.count ?? 0;
+      const total = loteCount + terrenoCount;
+      count = total > 0 ? total : undefined;
+    } else {
+      count = facets?.byType.find((f) => f.value === type)?.count;
+    }
     return {
       value: type,
-      label: type,
-      count: facet?.count,
+      label: type === "Lote" ? "Lote / Terreno" : type,
+      count,
     };
   });
 


### PR DESCRIPTION
# Search Bar Redesign & Filter Enhancements

## Overview

Comprehensive redesign of the search filter bar and supporting search infrastructure. Replaces native `<select>` dropdowns with custom Radix Popover-based `FilterDropdown` components, adds sub-location search support for Pérez Zeledón districts, introduces property type badges on cards, syncs unit preferences via a shared Zustand store, and consolidates the "Lote" and "Terreno" property types into a single unified filter option.

## Changes

### Search Filter Bar Redesign
- **`src/components/search/search-filter-bar.tsx`** — Replaced native `<select>` elements with custom `FilterDropdown` popover components for a polished desktop experience. Merged the toolbar (ViewMode, Sort, NearMe, UnitToggle) into the filter row. Added lifestyle tag chips row. Mobile sheet retains native selects for better touch UX.
- **`src/components/search/filter-dropdown.tsx`** *(NEW)* — Reusable Radix Popover dropdown with facet count badges, keyboard navigation, and a clean design matching the brand aesthetic.
- **`src/components/search/price-filter-popover.tsx`** *(NEW)* — Compact button-triggered popover wrapping the price range slider.
- **`src/components/search/filter-chips.tsx`** — Added sub-location filter chip display support.

### Sub-Location Search Support
- **`src/lib/locations.ts`** *(NEW)* — Shared locations module aligned with ALTITUD HUB hierarchy. Provides district labels, slug lookups, and parent area resolution for Pérez Zeledón's 12 districts.
- **`src/components/search/area-search-combobox.tsx`** *(NEW)* — Grouped area dropdown with optgroup-style PZ sub-locations and search/filter capability.
- **`src/components/home/hero-search-shell.tsx`** — Added sub-location keyword matching to smart search parser. Keywords like "San Isidro", "Rivas", "Cajón" now resolve to the correct PZ district and set both `area` and `sub_location` params.
- **`src/components/search/search-command-palette.tsx`** — Mirrored sub-location support from hero search.
- **`src/app/actions/search-actions.ts`** — Added `subLocation` filter dimension to the query builder. Added `getAvailableAreas` action returning hierarchical area + sub-location list.
- **`src/hooks/use-search-filters.ts`** — Added `subLocation` to the filter state and URL sync.
- **`src/types/search.ts`** — Added `subLocation` field to `SearchFilters` type.
- **`src/lib/db/schema/properties.ts`** — Added `subLocation` column.
- **`src/lib/db/migrations/0022_add_sub_location.sql`** *(NEW)* — Migration adding `sub_location` column.
- **`src/lib/db/scripts/populate-sub-locations.ts`** *(NEW)* — Script to populate sub-location data from existing property addresses.
- **`src/lib/db/scripts/analyze-locations.ts`** *(NEW)* — Analysis script for location data coverage.

### Property Type Badges
- **`src/components/property/property-card.tsx`** — Added color-coded property type badges (Casa, Apartamento, Lote, Terreno, Comercial, Finca) with bilingual labels. Hides beds/baths for land types. Merged "Land" and "Lot" into a single badge.

### Lote / Terreno Consolidation
- **`src/components/search/search-filter-bar.tsx`** — Merged "Lote" and "Terreno" into a single "Lote / Terreno" dropdown option with combined facet counts.
- **`src/components/home/hero-search-shell.tsx`** — Updated TYPE_KEYWORDS so `terreno`/`land` resolve to `"Lote"`. Updated TYPE_LABELS to display "Lote / Terreno".
- **`src/components/search/search-command-palette.tsx`** — Same keyword and label consolidation.
- **`src/app/actions/search-actions.ts`** — Changed `DB_TYPE_TO_SPANISH` so `Land` maps to `"Lote"` for unified facet aggregation.

### Unit Preference Sync
- **`src/store/unit-store.ts`** *(NEW)* — Shared Zustand store for area unit preference (m², acres, hectares) with localStorage persistence.
- **`src/hooks/use-locale-units.ts`** — Refactored to use the shared Zustand store so toggling units in the filter bar updates property cards and all other components in real-time.

### Map Popup
- **`src/components/map/map-view.tsx`** — Added click handler on property markers to show popup.
- **`src/components/map/map-property-popup.tsx`** — Added `onClose` prop support.

### UI Polish & Fixes
- **`src/components/search/sort-select.tsx`** — Redesigned to match filter dropdown style.
- **`src/components/search/view-mode-toggle.tsx`** — Refined styling.
- **`src/components/search/split-view-layout.tsx`** — Integrated toolbar controls into filter bar, adjusted layout.
- **`src/components/search/search-page-client.tsx`** — Wired up new filter bar props (viewMode, onNearMe, resultCount, areas).
- **`src/components/search/lifestyle-tag-chips.tsx`** — Slimmer compact chip styling.
- **`src/messages/en.json`** / **`src/messages/es.json`** — Added i18n keys for new filter labels.

### Code Quality
- Resolved all ESLint warnings across multiple files (unused vars, a11y, img elements).
- Fixed Prettier formatting in 12+ files.
- Added `propertySearchColumns` and `mapPropertyRowToSearchItem` helpers to `src/lib/db/queries/properties.ts`.

## Testing

- Verified filter dropdowns render correctly on desktop and mobile.
- Confirmed "Lote / Terreno" appears as a single option with combined count.
- Confirmed smart search keywords (`terreno`, `land`, `lote`, `lot`) all resolve to the same filter.
- Verified sub-location keywords resolve correctly in hero search and command palette.
- Property type badges display with correct colors and bilingual labels.
- Unit toggle syncs across all components via Zustand store.
- Production build compiles successfully.
