### PR TITLE
Fix : Remove Redundant Sidebar Video & Add Translation

### DIFF
--- a/src/components/listing/listing-detail-layout.tsx
+++ b/src/components/listing/listing-detail-layout.tsx
@@ -267,90 +267,75 @@ export async function ListingDetailLayout({
                 officeName={officeName ?? t("unknownOffice")}
               />
 
-              {/* Altitud Perks for This Listing Widget / Video Embed */}
-              {property.youtubeUrl ? (
-                <div className="rounded-xl overflow-hidden shadow-md border border-brand-warm bg-white">
-                  <iframe
-                    src={`https://www.youtube.com/embed/${extractYoutubeVideoId(property.youtubeUrl)}`}
-                    title="Property Video"
-                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                    allowFullScreen
-                    loading="lazy"
-                    className="w-full aspect-video"
-                  />
+              {/* Altitud Perks for This Listing Widget */}
+              <div className="rounded-xl border border-brand-warm bg-white p-6 shadow-md space-y-4">
+                <h3 className="text-sm font-bold uppercase tracking-wider text-brand-gold-dark">
+                  {locale === "es" ? "La Ventaja Altitud" : "The Altitud Advantage"}
+                </h3>
+                <p className="text-xs text-text-muted font-medium">
+                  {locale === "es"
+                    ? "Beneficios exclusivos incluidos con esta propiedad:"
+                    : "Exclusive benefits included with this property:"}
+                </p>
+                <ul className="space-y-3.5 pt-2">
+                  <li className="flex items-start gap-3">
+                    <span className="flex size-7 items-center justify-center rounded-full bg-brand-gold/10 text-brand-gold-dark text-xs font-bold flex-shrink-0">
+                      💳
+                    </span>
+                    <div>
+                      <h4 className="text-xs font-bold text-brand-navy">
+                        {locale === "es" ? "Financiamiento hasta 80%" : "Up to 80% Financing"}
+                      </h4>
+                      <p className="text-[11px] text-text-muted mt-0.5 leading-relaxed">
+                        {locale === "es"
+                          ? "Disponible según su nacionalidad, score y propiedad."
+                          : "Available based on nationality, credit score, and property."}
+                      </p>
+                    </div>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <span className="flex size-7 items-center justify-center rounded-full bg-brand-gold/10 text-brand-gold-dark text-xs font-bold flex-shrink-0">
+                      📐
+                    </span>
+                    <div>
+                      <h4 className="text-xs font-bold text-brand-navy">
+                        {locale === "es"
+                          ? "Diseño de Propiedad Gratuito"
+                          : "Free Architectural Design"}
+                      </h4>
+                      <p className="text-[11px] text-text-muted mt-0.5 leading-relaxed">
+                        {locale === "es"
+                          ? "Convenios exclusivos con constructoras para su plano personalizado."
+                          : "Exclusive agreements with builders for your custom layout."}
+                      </p>
+                    </div>
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <span className="flex size-7 items-center justify-center rounded-full bg-brand-gold/10 text-brand-gold-dark text-xs font-bold flex-shrink-0">
+                      ⚖️
+                    </span>
+                    <div>
+                      <h4 className="text-xs font-bold text-brand-navy">
+                        {locale === "es" ? "Consulta Legal de Cortesía" : "Free Legal Consultation"}
+                      </h4>
+                      <p className="text-[11px] text-text-muted mt-0.5 leading-relaxed">
+                        {locale === "es"
+                          ? "Revisión de título y ZMT con nuestros abogados aliados."
+                          : "Title and ZMT review with our trusted partner attorneys."}
+                      </p>
+                    </div>
+                  </li>
+                </ul>
+                <div className="pt-3 border-t border-brand-warm text-center">
+                  <Link
+                    href="/about"
+                    className="inline-flex items-center gap-1.5 text-xs font-bold text-brand-navy hover:text-brand-navy-light transition-colors"
+                  >
+                    <span>{locale === "es" ? "Saber más" : "Learn more"}</span>
+                    <span aria-hidden="true">→</span>
+                  </Link>
                 </div>
-              ) : (
-                <div className="rounded-xl border border-brand-warm bg-white p-6 shadow-md space-y-4">
-                  <h3 className="text-sm font-bold uppercase tracking-wider text-brand-gold-dark">
-                    {locale === "es" ? "La Ventaja Altitud" : "The Altitud Advantage"}
-                  </h3>
-                  <p className="text-xs text-text-muted font-medium">
-                    {locale === "es"
-                      ? "Beneficios exclusivos incluidos con esta propiedad:"
-                      : "Exclusive benefits included with this property:"}
-                  </p>
-                  <ul className="space-y-3.5 pt-2">
-                    <li className="flex items-start gap-3">
-                      <span className="flex size-7 items-center justify-center rounded-full bg-brand-gold/10 text-brand-gold-dark text-xs font-bold flex-shrink-0">
-                        💳
-                      </span>
-                      <div>
-                        <h4 className="text-xs font-bold text-brand-navy">
-                          {locale === "es" ? "Financiamiento hasta 80%" : "Up to 80% Financing"}
-                        </h4>
-                        <p className="text-[11px] text-text-muted mt-0.5 leading-relaxed">
-                          {locale === "es"
-                            ? "Disponible según su nacionalidad, score y propiedad."
-                            : "Available based on nationality, credit score, and property."}
-                        </p>
-                      </div>
-                    </li>
-                    <li className="flex items-start gap-3">
-                      <span className="flex size-7 items-center justify-center rounded-full bg-brand-gold/10 text-brand-gold-dark text-xs font-bold flex-shrink-0">
-                        📐
-                      </span>
-                      <div>
-                        <h4 className="text-xs font-bold text-brand-navy">
-                          {locale === "es"
-                            ? "Diseño de Propiedad Gratuito"
-                            : "Free Architectural Design"}
-                        </h4>
-                        <p className="text-[11px] text-text-muted mt-0.5 leading-relaxed">
-                          {locale === "es"
-                            ? "Convenios exclusivos con constructoras para su plano personalizado."
-                            : "Exclusive agreements with builders for your custom layout."}
-                        </p>
-                      </div>
-                    </li>
-                    <li className="flex items-start gap-3">
-                      <span className="flex size-7 items-center justify-center rounded-full bg-brand-gold/10 text-brand-gold-dark text-xs font-bold flex-shrink-0">
-                        ⚖️
-                      </span>
-                      <div>
-                        <h4 className="text-xs font-bold text-brand-navy">
-                          {locale === "es"
-                            ? "Consulta Legal de Cortesía"
-                            : "Free Legal Consultation"}
-                        </h4>
-                        <p className="text-[11px] text-text-muted mt-0.5 leading-relaxed">
-                          {locale === "es"
-                            ? "Revisión de título y ZMT con nuestros abogados aliados."
-                            : "Title and ZMT review with our trusted partner attorneys."}
-                        </p>
-                      </div>
-                    </li>
-                  </ul>
-                  <div className="pt-3 border-t border-brand-warm text-center">
-                    <Link
-                      href="/about"
-                      className="inline-flex items-center gap-1.5 text-xs font-bold text-brand-navy hover:text-brand-navy-light transition-colors"
-                    >
-                      <span>{locale === "es" ? "Saber más" : "Learn more"}</span>
-                      <span aria-hidden="true">→</span>
-                    </Link>
-                  </div>
-                </div>
-              )}
+              </div>
             </div>
           </div>
 

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -540,6 +540,7 @@
       "Sale": "For Sale",
       "Lease": "For Lease"
     },
+    "videoTitle": "Property Video Tour",
     "description": "Description",
     "features": "Features & Amenities",
     "specs": {

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -540,6 +540,7 @@
       "Sale": "En Venta",
       "Lease": "En Alquiler"
     },
+    "videoTitle": "Video Tour de la Propiedad",
     "description": "Descripción",
     "features": "Características y Amenidades",
     "specs": {


### PR DESCRIPTION
# Fix: Remove Redundant Sidebar Video & Add Translation

## Overview
This PR removes the redundant video embed that incorrectly replaced the "Altitud Perks" widget in the sidebar, and adds the missing `videoTitle` translation key.

## Changes
- **src/components/listing/listing-detail-layout.tsx**:
  - Removed the ternary operator that conditionally rendered the video embed in the sidebar.
  - Ensured the "Altitud Perks" (La Ventaja Altitud) widget always renders in the right column, matching the intended design.
- **src/messages/en.json** & **src/messages/es.json**:
  - Added the `videoTitle` translation key within the `ListingDetail` namespace (`"Property Video Tour"` for English and `"Video Tour de la Propiedad"` for Spanish) so that the translation key string no longer shows up.

## Testing
- Verified successful lint check.
- Verified successful production build via `npm run build`.
