### PR TITLE
chore: set community property types to Lots

### DIFF
--- a/src/lib/db/migrations/0023_set_community_property_types.sql
+++ b/src/lib/db/migrations/0023_set_community_property_types.sql
@@ -1,0 +1,4 @@
+-- Set property types for all communities to "Lots" / "Lotes"
+-- All current communities sell lots exclusively.
+UPDATE communities SET property_types_en = 'Lots', property_types_es = 'Lotes'
+WHERE property_types_en = '' OR property_types_en IS NULL;


### PR DESCRIPTION
Adds migration `0023_set_community_property_types.sql` that sets `property_types_en = 'Lots'` and `property_types_es = 'Lotes'` for all communities that currently have empty values. This makes the 'Lots' badge appear on each community card on the /communities page.