### PR TITLE
Fix : Search Bar Redesign & Filter Improvements

### DIFF
--- a/src/components/search/lifestyle-tag-chips.tsx
+++ b/src/components/search/lifestyle-tag-chips.tsx
@@ -21,12 +21,27 @@
 import { useTranslations } from "next-intl";
 import { LIFESTYLE_TAGS, tagDisplayLabel } from "@/lib/constants/lifestyle-tags";
 
+/**
+ * Property-type tags that should set the `type` filter (propertyType column)
+ * instead of the `tags` filter (lifestyleTags array column).
+ */
+const PROPERTY_TYPE_TAGS = new Set(["Casa", "Lote", "Finca"]);
+
 interface LifestyleTagChipsProps {
   activeTags: string[];
   onToggle: (tag: string) => void;
+  /** Current active property type filter (from the type dropdown) */
+  activeType?: string;
+  /** Callback to toggle a property-type chip (sets the `type` filter) */
+  onTypeToggle?: (type: string) => void;
 }
 
-export function LifestyleTagChips({ activeTags, onToggle }: LifestyleTagChipsProps) {
+export function LifestyleTagChips({
+  activeTags,
+  onToggle,
+  activeType,
+  onTypeToggle,
+}: LifestyleTagChipsProps) {
   const t = useTranslations("SearchPage");
 
   /**
@@ -48,14 +63,24 @@ export function LifestyleTagChips({ activeTags, onToggle }: LifestyleTagChipsPro
       className="flex gap-2 flex-wrap md:flex-nowrap overflow-x-auto"
     >
       {LIFESTYLE_TAGS.map((tag) => {
-        const isActive = activeTags.includes(tag);
+        const isPropertyType = PROPERTY_TYPE_TAGS.has(tag);
+        const isActive = isPropertyType ? activeType === tag : activeTags.includes(tag);
         const slug = tag.toLowerCase().replace(/\s+/g, "-");
+
+        const handleClick = () => {
+          if (isPropertyType && onTypeToggle) {
+            onTypeToggle(tag);
+          } else {
+            onToggle(tag);
+          }
+        };
+
         return (
           <button
             key={tag}
             type="button"
             data-testid={`lifestyle-tag-chip-${slug}`}
-            onClick={() => onToggle(tag)}
+            onClick={handleClick}
             aria-pressed={isActive}
             className={[
               "h-8 px-3.5 rounded-full text-xs font-medium transition-all duration-200 border",

--- a/src/components/search/search-filter-bar.tsx
+++ b/src/components/search/search-filter-bar.tsx
@@ -78,6 +78,11 @@ export function SearchFilterBar({
 
   const [mobileSheetOpen, setMobileSheetOpen] = useState(false);
 
+  /** Toggle a property-type chip — same effect as choosing from the Type dropdown */
+  const handleTypeToggle = (type: string) => {
+    setFilter("type", filters.type === type ? undefined : type);
+  };
+
   const isLandType = filters.type ? LAND_TYPES.includes(filters.type) : false;
 
   const priceValue: [number, number] = [filters.priceMin ?? 0, filters.priceMax ?? 5_000_000];
@@ -149,7 +154,12 @@ export function SearchFilterBar({
   const mobileFilterControls = (
     <div className="flex flex-wrap items-center gap-3 w-full">
       {/* Story 3.4: Lifestyle tag chips (AC #1, #2, #3) */}
-      <LifestyleTagChips activeTags={filters.tags ?? []} onToggle={toggleTag} />
+      <LifestyleTagChips
+        activeTags={filters.tags ?? []}
+        onToggle={toggleTag}
+        activeType={filters.type}
+        onTypeToggle={handleTypeToggle}
+      />
       {/* Listing Type dropdown (Sale / Lease) */}
       <div className="flex flex-col gap-1">
         <label className="text-xs font-medium text-muted-foreground">
@@ -309,7 +319,12 @@ export function SearchFilterBar({
           <div className="hidden md:flex flex-col gap-1 w-full">
             {/* Row 1: Lifestyle Tags (compact, scrollable) */}
             <div className="w-full overflow-x-auto no-scrollbar">
-              <LifestyleTagChips activeTags={filters.tags ?? []} onToggle={toggleTag} />
+              <LifestyleTagChips
+                activeTags={filters.tags ?? []}
+                onToggle={toggleTag}
+                activeType={filters.type}
+                onTypeToggle={handleTypeToggle}
+              />
             </div>
 
             {/* Row 2: All controls in a single unified row */}

--- a/src/components/search/split-view-layout.tsx
+++ b/src/components/search/split-view-layout.tsx
@@ -169,7 +169,7 @@ export function SplitViewLayout({
             // Desktop: show in split/grid mode, hide in full-map mode
             gridHidden ? "lg:hidden" : mapHidden ? "lg:w-full lg:block" : "lg:w-[65%] lg:block",
             "overflow-y-auto",
-            "h-full",
+            "h-full pt-2",
           )}
         >
           {/* Story 3.5: render PropertyGrid when filterProperties provided, else skeleton */}


### PR DESCRIPTION
# Search Bar Redesign & Filter Improvements

## Overview

Complete redesign of the search page filter bar with custom dropdown popovers, unified toolbar layout, and numerous bug fixes to ensure search filters, map pins, and property type chips all stay in sync.

## Changes

### Search Filter Bar Redesign
- **search-filter-bar.tsx**: Replaced native `<select>` dropdowns with custom `FilterDropdown` components (Radix Popover). Merged the toolbar (ViewMode, Sort, NearMe, UnitToggle) into the filter row. Added property-type toggle handler so Casa/Lote/Finca chips set the `type` filter correctly.
- **filter-dropdown.tsx** [NEW]: Custom dropdown component with popover, active state indicators, and facet count display.
- **price-filter-popover.tsx** [NEW]: Compact price range filter button with inline slider popover.
- **area-search-combobox.tsx** [NEW]: Searchable area/sub-location combobox with grouped display for PZ districts.

### Property Type Chip Fix (Casa/Lote/Finca → `type` filter)
- **lifestyle-tag-chips.tsx**: Fixed critical bug where clicking "House", "Lot", or "Farm" chips filtered by the `lifestyleTags` array column (returning only 3 results) instead of the `propertyType` column (returning 43+ results). Added `PROPERTY_TYPE_TAGS` set and `onTypeToggle` callback to route these chips through the correct filter.

### Map & Grid Filter Sync
- **map-actions.ts**: Extended `MapFilters` to include all search dimensions (price, bedrooms, bathrooms, lot size, area, sub-location, tags, keyword search) so map pins stay in sync with the grid.
- **split-view-layout.tsx**: Passes full filter state to `getPropertiesForMap` so split view keeps map and grid aligned. Added top padding to grid container.
- **search-page-client.tsx**: Wired all filter dimensions to map refetch triggers.

### Property Card Type Badges
- **property-card.tsx**: Added color-coded property type badge (House, Apartment, Lot, Commercial, Farm/Ranch) with consistent display mapping.
- **map-property-popup.tsx**: Enhanced popup with currency, unit preferences, listing type badge, and property type badge.

### Sub-Location Support
- **locations.ts** [NEW]: Shared locations module with ALTITUD HUB district hierarchy for Pérez Zeledón.
- **populate-sub-locations.ts** [NEW]: Script to populate sub-location field from property addresses.
- **0022_add_sub_location.sql** [NEW]: Migration adding `sub_location` column.

### Unit Store & Currency
- **unit-store.ts** [NEW]: Zustand store for unit preference (m²/ft²) shared across all components.
- **use-locale-units.ts**: Refactored to use shared Zustand store so the unit toggle updates all components simultaneously.

### Facet & Type Mapping Fixes
- **search-actions.ts**: Completed `DB_TYPE_TO_SPANISH` mapping with missing Spanish types and Business type. Added sub-location filter support.
- **filter-chips.tsx**: Added keyword search (`q`) chip display.

### Toolbar Consolidation
- **sort-select.tsx**: Converted to compact inline button for the unified toolbar.
- **view-mode-toggle.tsx**: Simplified for inline toolbar placement.

### Pre-commit Hooks
- **package.json**: Added husky and lint-staged for automatic pre-commit formatting.

### i18n
- **en.json** / **es.json**: Added translations for sub-location labels and new filter UI strings.

## Testing

- TypeScript compilation passes with zero errors
- Production build completes successfully
- No new lint errors introduced
- Verified that clicking Casa/Lote/Finca chips now correctly sets the `type` URL parameter instead of `tags`
- Verified the "All Types" dropdown and chips stay in sync