### PR TITLE
fix: register sub_location migration in journal and make idempotent

### DIFF
--- a/src/lib/db/migrations/0022_add_sub_location.sql
+++ b/src/lib/db/migrations/0022_add_sub_location.sql
@@ -1,1 +1,1 @@
-ALTER TABLE "properties" ADD COLUMN "sub_location" text;
+ALTER TABLE "properties" ADD COLUMN IF NOT EXISTS "sub_location" text;

--- a/src/lib/db/migrations/meta/_journal.json
+++ b/src/lib/db/migrations/meta/_journal.json
@@ -148,6 +148,13 @@
       "when": 1780455000000,
       "tag": "0021_update_dominical_area_guide_tokenized",
       "breakpoints": true
+    },
+    {
+      "idx": 21,
+      "version": "7",
+      "when": 1780458000000,
+      "tag": "0022_add_sub_location",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
The 0022_add_sub_location.sql migration file existed but was missing from the Drizzle journal, so it never ran on deploy. This adds it to the journal and makes it idempotent with IF NOT EXISTS.