### PR TITLE
fix: force-dynamic rendering on homepage to show fresh listings

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -6,6 +6,10 @@ import { FeaturedCommunities } from "@/components/home/featured-communities";
 import { FeaturedAreas } from "@/components/home/featured-areas";
 import { VipSearchBanner } from "@/components/home/vip-search-banner";
 
+/** Opt out of static caching so DB-driven sections (featured properties,
+ *  communities, areas) always render with fresh data. */
+export const dynamic = "force-dynamic";
+
 export default async function HomePage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   setRequestLocale(locale);


### PR DESCRIPTION
## Problem

The homepage at `dev.remax-altitud.cr` was showing **"New listings coming soon"** placeholders instead of real property data.

### Root Cause

The homepage was being **statically cached** by Next.js/Vercel with `s-maxage=31536000` (1 year) and `x-nextjs-cache: HIT`. This means it was generated once at build time — when the DB query either failed or returned empty — and that stale HTML was served to all visitors.

The search page works because it uses dynamic rendering, but the homepage had no `dynamic` export and defaulted to static generation.

## Fix

Added `export const dynamic = 'force-dynamic'` to `src/app/[locale]/page.tsx` so the homepage always queries the database on each request, ensuring the Featured Properties, Communities, and Areas sections display current data.

## Verification

- Confirmed the deployed homepage returns `x-nextjs-cache: HIT` with year-long cache (the bug)
- Confirmed the search page on the same deployment returns real property data (DB is fine)
- Confirmed the local DB has 186 visible properties that render correctly with this fix