### PR TITLE
Feature: Simplify Sell With Us Form

### DIFF
--- a/src/components/seller/seller-form.tsx
+++ b/src/components/seller/seller-form.tsx
@@ -1,30 +1,7 @@
 "use client";
 
-/**
- * SellerForm — Story 5.1 (AC #2–#14)
- *
- * 3-step progressive form for seller lead capture.
- * Lazy-loaded via next/dynamic in sell/page.tsx (R-006 compliance).
- *
- * Step 1 (Basics ~60s):  Property Type, Location (LocationPicker), Size
- * Step 2 (Details ~90s): Price, Pricing Help, Description, Photos, Beds/Baths
- * Step 3 (Contact ~30s): Name, Phone, Email, Preferred Language
- *
- * data-testid contract (CANNOT rename):
- *   seller-form         — root wrapper
- *   progress-bar        — segmented progress indicator
- *   form-step-1         — step 1 container
- *   form-step-2         — step 2 container
- *   form-step-3         — step 3 container
- *   pricing-help-checkbox — pricing help checkbox
- *   beds-baths-fields   — conditional bedrooms/bathrooms container
- *   seller-confirmation — rendered by SellerConfirmation component
- */
-
 import { useState, useId, type FormEvent, type ChangeEvent } from "react";
 import { useTranslations } from "next-intl";
-import { useLocaleUnits } from "@/hooks/use-locale-units";
-import { LocationPicker, type LocationValue } from "@/components/seller/location-picker";
 import { SellerConfirmation } from "@/components/seller/seller-confirmation";
 import type { Agent } from "@/lib/db/schema/agents";
 
@@ -33,28 +10,15 @@ import type { Agent } from "@/lib/db/schema/agents";
 // ---------------------------------------------------------------------------
 
 export interface SellerFormData {
-  // Step 1
   propertyType: "Casa" | "Lote/Terreno" | "Finca" | "Condominio" | "Comercial" | "";
-  location: LocationValue;
-  size: string;
-  sizeUnit: "sqm" | "sqft" | "acres";
-  // Step 2
-  priceExpectation: string;
-  needsPricingHelp: boolean;
+  locationText: string;
   description: string;
-  photos: File[];
-  bedrooms: string;
-  bathrooms: string;
-  // Step 3
   name: string;
   phone: string;
   email: string;
-  preferredLanguage: "en" | "es";
 }
 
-type Step1Errors = Partial<Record<"propertyType" | "location" | "size", string>>;
-type Step2Errors = Partial<Record<"priceExpectation", string>>;
-type Step3Errors = Partial<Record<"name" | "phone" | "email", string>>;
+type FormErrors = Partial<Record<keyof SellerFormData, string>>;
 
 type PropertyType = SellerFormData["propertyType"];
 
@@ -69,13 +33,9 @@ const PROPERTY_TYPES: {
   { value: "Comercial", labelKey: "form.step1.typeCommercial" as never },
 ];
 
