### PR TITLE
Feature : UX Enhancements and Printable Property Photos

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { SITE_ORIGIN } from "@/lib/seo/constants";
 import { SkipToContent } from "@/components/layout/skip-to-content";
 import { Header } from "@/components/layout/header";
 import { Footer } from "@/components/layout/footer";
+import { StickyMobileCta } from "@/components/layout/sticky-mobile-cta";
 
 const montserrat = Montserrat({
   subsets: ["latin", "latin-ext"],
@@ -101,8 +102,11 @@ export default async function LocaleLayout({
         <NextIntlClientProvider locale={locale} messages={messages}>
           <SkipToContent />
           <Header />
-          <main id="main-content">{children}</main>
+          <main id="main-content" className="pb-16 md:pb-0">
+            {children}
+          </main>
           <Footer />
+          <StickyMobileCta />
         </NextIntlClientProvider>
       </body>
     </html>

--- a/src/components/home/lifestyle-questionnaire.tsx
+++ b/src/components/home/lifestyle-questionnaire.tsx
@@ -33,11 +33,25 @@ export function LifestyleQuestionnaire({ initialProperties, locale }: LifestyleQ
     setStep(1);
   };
 
+  // Google Analytics event tracking helper
+  const trackEvent = (action: string, label: string) => {
+    if (typeof window !== "undefined" && "gtag" in window) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - gtag is dynamically injected
+      window.gtag("event", action, {
+        event_category: "LifestyleQuestionnaire",
+        event_label: label,
+      });
+    }
+  };
+
   const handleSelect = (choice: Choice) => {
+    trackEvent("select_option", `Step ${step}: ${choice}`);
     setAnswers((prev) => ({ ...prev, [step]: choice }));
   };
 
   const handleNext = () => {
+    trackEvent("next_step", `Completed Step ${step}`);
     if (step < totalQuestions) {
       setStep((prev) => prev + 1);
     } else {

--- a/src/components/layout/sticky-mobile-cta.tsx
+++ b/src/components/layout/sticky-mobile-cta.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Link } from "@/i18n/navigation";
+import { MessageCircle, Home } from "lucide-react";
+
+export function StickyMobileCta() {
+  const t = useTranslations("Navigation");
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-50 flex border-t border-brand-warm/20 bg-brand-navy pb-[env(safe-area-inset-bottom)] md:hidden">
+      <Link
+        href="/contact"
+        className="flex flex-1 items-center justify-center gap-2 border-r border-brand-warm/20 py-4 text-sm font-semibold text-white transition-colors hover:bg-white/5"
+      >
+        <MessageCircle className="size-4" />
+        {t("contact")}
+      </Link>
+      <Link
+        href="/sell"
+        className="flex flex-1 items-center justify-center gap-2 bg-brand-burgundy py-4 text-sm font-semibold text-white transition-colors hover:bg-brand-burgundy/90"
+      >
+        <Home className="size-4" />
+        {t("sellYourProperty")}
+      </Link>
+    </div>
+  );
+}

--- a/src/components/listing/property-print-view.tsx
+++ b/src/components/listing/property-print-view.tsx
@@ -106,7 +106,7 @@ export async function PropertyPrintView({
             {mainImage ? (
               <PropertyImage
                 src={mainImage.src}
-                alt={mainImage.alt}
+                alt={mainImage.alt || title}
                 fallbackSrc={mainImage.fallbackSrc}
                 fill
                 priority

--- a/src/components/listing/property-print-view.tsx
+++ b/src/components/listing/property-print-view.tsx
@@ -4,6 +4,7 @@ import { normalizePropertyImages } from "@/lib/utils/normalize-images";
 import { convertArea } from "@/lib/utils/units";
 import { SITE_ORIGIN } from "@/lib/seo/constants";
 import QRCode from "react-qr-code";
+import { PropertyImage } from "@/components/property/property-image";
 
 interface PropertyPrintViewProps {
   property: Property;
@@ -103,11 +104,14 @@ export async function PropertyPrintView({
           {/* Main Hero Image */}
           <div className="h-[75%] w-full relative overflow-hidden bg-gray-100">
             {mainImage ? (
-              /* eslint-disable-next-line @next/next/no-img-element */
-              <img
+              <PropertyImage
                 src={mainImage.src}
                 alt={mainImage.alt}
-                className="absolute inset-0 w-full h-full object-cover"
+                fallbackSrc={mainImage.fallbackSrc}
+                fill
+                priority
+                sizes="100vw"
+                className="object-cover"
               />
             ) : (
               <div className="absolute inset-0 flex items-center justify-center text-gray-300">
@@ -128,28 +132,40 @@ export async function PropertyPrintView({
           <div className="h-[25%] grid grid-cols-3 w-full border-t border-white">
             <div className="relative overflow-hidden bg-gray-200 border-r border-white">
               {secondaryImage1 && (
-                /* eslint-disable-next-line @next/next/no-img-element */ <img
+                <PropertyImage
                   src={secondaryImage1.src}
-                  alt="View 1"
-                  className="absolute inset-0 w-full h-full object-cover"
+                  alt={secondaryImage1.alt || "View 1"}
+                  fallbackSrc={secondaryImage1.fallbackSrc}
+                  fill
+                  priority
+                  sizes="33vw"
+                  className="object-cover"
                 />
               )}
             </div>
             <div className="relative overflow-hidden bg-gray-300 border-r border-white">
               {secondaryImage2 && (
-                /* eslint-disable-next-line @next/next/no-img-element */ <img
+                <PropertyImage
                   src={secondaryImage2.src}
-                  alt="View 2"
-                  className="absolute inset-0 w-full h-full object-cover"
+                  alt={secondaryImage2.alt || "View 2"}
+                  fallbackSrc={secondaryImage2.fallbackSrc}
+                  fill
+                  priority
+                  sizes="33vw"
+                  className="object-cover"
                 />
               )}
             </div>
             <div className="relative overflow-hidden bg-gray-400">
               {secondaryImage3 && (
-                /* eslint-disable-next-line @next/next/no-img-element */ <img
+                <PropertyImage
                   src={secondaryImage3.src}
-                  alt="View 3"
-                  className="absolute inset-0 w-full h-full object-cover"
+                  alt={secondaryImage3.alt || "View 3"}
+                  fallbackSrc={secondaryImage3.fallbackSrc}
+                  fill
+                  priority
+                  sizes="33vw"
+                  className="object-cover"
                 />
               )}
             </div>
@@ -166,6 +182,7 @@ export async function PropertyPrintView({
                 src="/images/brand/logo-remax-altitud.png"
                 alt="REMAX Altitud"
                 className="h-8 object-contain"
+                loading="eager"
               />
             </div>
           </div>


### PR DESCRIPTION
# UX Enhancements and Printable Property Photos

## Overview
This pull request introduces several key UX enhancements targeting mobile lead conversion and user analytics, while also resolving an issue with property photos failing to render in the printable view.

## Changes
- **Mobile Lead Conversion (Sticky CTA)**
  - `[NEW] src/components/layout/sticky-mobile-cta.tsx`: Introduced a sticky bottom navigation bar exclusive to mobile views (`md:hidden`). It provides immediate access to "Contact Us" and "Sell Your Property" CTAs across the entire site.
  - `[MODIFY] src/app/[locale]/layout.tsx`: Injected the `StickyMobileCta` component into the global application layout and added `pb-16 md:pb-0` padding to the main content to prevent the sticky footer from occluding the standard site footer.
- **Lifestyle Questionnaire Analytics**
  - `[MODIFY] src/components/home/lifestyle-questionnaire.tsx`: Integrated Google Analytics event tracking. The component now fires `window.gtag` events when a user selects a lifestyle choice (A, B, or C) and when they progress to the next step, enabling deeper funnel analysis and drop-off tracking.
- **Printable View Fix**
  - `[MODIFY] src/components/listing/property-print-view.tsx`: Resolved the issue where photos were not correctly showing up in the printable version of the property listings. 

## Testing
- Verified `StickyMobileCta` only renders on small/mobile viewports and correctly anchors to the bottom.
- Verified Google Analytics `gtag` triggers gracefully bypass execution if the tracking script is unavailable or blocked, preventing runtime crashes.
- Ensured successful compilation via `npm run build` with zero linting errors on the new additions.
