### PR TITLE
Fix : Print View Missing Photos

### DIFF
--- a/src/components/listing/property-print-view.tsx
+++ b/src/components/listing/property-print-view.tsx
@@ -106,7 +106,7 @@ export async function PropertyPrintView({
             {mainImage ? (
               <PropertyImage
                 src={mainImage.src}
-                alt={mainImage.alt}
+                alt={mainImage.alt || title}
                 fallbackSrc={mainImage.fallbackSrc}
                 fill
                 priority

--- a/src/components/listing/property-print-view.tsx
+++ b/src/components/listing/property-print-view.tsx
@@ -4,6 +4,7 @@ import { normalizePropertyImages } from "@/lib/utils/normalize-images";
 import { convertArea } from "@/lib/utils/units";
 import { SITE_ORIGIN } from "@/lib/seo/constants";
 import QRCode from "react-qr-code";
+import { PropertyImage } from "@/components/property/property-image";
 
 interface PropertyPrintViewProps {
   property: Property;
@@ -103,11 +104,14 @@ export async function PropertyPrintView({
           {/* Main Hero Image */}
           <div className="h-[75%] w-full relative overflow-hidden bg-gray-100">
             {mainImage ? (
-              /* eslint-disable-next-line @next/next/no-img-element */
-              <img
+              <PropertyImage
                 src={mainImage.src}
                 alt={mainImage.alt}
-                className="absolute inset-0 w-full h-full object-cover"
+                fallbackSrc={mainImage.fallbackSrc}
+                fill
+                priority
+                sizes="100vw"
+                className="object-cover"
               />
             ) : (
               <div className="absolute inset-0 flex items-center justify-center text-gray-300">
@@ -128,28 +132,40 @@ export async function PropertyPrintView({
           <div className="h-[25%] grid grid-cols-3 w-full border-t border-white">
             <div className="relative overflow-hidden bg-gray-200 border-r border-white">
               {secondaryImage1 && (
-                /* eslint-disable-next-line @next/next/no-img-element */ <img
+                <PropertyImage
                   src={secondaryImage1.src}
-                  alt="View 1"
-                  className="absolute inset-0 w-full h-full object-cover"
+                  alt={secondaryImage1.alt || "View 1"}
+                  fallbackSrc={secondaryImage1.fallbackSrc}
+                  fill
+                  priority
+                  sizes="33vw"
+                  className="object-cover"
                 />
               )}
             </div>
             <div className="relative overflow-hidden bg-gray-300 border-r border-white">
               {secondaryImage2 && (
-                /* eslint-disable-next-line @next/next/no-img-element */ <img
+                <PropertyImage
                   src={secondaryImage2.src}
-                  alt="View 2"
-                  className="absolute inset-0 w-full h-full object-cover"
+                  alt={secondaryImage2.alt || "View 2"}
+                  fallbackSrc={secondaryImage2.fallbackSrc}
+                  fill
+                  priority
+                  sizes="33vw"
+                  className="object-cover"
                 />
               )}
             </div>
             <div className="relative overflow-hidden bg-gray-400">
               {secondaryImage3 && (
-                /* eslint-disable-next-line @next/next/no-img-element */ <img
+                <PropertyImage
                   src={secondaryImage3.src}
-                  alt="View 3"
-                  className="absolute inset-0 w-full h-full object-cover"
+                  alt={secondaryImage3.alt || "View 3"}
+                  fallbackSrc={secondaryImage3.fallbackSrc}
+                  fill
+                  priority
+                  sizes="33vw"
+                  className="object-cover"
                 />
               )}
             </div>
@@ -166,6 +182,7 @@ export async function PropertyPrintView({
                 src="/images/brand/logo-remax-altitud.png"
                 alt="REMAX Altitud"
                 className="h-8 object-contain"
+                loading="eager"
               />
             </div>
           </div>


### PR DESCRIPTION
# Fix: Print View Missing Photos

## Overview
This PR resolves an issue where photos were not rendering when a user clicked the print button on a property detail page. The browser was deferring image loads for standard `<img>` tags inside the visually-hidden print container. By migrating to Next.js's optimized `PropertyImage` and forcing eager loading, we ensure images are available before the browser opens the print dialog.

## Changes
- **`src/components/listing/property-print-view.tsx`**
  - Replaced native `<img>` tags with `<PropertyImage>` to ensure robust loading behaviour and fallback handling.
  - Added the `priority={true}` attribute to force eager loading, bypassing lazy-loading mechanisms.
  - Passed `fallbackSrc` to handle edge cases if main or secondary images fail.
  - Added `alt={mainImage.alt || title}` to resolve strict TypeScript requirements (TS2322).
  - Ensured the `loading="eager"` attribute is present for the RE/MAX logo.

## Testing
- Verified TypeScript compilation using `npx tsc --noEmit`.
- Ran full production build `npm run build` to ensure no regression or build errors occur.
- Checked print layout visibility and verified eager loading behavior inside hidden containers.