-// ---------------------------------------------------------------------------
-// buildLeadPayload — exported for test 5.1-COMP-002b
-// ---------------------------------------------------------------------------
-
 export interface LeadPayload {
   propertyType: string;
-  location: LocationValue;
+  location: { text: string; lat: null; lng: null };
   size: string;
   sizeUnit: string;
   priceExpectation: string | null;
@@ -90,28 +50,22 @@ export interface LeadPayload {
   notes: string;
 }
 
-export function buildLeadPayload(data: SellerFormData): LeadPayload {
-  const notes = data.needsPricingHelp ? "Seller needs pricing consultation" : "";
-  // R-012 mitigation: if property type is land (Lote/Terreno), beds/baths are
-  // not applicable. Omit them from the payload regardless of any stale state
-  // from a prior property-type selection. Beds/baths visibility is also
-  // controlled in the UI (`showBedsBaths`); this is a defense-in-depth check.
-  const isLand = data.propertyType === "Lote/Terreno";
+export function buildLeadPayload(data: SellerFormData, locale: string): LeadPayload {
   return {
     propertyType: data.propertyType,
-    location: data.location,
-    size: data.size,
-    sizeUnit: data.sizeUnit,
-    priceExpectation: data.priceExpectation || null,
-    needsPricingHelp: data.needsPricingHelp,
+    location: { text: data.locationText, lat: null, lng: null },
+    size: "",
+    sizeUnit: "",
+    priceExpectation: null,
+    needsPricingHelp: false,
     description: data.description,
-    bedrooms: isLand ? null : data.bedrooms || null,
-    bathrooms: isLand ? null : data.bathrooms || null,
+    bedrooms: null,
+    bathrooms: null,
     name: data.name,
     phone: data.phone,
     email: data.email,
-    preferredLanguage: data.preferredLanguage,
-    notes,
+    preferredLanguage: locale === "es" ? "es" : "en",
+    notes: "",
   };
 }
 
@@ -124,7 +78,6 @@ interface FieldProps {
   error?: string;
   required?: boolean;
   optional?: boolean;
-  /** Localized "(Optional)" text — passed in by parent because Field cannot call useTranslations conditionally. */
   optionalLabel?: string;
   children: (params: { id: string; describedBy?: string; invalid: boolean }) => React.ReactNode;
 }
@@ -173,7 +126,6 @@ export function SellerForm({
   officeName = "REMAX Altitud",
 }: SellerFormProps) {
   const t = useTranslations("SellerPage");
-  const { unitSystem, toggleUnits } = useLocaleUnits(locale);
 
   // ---- Stable IDs for fields not wrapped by Field helper ----
   const emailFieldReactId = useId();
@@ -181,14 +133,8 @@ export function SellerForm({
   const emailErrorId = `${emailFieldId}-error`;
   const propertyTypeReactId = useId();
   const propertyTypeErrorId = `sf-propertyType-${propertyTypeReactId}-error`;
-  const locationFieldReactId = useId();
-  const locationFieldId = `sf-location-${locationFieldReactId}`;
-  const locationErrorId = `${locationFieldId}-error`;
-  const pricingHelpReactId = useId();
-  const pricingHelpId = `sf-pricing-help-${pricingHelpReactId}`;
 
   // ---- Form state ----
-  const [step, setStep] = useState<1 | 2 | 3>(1);
   const [submitted, setSubmitted] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [matchedAgent, setMatchedAgent] = useState<Partial<Agent> | null>(null);
@@ -196,121 +142,58 @@ export function SellerForm({
 
   const [formData, setFormData] = useState<SellerFormData>({
     propertyType: "",
-    location: { text: "", lat: null, lng: null },
-    size: "",
-    sizeUnit: unitSystem === "metric" ? "sqm" : "sqft",
-    priceExpectation: "",
-    needsPricingHelp: false,
+    locationText: "",
     description: "",
-    photos: [],
-    bedrooms: "",
-    bathrooms: "",
     name: "",
     phone: "",
     email: "",
-    preferredLanguage: locale === "es" ? "es" : "en",
   });
 
-  // ---- Validation errors ----
-  const [step1Errors, setStep1Errors] = useState<Step1Errors>({});
-  const [step2Errors, setStep2Errors] = useState<Step2Errors>({});
-  const [step3Errors, setStep3Errors] = useState<Step3Errors>({});
+  const [errors, setErrors] = useState<FormErrors>({});
 
-  // ---- Field update helpers ----
   function updateField<K extends keyof SellerFormData>(key: K, value: SellerFormData[K]) {
     setFormData((prev) => ({ ...prev, [key]: value }));
   }
 
-  // ---- Step navigation ----
-  // Phone: optional leading +, then a mix of digits/spaces/dashes/parens, with at
-  // least 7 actual digits required. Story 5.3 owns strict E.164 validation; this
-  // is the same permissive pattern as contact-form.tsx but tightened to require
-  // ≥7 digits (not just 7 characters), so "       " or "+++++++" are rejected.
   const EMAIL_RE = /^[^@\s]+@[^@\s]+\.[^@\s]+$/;
   const phoneHasEnoughDigits = (v: string) => v.replace(/\D/g, "").length >= 7;
   const PHONE_RE = /^\+?[\d\s\-()]+$/;
 
-  // Photo upload limits (matches photosDescription i18n string).
-  const MAX_PHOTOS = 5;
-  const MAX_PHOTO_BYTES = 10 * 1024 * 1024; // 10MB
-
-  function validateStep1(): Step1Errors {
-    const errors: Step1Errors = {};
+  function validateForm(): FormErrors {
+    const newErrors: FormErrors = {};
     if (!formData.propertyType) {
-      errors.propertyType = t("form.validation.propertyTypeRequired");
+      newErrors.propertyType = t("form.validation.propertyTypeRequired");
     }
-    if (!formData.location.text.trim()) {
-      errors.location = t("form.validation.locationRequired");
+    if (!formData.locationText.trim()) {
+      newErrors.locationText = t("form.validation.locationRequired");
     }
-    return errors;
-  }
-
-  function validateStep2(): Step2Errors {
-    const errors: Step2Errors = {};
-    if (!formData.needsPricingHelp && formData.priceExpectation) {
-      const price = Number(formData.priceExpectation);
-      if (Number.isNaN(price)) {
-        errors.priceExpectation = t("form.validation.priceInvalid");
-      }
-    }
-    return errors;
-  }
-
-  function validateStep3(): Step3Errors {
-    const errors: Step3Errors = {};
     if (!formData.name.trim()) {
-      errors.name = t("form.validation.nameRequired");
+      newErrors.name = t("form.validation.nameRequired");
     }
     if (!formData.phone.trim()) {
-      errors.phone = t("form.validation.phoneRequired");
+      newErrors.phone = t("form.validation.phoneRequired");
     } else if (!PHONE_RE.test(formData.phone) || !phoneHasEnoughDigits(formData.phone)) {
-      errors.phone = t("form.validation.phoneInvalid");
+      newErrors.phone = t("form.validation.phoneInvalid");
     }
     if (formData.email && !EMAIL_RE.test(formData.email)) {
-      errors.email = t("form.validation.emailInvalid");
+      newErrors.email = t("form.validation.emailInvalid");
     }
-    return errors;
-  }
-
-  function handleNext() {
-    if (step === 1) {
-      const errors = validateStep1();
-      if (Object.keys(errors).length > 0) {
-        setStep1Errors(errors);
-        return;
-      }
-      setStep1Errors({});
-      setStep(2);
-    } else if (step === 2) {
-      const errors = validateStep2();
-      if (Object.keys(errors).length > 0) {
-        setStep2Errors(errors);
-        return;
-      }
-      setStep2Errors({});
-      setStep(3);
-    }
-  }
-
-  function handleBack() {
-    if (step === 2) setStep(1);
-    else if (step === 3) setStep(2);
+    return newErrors;
   }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
-    const errors = validateStep3();
-    if (Object.keys(errors).length > 0) {
-      setStep3Errors(errors);
+    const newErrors = validateForm();
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors);
       return;
     }
-    setStep3Errors({});
+    setErrors({});
     setSubmitting(true);
     setSubmitError(null);
-    // Story 5.3: POST /api/leads with full payload, UTM params, and referrer
-    const payload = buildLeadPayload(formData);
 
-    // Import UTM extractor — browser-safe, reads from window.location.search
+    const payload = buildLeadPayload(formData, locale);
+
     const { extractUtmParams } = await import("@/lib/utils/utm");
     const utmParams = extractUtmParams();
 
@@ -334,24 +217,20 @@ export function SellerForm({
       const body = await response.json();
 
       if (response.status === 201) {
-        // Success — store matched agent from response for confirmation
         if (body.agent) {
           setMatchedAgent(body.agent);
         }
         setSubmitting(false);
         setSubmitted(true);
       } else if (response.status === 409) {
-        // Duplicate — show friendly message
         setSubmitError(locale === "es" ? "Ya se envió esta solicitud." : "Already submitted.");
         setSubmitting(false);
       } else if (response.status === 400) {
-        // Validation error
         const issues =
           body.issues?.map((i: { message: string }) => i.message).join(", ") ?? "Validation error";
         setSubmitError(issues);
         setSubmitting(false);
       } else {
-        // Server error
         setSubmitError(
           locale === "es"
             ? "Error al enviar. Intente de nuevo."
@@ -369,16 +248,6 @@ export function SellerForm({
     }
   }
 
-  // Beds/Baths visibility (R-012 mitigation, AC #5)
-  const showBedsBaths = formData.propertyType !== "Lote/Terreno";
-
-  // Price required unless needsPricingHelp (R-008 mitigation, AC #6)
-  const priceRequired = !formData.needsPricingHelp;
-
-  // Unit label
-  const sizeUnitLabel = unitSystem === "metric" ? "m²" : "ft²";
-
-  // ---- Post-submit: show confirmation screen ----
   if (submitted) {
     const agentToShow = (matchedAgent as Agent | null) ?? fallbackAgent;
     if (agentToShow) {
@@ -386,536 +255,202 @@ export function SellerForm({
     }
   }
 
-  // Progress bar step labels
-  const stepLabels = [
-    { label: t("form.step1Label"), estimate: t("form.step1TimeEstimate") },
-    { label: t("form.step2Label"), estimate: t("form.step2TimeEstimate") },
-    { label: t("form.step3Label"), estimate: t("form.step3TimeEstimate") },
-  ];
-
   return (
     <div id="seller-form" data-testid="seller-form" className="mx-auto max-w-2xl px-4 py-10">
-      {/* Progress bar (AC #2) */}
-      <nav
-        data-testid="progress-bar"
-        aria-label={t("form.progressAriaLabel", { current: step, total: 3 })}
-        className="mb-8"
-      >
-        <ol className="flex items-center gap-0">
-          {stepLabels.map((s, i) => {
-            const stepNum = (i + 1) as 1 | 2 | 3;
-            const isActive = stepNum === step;
-            const isCompleted = stepNum < step;
-            return (
-              <li key={stepNum} className="flex flex-1 flex-col items-center">
-                <div className="flex w-full items-center">
-                  <div
-                    className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold transition-colors ${
-                      isCompleted
-                        ? "bg-brand-navy text-white"
-                        : isActive
-                          ? "bg-brand-gold text-brand-navy"
-                          : "bg-gray-200 text-gray-400"
-                    }`}
-                    aria-current={isActive ? "step" : undefined}
-                  >
-                    {isCompleted ? "✓" : stepNum}
-                  </div>
-                  {i < 2 && (
-                    <div
-                      className={`h-1 flex-1 transition-colors ${
-                        isCompleted ? "bg-brand-navy" : "bg-gray-200"
-                      }`}
-                    />
-                  )}
-                </div>
-                <span
-                  className={`mt-1 text-xs ${
-                    isActive ? "font-semibold text-brand-navy" : "text-text-muted"
+      <form onSubmit={handleSubmit} noValidate className="space-y-6">
+        <h2 className="text-xl font-bold text-brand-navy">{t("form.step1.heading")}</h2>
+
+        <fieldset>
+          <legend className="mb-2 text-sm font-semibold text-brand-navy">
+            {t("form.step1.propertyTypeLabel")}
+            <span aria-hidden className="ml-0.5 text-red-500">
+              *
+            </span>
+          </legend>
+          <div
+            className="grid grid-cols-2 gap-2 sm:grid-cols-3"
+            role="radiogroup"
+            aria-label={t("form.step1.propertyTypeAriaLabel")}
+            aria-describedby={errors.propertyType ? propertyTypeErrorId : undefined}
+            aria-invalid={errors.propertyType ? true : undefined}
+          >
+            {PROPERTY_TYPES.map(({ value }) => {
+              const labelKey = `form.step1.${
+                value === "Casa"
+                  ? "typeCasa"
+                  : value === "Lote/Terreno"
+                    ? "typeLote"
+                    : value === "Finca"
+                      ? "typeFinca"
+                      : value === "Condominio"
+                        ? "typeCondominio"
+                        : "typeCommercial"
+              }` as Parameters<typeof t>[0];
+              return (
+                <label
+                  key={value}
+                  className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
+                    formData.propertyType === value
+                      ? "border-brand-navy bg-brand-navy/5 font-semibold"
+                      : "border-border hover:border-brand-navy/30"
                   }`}
                 >
-                  {s.label}
-                </span>
-                <span className="text-xs text-text-muted">{s.estimate}</span>
-              </li>
-            );
-          })}
-        </ol>
-      </nav>
-
-      <form onSubmit={handleSubmit} noValidate>
-        {/* ---------------------------------------------------------------- */}
-        {/* STEP 1 — Basics */}
-        {/* ---------------------------------------------------------------- */}
-        {step === 1 && (
-          <div data-testid="form-step-1" className="space-y-6">
-            <h2 className="text-xl font-bold text-brand-navy">{t("form.step1.heading")}</h2>
-
-            {/* Property Type — 5 radio options (AC #3, 5.1-COMP-005) */}
-            <fieldset>
-              <legend className="mb-2 text-sm font-semibold text-brand-navy">
-                {t("form.step1.propertyTypeLabel")}
-                <span aria-hidden className="ml-0.5 text-red-500">
-                  *
-                </span>
-              </legend>
-              <div
-                className="grid grid-cols-2 gap-2 sm:grid-cols-3"
-                role="radiogroup"
-                aria-label={t("form.step1.propertyTypeAriaLabel")}
-                aria-describedby={step1Errors.propertyType ? propertyTypeErrorId : undefined}
-                aria-invalid={step1Errors.propertyType ? true : undefined}
-              >
-                {PROPERTY_TYPES.map(({ value }) => {
-                  const labelKey = `form.step1.${
-                    value === "Casa"
-                      ? "typeCasa"
-                      : value === "Lote/Terreno"
-                        ? "typeLote"
-                        : value === "Finca"
-                          ? "typeFinca"
-                          : value === "Condominio"
-                            ? "typeCondominio"
-                            : "typeCommercial"
-                  }` as Parameters<typeof t>[0];
-                  return (
-                    <label
-                      key={value}
-                      className={`flex cursor-pointer items-center gap-2 rounded-lg border px-3 py-2.5 text-sm transition-colors ${
-                        formData.propertyType === value
-                          ? "border-brand-navy bg-brand-navy/5 font-semibold"
-                          : "border-border hover:border-brand-navy/30"
-                      }`}
-                    >
-                      <input
-                        type="radio"
-                        name="propertyType"
-                        value={value}
-                        checked={formData.propertyType === value}
-                        onChange={() =>
-                          updateField("propertyType", value as Exclude<PropertyType, "">)
-                        }
-                        className="sr-only"
-                        aria-label={t(labelKey)}
-                      />
-                      <span
-                        className={`h-4 w-4 shrink-0 rounded-full border-2 ${
-                          formData.propertyType === value
-                            ? "border-brand-navy bg-brand-navy"
-                            : "border-gray-300"
-                        }`}
-                        aria-hidden
-                      />
-                      {t(labelKey)}
-                    </label>
-                  );
-                })}
-              </div>
-              {step1Errors.propertyType && (
-                <span
-                  id={propertyTypeErrorId}
-                  role="alert"
-                  className="mt-1 text-xs text-[var(--color-error,#dc2626)]"
-                >
-                  {step1Errors.propertyType}
-                </span>
-              )}
-            </fieldset>
-
-            {/* Location — LocationPicker (AC #3, #4) */}
-            <div
-              aria-describedby={step1Errors.location ? locationErrorId : undefined}
-              aria-invalid={step1Errors.location ? true : undefined}
-            >
-              <label
-                htmlFor={locationFieldId}
-                className="mb-2 block text-sm font-semibold text-brand-navy"
-              >
-                {t("form.step1.locationLabel")}
-                <span aria-hidden className="ml-0.5 text-red-500">
-                  *
-                </span>
-              </label>
-              <LocationPicker
-                value={formData.location}
-                onChange={(val) => updateField("location", val)}
-                locale={locale}
-                placeholder={t("form.step1.locationPlaceholder")}
-                inputId={locationFieldId}
-                describedBy={step1Errors.location ? locationErrorId : undefined}
-                invalid={Boolean(step1Errors.location)}
-              />
-              {step1Errors.location && (
-                <span
-                  id={locationErrorId}
-                  role="alert"
-                  className="mt-1 text-xs text-[var(--color-error,#dc2626)]"
-                >
-                  {step1Errors.location}
-                </span>
-              )}
-            </div>
-
-            {/* Size + unit toggle (AC #3, 5.1-COMP-006) */}
-            <Field label={t("form.step1.sizeLabel")}>
-              {({ id }) => (
-                <div className="flex gap-2">
                   <input
-                    id={id}
-                    type="number"
-                    value={formData.size}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                      updateField("size", e.target.value)
-                    }
-                    placeholder={t("form.step1.sizePlaceholder")}
-                    aria-label={t("form.step1.sizeAriaLabel")}
-                    min="0"
-                    className="flex-1 rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
+                    type="radio"
+                    name="propertyType"
+                    value={value}
+                    checked={formData.propertyType === value}
+                    onChange={() => updateField("propertyType", value as Exclude<PropertyType, "">)}
+                    className="sr-only"
+                    aria-label={t(labelKey)}
                   />
-                  <button
-                    type="button"
-                    data-testid="size-unit-toggle"
-                    onClick={toggleUnits}
-                    aria-label={t("form.step1.sizeUnitAriaLabel")}
-                    className="rounded-lg border border-border px-4 py-3 text-sm font-semibold text-brand-navy hover:bg-gray-50"
-                  >
-                    {sizeUnitLabel}
-                  </button>
-                </div>
-              )}
-            </Field>
-
-            {/* Step navigation */}
-            <div className="flex justify-end pt-2">
-              <button
-                type="button"
-                onClick={handleNext}
-                aria-label={t("form.nextButtonAriaLabel")}
-                className="rounded-lg bg-brand-navy px-8 py-3 text-sm font-semibold text-white transition-colors hover:bg-brand-navy/90"
-              >
-                {t("form.nextButton")}
-              </button>
-            </div>
+                  <span
+                    className={`h-4 w-4 shrink-0 rounded-full border-2 ${
+                      formData.propertyType === value
+                        ? "border-brand-navy bg-brand-navy"
+                        : "border-gray-300"
+                    }`}
+                    aria-hidden
+                  />
+                  {t(labelKey)}
+                </label>
+              );
+            })}
           </div>
-        )}
-
-        {/* ---------------------------------------------------------------- */}
-        {/* STEP 2 — Details */}
-        {/* ---------------------------------------------------------------- */}
-        {step === 2 && (
-          <div data-testid="form-step-2" className="space-y-6">
-            <h2 className="text-xl font-bold text-brand-navy">{t("form.step2.heading")}</h2>
-
-            {/* Price Expectation (AC #5) */}
-            <Field
-              label={t("form.step2.priceLabel")}
-              required={priceRequired}
-              optional={!priceRequired}
-              optionalLabel={t("form.step2.priceOptionalLabel")}
-              error={step2Errors.priceExpectation}
+          {errors.propertyType && (
+            <span
+              id={propertyTypeErrorId}
+              role="alert"
+              className="mt-1 text-xs text-[var(--color-error,#dc2626)]"
             >
-              {({ id, describedBy, invalid }) => (
-                <input
-                  id={id}
-                  name="priceExpectation"
-                  type="number"
-                  value={formData.priceExpectation}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                    updateField("priceExpectation", e.target.value)
-                  }
-                  placeholder={t("form.step2.pricePlaceholder")}
-                  aria-label={t("form.step2.priceAriaLabel")}
-                  aria-describedby={describedBy}
-                  aria-invalid={invalid || undefined}
-                  required={priceRequired}
-                  min="0"
-                  className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
-                />
-              )}
-            </Field>
+              {errors.propertyType}
+            </span>
+          )}
+        </fieldset>
 
-            {/* Pricing Help checkbox (AC #6, R-008) */}
-            <div className="flex items-start gap-3">
+        <Field label={t("form.step1.locationLabel")} required error={errors.locationText}>
+          {({ id, describedBy, invalid }) => (
+            <input
+              id={id}
+              type="text"
+              value={formData.locationText}
+              onChange={(e: ChangeEvent<HTMLInputElement>) =>
+                updateField("locationText", e.target.value)
+              }
+              placeholder={t("form.step1.locationPlaceholder")}
+              aria-describedby={describedBy}
+              aria-invalid={invalid || undefined}
+              required
+              className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
+            />
+          )}
+        </Field>
+
+        <Field label={t("form.step2.descriptionLabel")}>
+          {({ id }) => (
+            <textarea
+              id={id}
+              value={formData.description}
+              onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                updateField("description", e.target.value)
+              }
+              placeholder={t("form.step2.descriptionPlaceholder")}
+              aria-label={t("form.step2.descriptionAriaLabel")}
+              rows={4}
+              className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy resize-none"
+            />
+          )}
+        </Field>
+
+        <Field label={t("form.step3.nameLabel")} required error={errors.name}>
+          {({ id, describedBy, invalid }) => (
+            <input
+              id={id}
+              type="text"
+              value={formData.name}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("name", e.target.value)}
+              placeholder={t("form.step3.namePlaceholder")}
+              aria-label={t("form.step3.nameAriaLabel")}
+              aria-describedby={describedBy}
+              aria-invalid={invalid || undefined}
+              required
+              autoComplete="name"
+              className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
+            />
+          )}
+        </Field>
+
+        <div className="space-y-1.5">
+          <Field label={t("form.step3.phoneLabel")} required error={errors.phone}>
+            {({ id, describedBy, invalid }) => (
               <input
-                type="checkbox"
-                id={pricingHelpId}
-                data-testid="pricing-help-checkbox"
-                checked={formData.needsPricingHelp}
+                id={id}
+                type="tel"
+                value={formData.phone}
                 onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                  updateField("needsPricingHelp", e.target.checked)
+                  updateField("phone", e.target.value)
                 }
-                className="mt-0.5 h-4 w-4 rounded border-border text-brand-navy"
-              />
-              <div>
-                <label
-                  htmlFor={pricingHelpId}
-                  className="text-sm font-semibold text-brand-navy cursor-pointer"
-                >
-                  {t("form.step2.pricingHelpLabel")}
-                </label>
-                <p className="mt-0.5 text-xs text-text-muted">
-                  {t("form.step2.pricingHelpDescription")}
-                </p>
-              </div>
-            </div>
-
-            {/* Description (optional) (AC #5) */}
-            <Field label={t("form.step2.descriptionLabel")}>
-              {({ id }) => (
-                <textarea
-                  id={id}
-                  value={formData.description}
-                  onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
-                    updateField("description", e.target.value)
-                  }
-                  placeholder={t("form.step2.descriptionPlaceholder")}
-                  aria-label={t("form.step2.descriptionAriaLabel")}
-                  rows={4}
-                  className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy resize-none"
-                />
-              )}
-            </Field>
-
-            {/* Photos (optional) (AC #5) */}
-            {/* The visible heading is a <span> (not <label>) so screen readers
-                don't announce it as a separate orphan label — the wrapping
-                <label> below provides the accessible label for the file input. */}
-            <div className="space-y-1.5">
-              <span className="block text-sm font-semibold text-brand-navy">
-                {t("form.step2.photosLabel")}
-              </span>
-              <p className="text-xs text-text-muted">{t("form.step2.photosDescription")}</p>
-              <label
-                className="flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-border px-4 py-3 text-sm text-text-muted hover:border-brand-navy/30 hover:text-brand-navy transition-colors"
-                aria-label={t("form.step2.photosAriaLabel")}
-              >
-                <input
-                  type="file"
-                  accept="image/jpeg,image/png"
-                  multiple
-                  className="sr-only"
-                  onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                    if (e.target.files) {
-                      // Enforce client-side limits documented in photosDescription:
-                      // up to 5 photos, max 10MB each. Oversized files are dropped
-                      // silently here; Story 5.3 will surface a localized error.
-                      const files = Array.from(e.target.files)
-                        .filter((f) => f.size <= MAX_PHOTO_BYTES)
-                        .slice(0, MAX_PHOTOS);
-                      updateField("photos", files);
-                    }
-                  }}
-                />
-                {t("form.step2.photosButton")}
-                {formData.photos.length > 0 && (
-                  <span className="ml-2 text-brand-navy font-medium">
-                    ({formData.photos.length})
-                  </span>
-                )}
-              </label>
-            </div>
-
-            {/* Bedrooms / Bathrooms — hidden for Lote/Terreno (AC #5, R-012) */}
-            {showBedsBaths && (
-              <div data-testid="beds-baths-fields" className="grid grid-cols-2 gap-4">
-                <Field label={t("form.step2.bedroomsLabel")}>
-                  {({ id }) => (
-                    <select
-                      id={id}
-                      value={formData.bedrooms}
-                      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-                        updateField("bedrooms", e.target.value)
-                      }
-                      aria-label={t("form.step2.bedroomsAriaLabel")}
-                      className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
-                    >
-                      <option value="">—</option>
-                      {[1, 2, 3, 4, 5, 6, 7, "8+"].map((n) => (
-                        <option key={n} value={String(n)}>
-                          {n}
-                        </option>
-                      ))}
-                    </select>
-                  )}
-                </Field>
-                <Field label={t("form.step2.bathroomsLabel")}>
-                  {({ id }) => (
-                    <select
-                      id={id}
-                      value={formData.bathrooms}
-                      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-                        updateField("bathrooms", e.target.value)
-                      }
-                      aria-label={t("form.step2.bathroomsAriaLabel")}
-                      className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
-                    >
-                      <option value="">—</option>
-                      {[1, 1.5, 2, 2.5, 3, 4, "5+"].map((n) => (
-                        <option key={n} value={String(n)}>
-                          {n}
-                        </option>
-                      ))}
-                    </select>
-                  )}
-                </Field>
-              </div>
-            )}
-
-            {/* Step navigation */}
-            <div className="flex justify-between pt-2">
-              <button
-                type="button"
-                onClick={handleBack}
-                aria-label={t("form.backButtonAriaLabel")}
-                className="rounded-lg border border-border px-6 py-3 text-sm font-semibold text-brand-navy transition-colors hover:bg-gray-50"
-              >
-                {t("form.backButton")}
-              </button>
-              <button
-                type="button"
-                onClick={handleNext}
-                aria-label={t("form.nextButtonAriaLabel")}
-                className="rounded-lg bg-brand-navy px-8 py-3 text-sm font-semibold text-white transition-colors hover:bg-brand-navy/90"
-              >
-                {t("form.nextButton")}
-              </button>
-            </div>
-          </div>
-        )}
-
-        {/* ---------------------------------------------------------------- */}
-        {/* STEP 3 — Contact */}
-        {/* ---------------------------------------------------------------- */}
-        {step === 3 && (
-          <div data-testid="form-step-3" className="space-y-6">
-            <h2 className="text-xl font-bold text-brand-navy">{t("form.step3.heading")}</h2>
-
-            {/* Name (required) (AC #7) */}
-            <Field label={t("form.step3.nameLabel")} required error={step3Errors.name}>
-              {({ id, describedBy, invalid }) => (
-                <input
-                  id={id}
-                  type="text"
-                  value={formData.name}
-                  onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                    updateField("name", e.target.value)
-                  }
-                  placeholder={t("form.step3.namePlaceholder")}
-                  aria-label={t("form.step3.nameAriaLabel")}
-                  aria-describedby={describedBy}
-                  aria-invalid={invalid || undefined}
-                  required
-                  autoComplete="name"
-                  className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
-                />
-              )}
-            </Field>
-
-            {/* Phone / WhatsApp (required) (AC #7) */}
-            <div className="space-y-1.5">
-              <Field label={t("form.step3.phoneLabel")} required error={step3Errors.phone}>
-                {({ id, describedBy, invalid }) => (
-                  <input
-                    id={id}
-                    type="tel"
-                    value={formData.phone}
-                    onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                      updateField("phone", e.target.value)
-                    }
-                    placeholder={t("form.step3.phonePlaceholder")}
-                    aria-label={t("form.step3.phoneAriaLabel")}
-                    aria-describedby={describedBy}
-                    aria-invalid={invalid || undefined}
-                    required
-                    autoComplete="tel"
-                    className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
-                  />
-                )}
-              </Field>
-              <p className="text-xs text-text-muted">{t("form.step3.phoneDescription")}</p>
-            </div>
-
-            {/* Email (optional) (AC #7) */}
-            <div>
-              <div className="flex items-center gap-2 mb-1.5">
-                <label htmlFor={emailFieldId} className="text-sm font-semibold text-brand-navy">
-                  {t("form.step3.emailLabel")}
-                </label>
-                <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-text-muted">
-                  {t("form.step3.emailOptionalBadge")}
-                </span>
-              </div>
-              <input
-                id={emailFieldId}
-                type="email"
-                value={formData.email}
-                onChange={(e: ChangeEvent<HTMLInputElement>) =>
-                  updateField("email", e.target.value)
-                }
-                placeholder={t("form.step3.emailPlaceholder")}
-                aria-label={t("form.step3.emailAriaLabel")}
-                aria-describedby={step3Errors.email ? emailErrorId : undefined}
-                aria-invalid={step3Errors.email ? true : undefined}
-                autoComplete="email"
+                placeholder={t("form.step3.phonePlaceholder")}
+                aria-label={t("form.step3.phoneAriaLabel")}
+                aria-describedby={describedBy}
+                aria-invalid={invalid || undefined}
+                required
+                autoComplete="tel"
                 className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
               />
-              {step3Errors.email && (
-                <span
-                  id={emailErrorId}
-                  role="alert"
-                  className="mt-1 text-xs text-[var(--color-error,#dc2626)]"
-                >
-                  {step3Errors.email}
-                </span>
-              )}
-            </div>
-
-            {/* Preferred Language (auto-detected, selectable) (AC #7) */}
-            <Field label={t("form.step3.languageLabel")}>
-              {({ id }) => (
-                <select
-                  id={id}
-                  value={formData.preferredLanguage}
-                  onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-                    updateField("preferredLanguage", e.target.value as "en" | "es")
-                  }
-                  aria-label={t("form.step3.languageAriaLabel")}
-                  className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
-                >
-                  <option value="en">{t("form.step3.languageEn")}</option>
-                  <option value="es">{t("form.step3.languageEs")}</option>
-                </select>
-              )}
-            </Field>
-
-            {/* Submit error message (Story 5.3) */}
-            {submitError && (
-              <div role="alert" className="rounded-lg bg-red-50 p-3 text-sm text-red-700">
-                {submitError}
-              </div>
             )}
+          </Field>
+          <p className="text-xs text-text-muted">{t("form.step3.phoneDescription")}</p>
+        </div>
 
-            {/* Step navigation */}
-            <div className="flex justify-between pt-2">
-              <button
-                type="button"
-                onClick={handleBack}
-                aria-label={t("form.backButtonAriaLabel")}
-                className="rounded-lg border border-border px-6 py-3 text-sm font-semibold text-brand-navy transition-colors hover:bg-gray-50"
-              >
-                {t("form.backButton")}
-              </button>
-              <button
-                type="submit"
-                disabled={submitting}
-                aria-label={t("form.submitButtonAriaLabel")}
-                className="rounded-lg bg-brand-navy px-8 py-3 text-sm font-semibold text-white transition-colors hover:bg-brand-navy/90 disabled:opacity-60 disabled:cursor-not-allowed"
-              >
-                {submitting ? t("form.submittingButton") : t("form.submitButton")}
-              </button>
-            </div>
+        <div>
+          <div className="flex items-center gap-2 mb-1.5">
+            <label htmlFor={emailFieldId} className="text-sm font-semibold text-brand-navy">
+              {t("form.step3.emailLabel")}
+            </label>
+            <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-text-muted">
+              {t("form.step3.emailOptionalBadge")}
+            </span>
+          </div>
+          <input
+            id={emailFieldId}
+            type="email"
+            value={formData.email}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => updateField("email", e.target.value)}
+            placeholder={t("form.step3.emailPlaceholder")}
+            aria-label={t("form.step3.emailAriaLabel")}
+            aria-describedby={errors.email ? emailErrorId : undefined}
+            aria-invalid={errors.email ? true : undefined}
+            autoComplete="email"
+            className="w-full rounded-lg border border-border bg-background px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand-navy"
+          />
+          {errors.email && (
+            <span
+              id={emailErrorId}
+              role="alert"
+              className="mt-1 text-xs text-[var(--color-error,#dc2626)]"
+            >
+              {errors.email}
+            </span>
+          )}
+        </div>
+
+        {submitError && (
+          <div role="alert" className="rounded-lg bg-red-50 p-3 text-sm text-red-700">
+            {submitError}
           </div>
         )}
+
+        <div className="pt-2">
+          <button
+            type="submit"
+            disabled={submitting}
+            aria-label={t("form.submitButtonAriaLabel")}
+            className="w-full rounded-lg bg-brand-navy px-8 py-3 text-sm font-semibold text-white transition-colors hover:bg-brand-navy/90 disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {submitting ? t("form.submittingButton") : t("form.submitButton")}
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/tests/unit/seller/seller-form.spec.tsx
+++ b/tests/unit/seller/seller-form.spec.tsx
@@ -1,43 +1,7 @@
-/**
- * Story 5.1: Seller Landing Page & "List With Us" Form — Unit/Component Tests
- * Component: src/components/seller/seller-form.tsx
- *
- * TDD Phase: GREEN — all tests are active after component implementation.
- *
- * Covers (from test-design-epic-5.md):
- *   5.1-COMP-002 — "I need help with pricing" makes price optional + attaches note to payload
- *   5.1-COMP-003 — Inline validation errors appear in correct locale (EN)
- *   5.1-COMP-004 — Beds/Baths hidden when "Lote/Terreno" property type selected
- *   5.1-COMP-005 — Property Type radio shows 5 options
- *   5.1-COMP-006 — Size field renders with m²/acres/ft² toggle
- *   5.1-COMP-007 — Step 2 renders all fields for Casa type
- *   5.1-COMP-008 — Step 3 renders Name, Phone/WhatsApp, Email (optional), Preferred Language
- *   5.1-UNIT-001 — All form strings render in Spanish locale
- *   5.1-E2E-002  — SellerForm exported from seller-form.tsx (lazy-load contract)
- *
- * data-testid contract (CANNOT rename once established):
- *   data-testid="seller-form"             — SellerForm root wrapper
- *   data-testid="form-step-1"             — Step 1 container
- *   data-testid="form-step-2"             — Step 2 container
- *   data-testid="form-step-3"             — Step 3 container
- *   data-testid="progress-bar"            — Progress indicator
- *   data-testid="pricing-help-checkbox"   — Pricing help checkbox
- *   data-testid="location-text-input"     — Text address input
- *   data-testid="beds-baths-fields"       — Beds/baths conditional container
- *
- * Environment: jsdom (React component — .spec.tsx → jsdom via vitest.config.mts)
- */
-
-// ---------------------------------------------------------------------------
-// Module mocks — declared BEFORE any imports of the module under test
-// vi.mock hoisting rule: ALL vi.mock() calls MUST appear before import statements
-// ---------------------------------------------------------------------------
-
 import { vi, describe, it, expect, afterEach } from "vitest";
 
 vi.mock("next-intl", () => ({
   useTranslations: vi.fn(() => (key: string, values?: Record<string, unknown>) => {
-    // Return the i18n key as the string value — enough for assertions
     if (values) return `${key}(${JSON.stringify(values)})`;
     return key;
   }),
@@ -48,28 +12,11 @@ vi.mock("next/navigation", () => ({
   useSearchParams: vi.fn(() => ({ toString: vi.fn(() => ""), get: vi.fn(() => null) })),
 }));
 
-// Mock LocationPicker to isolate SellerForm from map dependencies
+// Mock LocationPicker is no longer needed but kept empty to avoid issues if any other file imports it here
 vi.mock("@/components/seller/location-picker", () => ({
-  LocationPicker: vi.fn(
-    ({
-      value,
-      onChange,
-    }: {
-      value: { text: string; lat: number | null; lng: number | null };
-      onChange: (v: { text: string; lat: number | null; lng: number | null }) => void;
-    }) => (
-      <div data-testid="location-picker-mock">
-        <input
-          data-testid="location-text-input"
-          value={value.text}
-          onChange={(e) => onChange({ text: e.target.value, lat: null, lng: null })}
-        />
-      </div>
-    ),
-  ),
+  LocationPicker: vi.fn(() => <div />),
 }));
 
-// Mock SellerConfirmation — tested in isolation
 vi.mock("@/components/seller/seller-confirmation", () => ({
   SellerConfirmation: vi.fn(({ agent }: { agent: unknown; locale: string }) => (
     <div data-testid="seller-confirmation">
@@ -78,7 +25,6 @@ vi.mock("@/components/seller/seller-confirmation", () => ({
   )),
 }));
 
-// Mock useLocaleUnits (size unit toggle)
 vi.mock("@/hooks/use-locale-units", () => ({
   useLocaleUnits: vi.fn(() => ({
     unitSystem: "metric",
@@ -86,33 +32,19 @@ vi.mock("@/hooks/use-locale-units", () => ({
   })),
 }));
 
-// ---------------------------------------------------------------------------
-// Imports — AFTER mocks
-// ---------------------------------------------------------------------------
-
 import React from "react";
 import { readFileSync } from "node:fs";
 import { resolve as pathResolve } from "node:path";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-// ---------------------------------------------------------------------------
-
 afterEach(() => {
   cleanup();
   vi.clearAllMocks();
 });
 
-// ---------------------------------------------------------------------------
-// 5.1-E2E-002: SellerForm lazy-load contract
-// ---------------------------------------------------------------------------
-
 describe("SellerForm lazy-load contract (5.1-E2E-002)", () => {
   it("[P0] 5.1-E2E-002: SellerForm is exported as a named export from seller-form.tsx", async () => {
-    // Use dynamic import (ESM-compatible; require() doesn't resolve @/ aliases in Vitest)
-    // The lazy load in page.tsx uses next/dynamic with a named export:
-    //   () => import('@/components/seller/seller-form').then(m => m.SellerForm)
-    // This test verifies the named export contract exists.
     const sellerFormModule = await import("@/components/seller/seller-form");
     expect(typeof sellerFormModule.SellerForm).toBe("function");
   });
@@ -124,13 +56,7 @@ describe("SellerForm lazy-load contract (5.1-E2E-002)", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Helper: render SellerForm for tests
-// We import lazily to avoid hard failures if file not yet created.
-// ---------------------------------------------------------------------------
-
 async function renderSellerForm(props: { locale?: string; fallbackAgent?: unknown } = {}) {
-  // Dynamic import after mocks are established (ESM-compatible; require() doesn't resolve @/ aliases)
   const { SellerForm } = await import("@/components/seller/seller-form");
   type SellerFormProps = React.ComponentProps<typeof SellerForm>;
   return render(
@@ -146,309 +72,54 @@ async function renderSellerForm(props: { locale?: string; fallbackAgent?: unknow
   );
 }
 
-// ---------------------------------------------------------------------------
-// Step 1 field rendering (5.1-COMP-005, 5.1-COMP-006)
-// ---------------------------------------------------------------------------
-
-describe("SellerForm — Step 1: Basics", () => {
-  it("[P2] 5.1-COMP-005: Step 1 renders 5 property type radio options (Casa, Lote/Terreno, Finca, Condominio, Comercial)", async () => {
+describe("SellerForm — Form Fields", () => {
+  it("[P2] 5.1-COMP-005: Form renders 5 property type radio options", async () => {
     await renderSellerForm();
-
-    // All 5 property types must be present as radio inputs
-    // The useTranslations mock returns i18n keys (e.g. "form.step1.typeCasa")
     const radios = document.querySelectorAll('input[type="radio"]');
     expect(radios.length).toBe(5);
-    // Verify at least one radio has Casa value and one has Lote/Terreno value
-    const casaRadio = document.querySelector('input[type="radio"][value="Casa"]');
-    const loteRadio = document.querySelector('input[type="radio"][value="Lote/Terreno"]');
-    const fincaRadio = document.querySelector('input[type="radio"][value="Finca"]');
-    const condominioRadio = document.querySelector('input[type="radio"][value="Condominio"]');
-    const comercialRadio = document.querySelector('input[type="radio"][value="Comercial"]');
-    expect(casaRadio).not.toBeNull();
-    expect(loteRadio).not.toBeNull();
-    expect(fincaRadio).not.toBeNull();
-    expect(condominioRadio).not.toBeNull();
-    expect(comercialRadio).not.toBeNull();
   });
 
-  it("[P2] 5.1-COMP-006: Step 1 size field renders with unit toggle", async () => {
+  it("[P2] 5.1-COMP-008: Form renders Location, Description, Name, Phone, Email", async () => {
     await renderSellerForm();
-
-    // Size field must be present
-    const sizeInput =
-      screen.queryByRole("spinbutton") ?? document.querySelector('input[type="number"]');
-    expect(sizeInput).not.toBeNull();
-
-    // Unit toggle must be present
-    const unitToggle = document.querySelector('[data-testid="size-unit-toggle"]');
-    expect(unitToggle).not.toBeNull();
-
-    // Check for metric label (m²) — mocked useLocaleUnits returns 'metric'
-    expect(document.querySelector('[data-testid="size-unit-toggle"]')?.textContent).toMatch(/m²/i);
-  });
-
-  it("[P1] Step 1 container has data-testid='form-step-1'", async () => {
-    await renderSellerForm();
-    expect(document.querySelector('[data-testid="form-step-1"]')).not.toBeNull();
-  });
-
-  it("[P1] progress bar is present with data-testid='progress-bar' on initial render", async () => {
-    await renderSellerForm();
-    expect(document.querySelector('[data-testid="progress-bar"]')).not.toBeNull();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Step 2 field rendering (5.1-COMP-007)
-// ---------------------------------------------------------------------------
-
-describe("SellerForm — Step 2: Details", () => {
-  /**
-   * Helper to advance to Step 2 by filling required Step 1 fields.
-   */
-  async function advanceToStep2() {
-    const user = userEvent.setup();
-    await renderSellerForm();
-
-    // Select Casa (non-land type) — using value attribute since i18n keys are mocked
-    const casaRadio = document.querySelector(
-      'input[type="radio"][value="Casa"]',
-    ) as HTMLInputElement;
-    expect(casaRadio).not.toBeNull();
-    await user.click(casaRadio);
-
-    // Fill location using fireEvent.change (controlled input — sets full value at once)
-    const locationInput = screen.getByTestId("location-text-input");
-    fireEvent.change(locationInput, { target: { value: "Perez Zeledon" } });
-
-    // Click Next
-    const nextButton = document.querySelector(
-      'button[aria-label="form.nextButtonAriaLabel"]',
-    ) as HTMLButtonElement;
-    expect(nextButton).not.toBeNull();
-    await user.click(nextButton);
-  }
-
-  it("[P2] 5.1-COMP-007: Step 2 renders Price, pricing-help checkbox, Description, Photos, Beds/Baths for Casa type", async () => {
-    await advanceToStep2();
-
-    // Step 2 container must be active
-    expect(document.querySelector('[data-testid="form-step-2"]')).not.toBeNull();
-
-    // Price field must be visible
-    const priceInput = document.querySelector('[name="priceExpectation"]');
-    expect(priceInput).not.toBeNull();
-
-    // Pricing help checkbox (data-testid contract)
-    expect(document.querySelector('[data-testid="pricing-help-checkbox"]')).not.toBeNull();
-
+    
     // Description textarea must be present
     const descriptionField = document.querySelector("textarea");
     expect(descriptionField).not.toBeNull();
 
-    // Beds/Baths must be visible for Casa (non-land type)
-    expect(document.querySelector('[data-testid="beds-baths-fields"]')).not.toBeNull();
-  });
-
-  it("[P0] 5.1-COMP-004: beds/baths fields are hidden when Lote/Terreno property type is selected (R-012)", async () => {
-    const user = userEvent.setup();
-    await renderSellerForm();
-
-    // Select Lote/Terreno — using value attribute since i18n keys are mocked
-    const loteRadio = document.querySelector(
-      'input[type="radio"][value="Lote/Terreno"]',
-    ) as HTMLInputElement;
-    expect(loteRadio).not.toBeNull();
-    await user.click(loteRadio);
-
-    // Fill location to allow advancing (fireEvent.change for controlled input)
-    const locationInput = screen.getByTestId("location-text-input");
-    fireEvent.change(locationInput, { target: { value: "San Isidro" } });
-
-    // Advance to Step 2
-    const nextButton = document.querySelector(
-      'button[aria-label="form.nextButtonAriaLabel"]',
-    ) as HTMLButtonElement;
-    expect(nextButton).not.toBeNull();
-    await user.click(nextButton);
-
-    // Beds/Baths fields must be HIDDEN or not rendered (R-012)
-    const bedsBathsContainer = document.querySelector('[data-testid="beds-baths-fields"]');
-    const isHiddenOrAbsent =
-      bedsBathsContainer === null ||
-      (bedsBathsContainer as HTMLElement).hidden === true ||
-      bedsBathsContainer.className.includes("hidden");
-    expect(isHiddenOrAbsent).toBe(true);
-  });
-
-  it("[P1] 5.1-COMP-002: checking 'I need help with pricing' makes price field optional (R-008)", async () => {
-    const user = userEvent.setup();
-    await advanceToStep2();
-
-    // Price field should initially be required
-    const priceInput = document.querySelector(
-      '[name="priceExpectation"]',
-    ) as HTMLInputElement | null;
-    expect(priceInput).not.toBeNull();
-
-    // Check the pricing help checkbox
-    const pricingHelpCheckbox = document.querySelector(
-      '[data-testid="pricing-help-checkbox"]',
-    ) as HTMLInputElement | null;
-    expect(pricingHelpCheckbox).not.toBeNull();
-
-    await user.click(pricingHelpCheckbox!);
-
-    // After checking: price field must NOT be required
-    const updatedPriceInput = document.querySelector(
-      '[name="priceExpectation"]',
-    ) as HTMLInputElement | null;
-    // The field was already asserted non-null above; it must still be present after checkbox click.
-    expect(updatedPriceInput).not.toBeNull();
-    expect(updatedPriceInput!.required).toBe(false);
-
-    // Advance to step 3 without filling price (should succeed now)
-    const nextButton = screen.getByRole("button", { name: /next|siguiente/i });
-    await user.click(nextButton);
-
-    // Must reach step 3 (price was optional)
-    expect(document.querySelector('[data-testid="form-step-3"]')).not.toBeNull();
-  });
-
-  it("[P1] 5.1-COMP-002b: buildLeadPayload includes pricing consultation note when checkbox is checked (R-008)", async () => {
-    // buildLeadPayload is a named export of seller-form.tsx (verified in contract test 5.1-E2E-002).
-    const { buildLeadPayload } = await import("@/components/seller/seller-form");
-
-    // The function must be present — no conditional branching.
-    expect(typeof buildLeadPayload).toBe("function");
-
-    const payload = buildLeadPayload({
-      propertyType: "Casa",
-      location: { text: "San Isidro", lat: 9.37, lng: -83.7 },
-      size: "500",
-      sizeUnit: "sqm",
-      priceExpectation: "",
-      needsPricingHelp: true,
-      description: "",
-      photos: [],
-      bedrooms: "",
-      bathrooms: "",
-      name: "Carlos",
-      phone: "+50688881234",
-      email: "",
-      preferredLanguage: "en",
-    });
-
-    // R-008: notes must include pricing consultation signal
-    expect(payload.notes).toMatch(/pricing consultation|pricing help|needs pricing/i);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Step 3 field rendering (5.1-COMP-008)
-// ---------------------------------------------------------------------------
-
-describe("SellerForm — Step 3: Contact", () => {
-  /**
-   * Helper to advance to Step 3.
-   */
-  async function advanceToStep3() {
-    const user = userEvent.setup();
-    await renderSellerForm();
-
-    // Step 1 — use value attribute since i18n keys are mocked
-    const casaRadio = document.querySelector(
-      'input[type="radio"][value="Casa"]',
-    ) as HTMLInputElement;
-    expect(casaRadio).not.toBeNull();
-    await user.click(casaRadio);
-    const locationInput = screen.getByTestId("location-text-input");
-    fireEvent.change(locationInput, { target: { value: "Perez Zeledon" } });
-    const nextBtn1 = document.querySelector(
-      'button[aria-label="form.nextButtonAriaLabel"]',
-    ) as HTMLButtonElement;
-    await user.click(nextBtn1);
-
-    // Step 2 — assert present then advance
-    expect(document.querySelector('[data-testid="form-step-2"]')).not.toBeNull();
-    const nextBtn2 = document.querySelector(
-      'button[aria-label="form.nextButtonAriaLabel"]',
-    ) as HTMLButtonElement;
-    await user.click(nextBtn2);
-  }
-
-  it("[P2] 5.1-COMP-008: Step 3 renders Name (required), Phone/WhatsApp (required), Email (optional), Preferred Language", async () => {
-    await advanceToStep3();
-
-    // Step 3 container must be active
-    expect(document.querySelector('[data-testid="form-step-3"]')).not.toBeNull();
-
     // Name field (required)
-    const nameInput =
-      document.querySelector('input[autocomplete="name"]') ??
-      document.querySelector('input[type="text"]');
+    const nameInput = document.querySelector('input[autocomplete="name"]') ?? document.querySelector('input[type="text"]');
     expect(nameInput).not.toBeNull();
 
-    // Phone/WhatsApp field (required)
+    // Phone field (required)
     const phoneInput = document.querySelector('input[type="tel"]');
     expect(phoneInput).not.toBeNull();
 
     // Email (optional)
     const emailInput = document.querySelector('input[type="email"]');
     expect(emailInput).not.toBeNull();
-
-    // Optional badge must be visible near the email field
-    const optionalBadge = screen.queryByText(/optional|opcional/i);
-    expect(optionalBadge).not.toBeNull();
-
-    // Preferred Language selector
-    const langSelect = document.querySelector("select");
-    expect(langSelect).not.toBeNull();
   });
 });
 
-// ---------------------------------------------------------------------------
-// Validation errors in locale (5.1-COMP-003)
-// ---------------------------------------------------------------------------
-
-describe("SellerForm — Validation (5.1-COMP-003)", () => {
-  it("[P1] 5.1-COMP-003: inline validation errors appear when required field is empty and Next is clicked", async () => {
+describe("SellerForm — Validation", () => {
+  it("[P1] 5.1-COMP-003: inline validation errors appear when required field is empty and Submit is clicked", async () => {
     const user = userEvent.setup();
     await renderSellerForm({ locale: "en" });
 
-    // Tap Next without filling any Step 1 fields
-    // The button has aria-label="form.nextButtonAriaLabel" (mocked i18n key)
-    const nextButton = document.querySelector(
-      'button[aria-label="form.nextButtonAriaLabel"]',
-    ) as HTMLButtonElement;
-    expect(nextButton).not.toBeNull();
-    await user.click(nextButton);
+    const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(submitButton).not.toBeNull();
+    await user.click(submitButton);
 
-    // Error messages must appear
     const errorElements = document.querySelectorAll('[role="alert"]');
     expect(errorElements.length).toBeGreaterThan(0);
-
-    // Errors must be non-empty
     const firstError = errorElements[0].textContent ?? "";
     expect(firstError.length).toBeGreaterThan(0);
   });
 
   it("[P2] 5.1-UNIT-001: all form strings render in Spanish locale (locale='es')", async () => {
     await renderSellerForm({ locale: "es" });
-
-    // With the mocked useTranslations, the component renders i18n keys.
-    // Verify the component renders without throwing and has core structure.
     expect(document.querySelector('[data-testid="seller-form"]')).not.toBeNull();
-
-    // Step 1 heading must be present
-    const step1Heading = document.querySelector('[data-testid="form-step-1"] h2');
-    expect(step1Heading).not.toBeNull();
   });
 });
-
-// ---------------------------------------------------------------------------
-// SellerForm root wrapper
-// ---------------------------------------------------------------------------
 
 describe("SellerForm — Root wrapper", () => {
   it("[P1] SellerForm root has data-testid='seller-form'", async () => {


### PR DESCRIPTION
# Simplify Sell With Us Form

## Overview

The "Sell With Us" form has been significantly simplified to improve the user experience. The previous 3-step progressive form has been condensed into a single, straightforward step. Unnecessary fields have been removed, and the map-based location picker has been replaced with a simple text input.

## Changes

- `src/components/seller/seller-form.tsx`:
  - **Removed progressive steps**: Replaced the 3-step state logic with a single-page form.
  - **Removed fields**: Removed `size`, `priceExpectation`, `needsPricingHelp`, `photos`, `bedrooms`, `bathrooms`, and `preferredLanguage`.
  - **Simplified Location**: Replaced the interactive `LocationPicker` with a standard text input field for the property location.
  - **Updated Payload**: Modified `buildLeadPayload` to gracefully handle the removed fields, substituting them with empty defaults or nulls to remain compatible with the backend schema.
- `tests/unit/seller/seller-form.spec.tsx`:
  - **Updated Unit Tests**: Removed obsolete tests that checked for steps, missing fields (beds/baths, price checkbox), and the map picker.
  - **Refactored Tests**: Verified that the new form correctly renders the remaining required fields (Property Type, Location, Description, Name, Phone, Email) and displays validation errors properly.

## Testing

- **Unit Tests**: Executed `npm run test tests/unit/seller/seller-form.spec.tsx` locally, confirming that all 7 tests passed successfully.
- **Linting**: Verified with `npm run lint` that no new lint errors were introduced.
- **Production Build**: Verified the application compiles successfully via `npm run build`.
