### PR TITLE
Fix : Area Guide Navigation and Performance Optimizations

### DIFF
--- a/src/app/[locale]/areas/[slug]/page.tsx
+++ b/src/app/[locale]/areas/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { notFound } from "next/navigation";
-import { getAreaBySlug, getAllAreaSlugs, getPropertiesByAreaSlug } from "@/lib/db/queries/areas";
+import { getAreaBySlug, getAllAreaSlugs } from "@/lib/db/queries/areas";
 import { getCommunitiesByAreaId, sortCommunitiesCustom } from "@/lib/db/queries/communities";
 import {
   generatePlaceJsonLd,
@@ -11,8 +11,9 @@ import {
 import { buildAlternatesMetadata } from "@/lib/seo/metadata";
 import { AreaGuideHero } from "@/components/area/area-guide-hero";
 import { AreaGuideDescription } from "@/components/area/area-guide-description";
-import { AreaGuideTabs } from "@/components/area/area-guide-tabs";
 import { CommunityCard } from "@/components/area/community-card";
+import { Link } from "@/i18n/navigation";
+import { Button } from "@/components/ui/button";
 import { FeaturedAreas } from "@/components/home/featured-areas";
 import { AreaGalleryCarousel } from "@/components/area/area-gallery-carousel";
 import { AreaVideos } from "@/components/area/area-videos";
@@ -83,10 +84,7 @@ export default async function AreaGuidePage({
 
   const t = await getTranslations({ locale, namespace: "AreaGuide" });
 
-  const [areaProperties, communities] = await Promise.all([
-    getPropertiesByAreaSlug(slug),
-    getCommunitiesByAreaId(area.id),
-  ]);
+  const communities = await getCommunitiesByAreaId(area.id);
 
   const placeJsonLd = generatePlaceJsonLd(area, locale);
   const areaName = locale === "es" ? area.nameEs : area.nameEn;
@@ -167,7 +165,16 @@ export default async function AreaGuidePage({
           </div>
         </section>
       )}
-      <AreaGuideTabs properties={areaProperties} locale={locale} />
+      <section className="mx-auto flex justify-center max-w-7xl px-4 py-8 sm:px-6 lg:px-8 border-t border-border/40 mt-8">
+        <Link href={`/search?areas=${slug}`}>
+          <Button
+            size="lg"
+            className="bg-[var(--color-navy,#000E35)] hover:bg-[var(--color-navy,#000E35)]/90 text-white font-semibold"
+          >
+            {t("searchProperties", { defaultValue: "Search Properties in this Area" })}
+          </Button>
+        </Link>
+      </section>
 
       {/* Area Photo Gallery Carousel */}
       <AreaGalleryCarousel

--- a/src/components/area/area-guide-hero.tsx
+++ b/src/components/area/area-guide-hero.tsx
@@ -41,6 +41,20 @@ export async function AreaGuideHero({ area, locale }: AreaGuideHeroProps) {
 
   const regionLabel = t(`region.${area.region === "Mountain" ? "Mountain" : "Coast"}`);
 
+  const getLocalizedValue = (value?: string | number) => {
+    if (typeof value !== "string") return value;
+    const parts = value.split(" / ");
+    if (parts.length === 2) {
+      return locale === "es" ? parts[1] : parts[0];
+    }
+    return value;
+  };
+
+  const elevation = getLocalizedValue(metadata?.elevation as string | number);
+  const climate = getLocalizedValue(metadata?.climate as string);
+  const nearestBeach = getLocalizedValue(metadata?.nearestBeach as string);
+  const nearestHospital = getLocalizedValue(metadata?.nearestHospital as string);
+
   return (
     <section
       data-testid="area-guide-hero"
@@ -89,28 +103,28 @@ export async function AreaGuideHero({ area, locale }: AreaGuideHeroProps) {
           {/* Climate / altitude metadata */}
           {metadata && (
             <div className="mt-4 flex flex-wrap gap-4 text-sm text-white/90">
-              {metadata.elevation && (
+              {elevation && (
                 <span className="flex items-center gap-1.5">
                   <span aria-hidden="true">🏔</span>
-                  {metadata.elevation}
+                  {elevation}
                 </span>
               )}
-              {metadata.climate && (
+              {climate && (
                 <span className="flex items-center gap-1.5">
                   <span aria-hidden="true">🌡</span>
-                  {metadata.climate}
+                  {climate}
                 </span>
               )}
-              {metadata.nearestBeach && (
+              {nearestBeach && (
                 <span className="flex items-center gap-1.5">
                   <span aria-hidden="true">🏖</span>
-                  {metadata.nearestBeach}
+                  {nearestBeach}
                 </span>
               )}
-              {metadata.nearestHospital && (
+              {nearestHospital && (
                 <span className="flex items-center gap-1.5">
                   <span aria-hidden="true">🏥</span>
-                  {metadata.nearestHospital}
+                  {nearestHospital}
                 </span>
               )}
             </div>

--- a/src/components/area/area-index-card.tsx
+++ b/src/components/area/area-index-card.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import { getTranslations } from "next-intl/server";
+import { Link } from "@/i18n/navigation";
 import type { Area } from "@/lib/db/schema/areas";
 import { getAreaHeroImage } from "@/lib/utils";
 
@@ -32,8 +33,8 @@ export async function AreaIndexCard({ area, locale }: AreaIndexCardProps) {
   const regionLabel = t(`region.${area.region === "Mountain" ? "Mountain" : "Coast"}`);
 
   return (
-    <a
-      href={`/${locale}/areas/${area.slug}`}
+    <Link
+      href={`/areas/${area.slug}`}
       data-testid="area-index-card"
       className="group flex flex-col overflow-hidden rounded-[var(--radius-lg,12px)] bg-[var(--color-bg-white,#fff)] shadow-[var(--shadow-sm)] transition-all duration-200 ease-out hover:translate-y-[-4px] hover:shadow-[var(--shadow-lg)]"
     >
@@ -84,6 +85,6 @@ export async function AreaIndexCard({ area, locale }: AreaIndexCardProps) {
           {description}
         </p>
       </div>
-    </a>
+    </Link>
   );
 }

--- a/src/components/home/featured-areas.tsx
+++ b/src/components/home/featured-areas.tsx
@@ -1,7 +1,7 @@
 import { getTranslations } from "next-intl/server";
 import { getAllAreas } from "@/lib/db/queries/areas";
 import Image from "next/image";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { getAreaHeroImage } from "@/lib/utils";
 
 interface FeaturedAreasProps {

--- a/src/components/home/split-hero.tsx
+++ b/src/components/home/split-hero.tsx
@@ -124,6 +124,7 @@ export function SplitHero() {
           ctaKey="coastCta"
           href="/search?region=coast"
           accent="coast"
+          priority
           fetchPriority="high"
         />
       </div>

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -78,6 +78,12 @@ export const mainNavItems: NavItem[] = [
     icon: "👥",
   },
   {
+    labelKey: "blog",
+    href: "/blog",
+    activePrefix: "/blog",
+    icon: "📝",
+  },
+  {
     labelKey: "ourAgents",
     href: "/agents",
     activePrefix: "/agents",


### PR DESCRIPTION
# Area Guide Fixes and Optimizations

## Overview
This PR resolves two UI issues reported in the Area Guide and Home Page components, and optimizes the performance of the Area Guide by replacing a heavy data load with a faster CTA.

## Changes

- **Modified `src/components/home/featured-areas.tsx` & `src/components/area/area-index-card.tsx`**: Replaced standard `<a href="...">` and `next/link` implementations with the custom `<Link>` from `@/i18n/navigation`. This prevents full-page reloads when navigating to area pages, providing a significantly faster and smoother client-side routing experience.
- **Modified `src/components/area/area-guide-hero.tsx`**: Fixed a bug where bilingual metadata fields (like climate or distance) were displaying both English and Spanish text regardless of the active locale. Added a `getLocalizedValue` helper to properly split values formatted as "English / Spanish" and render only the selected language.
- **Modified `src/app/[locale]/areas/[slug]/page.tsx`**: Removed the `AreaGuideTabs` section which previously loaded and rendered all properties for the area at the bottom of the page. Replaced this with a prominent "Search Properties" button linking to the pre-filtered search page (`/search?areas=slug`). Additionally, the server-side query fetching all properties has been removed to significantly speed up page load times.
- **Modified `src/lib/navigation.ts`**: Added the new Blog page route to the main navigation menu items.

## Testing
- Verified that clicking on area cards on the home page and in the navigation dropdown now correctly utilizes fast, client-side routing.
- Verified that the Dominical page correctly displays English metadata ("Tropical wet") when the site is set to English.
- Verified that the Area Guide page no longer loads the full property list and instead displays the new localized search CTA.
- Ensured the build succeeds and passes linting checks.
