### PR TITLE
Fix : Community & UI Polish

### DIFF
--- a/src/app/[locale]/areas/[slug]/communities/[community]/page.tsx
+++ b/src/app/[locale]/areas/[slug]/communities/[community]/page.tsx
@@ -82,7 +82,7 @@ export default async function CommunityPage({
   ]);
   if (!area || !community) notFound();
 
-  const [communityProperties, similarCommunities] = await Promise.all([
+  const [communityProperties, similarResult] = await Promise.all([
     getPropertiesByCommunityId(community.id),
     getSimilarCommunities(community.areaId, communitySlug),
   ]);
@@ -128,10 +128,12 @@ export default async function CommunityPage({
       <CommunityMiniMap community={community} areaName={areaName} locale={locale} />
       <CommunityTabs properties={communityProperties} community={community} locale={locale} />
       <SimilarCommunitiesSlider
-        communities={similarCommunities}
+        communities={similarResult.communities}
         locale={locale}
         areaSlug={slug}
         areaName={areaName}
+        isFallback={similarResult.isFallback}
+        fallbackAreaMap={similarResult.fallbackAreaMap}
       />
     </main>
   );

--- a/src/components/area/community-card.tsx
+++ b/src/components/area/community-card.tsx
@@ -190,24 +190,25 @@ export function CommunityCard({
           </div>
         </div>
 
-        {/* Listings Counter */}
-        {typeof listingCount === "number" && listingCount > 0 && (
-          <div className="mt-4 flex items-center justify-between text-xs font-semibold text-text-muted">
-            <span>
-              {listingCount}{" "}
-              {listingCount === 1
-                ? locale === "es"
-                  ? "propiedad disponible"
-                  : "listing available"
-                : locale === "es"
-                  ? "propiedades disponibles"
-                  : "listings available"}
-            </span>
-            <span className="text-[var(--color-gold,#C2A661)] transition-transform duration-300 group-hover:translate-x-1 font-bold">
-              {locale === "es" ? "Ver detalles →" : "View details →"}
-            </span>
-          </div>
-        )}
+        {/* Listings Counter & View Details CTA */}
+        <div className="mt-4 flex items-center justify-between text-xs font-semibold text-text-muted">
+          <span>
+            {typeof listingCount === "number" && listingCount > 0
+              ? `${listingCount} ${
+                  listingCount === 1
+                    ? locale === "es"
+                      ? "propiedad disponible"
+                      : "listing available"
+                    : locale === "es"
+                      ? "propiedades disponibles"
+                      : "listings available"
+                }`
+              : ""}
+          </span>
+          <span className="text-[var(--color-gold,#C2A661)] transition-transform duration-300 group-hover:translate-x-1 font-bold">
+            {locale === "es" ? "Ver detalles →" : "View details →"}
+          </span>
+        </div>
       </div>
     </a>
   );

--- a/src/components/community/similar-communities-slider.tsx
+++ b/src/components/community/similar-communities-slider.tsx
@@ -10,6 +10,13 @@ interface SimilarCommunitiesSliderProps {
   locale: string;
   areaSlug: string;
   areaName?: string;
+  /** True when displaying communities from other areas as a fallback. */
+  isFallback?: boolean;
+  /** Map from community slug → area info, used only in fallback mode. */
+  fallbackAreaMap?: Record<
+    string,
+    { areaSlug: string; areaNameEn: string; areaNameEs: string }
+  > | null;
 }
 
 /**
@@ -18,29 +25,49 @@ interface SimilarCommunitiesSliderProps {
  * Horizontal slider showing nearby community cards.
  * Always visible below tabs, not tabbed.
  * Uses CommunityCard from src/components/area/community-card.tsx.
+ *
+ * When this community is the only one in its area, falls back to
+ * communities from other areas with a contextual subtitle.
  */
 export function SimilarCommunitiesSlider({
   communities,
   locale,
   areaSlug,
   areaName,
+  isFallback = false,
+  fallbackAreaMap,
 }: SimilarCommunitiesSliderProps) {
   const t = useTranslations("CommunityPage");
 
   if (communities.length === 0) return null;
+
+  const heading = isFallback ? t("exploreCommunities.heading") : t("similarCommunities.heading");
 
   return (
     <section
       data-testid="community-similar-slider"
       className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8"
     >
-      <h2 className="mb-6 text-2xl font-bold text-brand-navy">{t("similarCommunities.heading")}</h2>
+      <h2 className="mb-2 text-2xl font-bold text-brand-navy">{heading}</h2>
+      {isFallback && (
+        <p className="mb-6 text-sm text-gray-500">{t("exploreCommunities.subtitle")}</p>
+      )}
+      {!isFallback && <div className="mb-4" />}
       <div
         className="flex gap-6 overflow-x-auto pb-4 scrollbar-thin scrollbar-thumb-gray-300"
         role="region"
-        aria-label={t("similarCommunities.heading")}
+        aria-label={heading}
       >
         {sortCommunitiesCustom(communities).map((community) => {
+          // Resolve area info: use fallback map when in fallback mode
+          const areaInfo = isFallback && fallbackAreaMap?.[community.slug];
+          const cardAreaSlug = areaInfo ? areaInfo.areaSlug : areaSlug;
+          const cardAreaName = areaInfo
+            ? locale === "es"
+              ? areaInfo.areaNameEs
+              : areaInfo.areaNameEn
+            : areaName;
+
           const tagline = locale === "es" ? community.taglineEs : community.taglineEn;
           const qf = (community.quickFacts || {}) as Record<string, unknown>;
 
@@ -69,12 +96,12 @@ export function SimilarCommunitiesSlider({
                 name={community.name}
                 tagline={tagline}
                 heroImageUrl={community.heroImageUrl}
-                href={`/${locale}/areas/${areaSlug}/communities/${community.slug}`}
+                href={`/${locale}/areas/${cardAreaSlug}/communities/${community.slug}`}
                 locale={locale}
                 priceMin={community.priceMinUsd}
                 priceMax={community.priceMaxUsd}
                 listingCount={community.listingCount}
-                location={areaName}
+                location={cardAreaName}
                 propertyTypes={propertyTypes}
                 sizeMin={sizeMin}
                 sizeMax={sizeMax}

--- a/src/components/listing/property-gallery.tsx
+++ b/src/components/listing/property-gallery.tsx
@@ -334,9 +334,6 @@ export function PropertyGallery({ images, propertyTitle }: PropertyGalleryProps)
             fill
             sizes="100vw"
             priority={activeIndex === 0}
-            {...(activeImage.blurDataUrl
-              ? { placeholder: "blur" as const, blurDataURL: activeImage.blurDataUrl }
-              : {})}
             className="object-cover"
           />
 
@@ -434,9 +431,6 @@ export function PropertyGallery({ images, propertyTitle }: PropertyGalleryProps)
                   fallbackSrc={activeImage.fallbackSrc || "/property-placeholder.svg"}
                   fill
                   sizes="100vw"
-                  {...(activeImage.blurDataUrl
-                    ? { placeholder: "blur" as const, blurDataURL: activeImage.blurDataUrl }
-                    : {})}
                   className="object-contain"
                 />
               </div>

--- a/src/lib/db/queries/communities.ts
+++ b/src/lib/db/queries/communities.ts
@@ -83,18 +83,56 @@ export async function getPropertiesByCommunityId(
 
 /**
  * Fetches communities in the same area, excluding current community.
+ * Falls back to communities from other areas when none exist in the same area.
  * Used by SimilarCommunitiesSlider (AC #6).
  */
 export async function getSimilarCommunities(areaId: string, excludeSlug: string) {
   try {
-    return await db
+    const sameArea = await db
       .select()
       .from(communities)
       .where(and(eq(communities.areaId, areaId), not(eq(communities.slug, excludeSlug))))
       .orderBy(asc(communities.name));
+
+    if (sameArea.length > 0) {
+      return { communities: sameArea, isFallback: false, fallbackAreaMap: null };
+    }
+
+    // Fallback: show communities from other areas, joining to get area info
+    const rows = await db
+      .select({
+        community: communities,
+        areaSlug: areas.slug,
+        areaNameEn: areas.nameEn,
+        areaNameEs: areas.nameEs,
+      })
+      .from(communities)
+      .innerJoin(areas, eq(communities.areaId, areas.id))
+      .where(not(eq(communities.slug, excludeSlug)))
+      .orderBy(asc(communities.name))
+      .limit(6);
+
+    // Build a map from community slug → { areaSlug, areaName }
+    const fallbackAreaMap: Record<
+      string,
+      { areaSlug: string; areaNameEn: string; areaNameEs: string }
+    > = {};
+    for (const row of rows) {
+      fallbackAreaMap[row.community.slug] = {
+        areaSlug: row.areaSlug,
+        areaNameEn: row.areaNameEn,
+        areaNameEs: row.areaNameEs,
+      };
+    }
+
+    return {
+      communities: rows.map((r) => r.community),
+      isFallback: true,
+      fallbackAreaMap,
+    };
   } catch (error) {
     console.error("Database query failed in getSimilarCommunities:", error);
-    return [];
+    return { communities: [], isFallback: false, fallbackAreaMap: null };
   }
 }
 

--- a/src/lib/navigation.ts
+++ b/src/lib/navigation.ts
@@ -49,7 +49,7 @@ export const mainNavItems: NavItem[] = [
         children: [
           {
             labelKey: "rise",
-            href: "/areas/perez-zeledon/communities/rise",
+            href: "/areas/perez-zeledon/communities/rise-costa-rica",
           },
           {
             labelKey: "santaElenaHills",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -918,6 +918,10 @@
     "similarCommunities": {
       "heading": "Similar Communities"
     },
+    "exploreCommunities": {
+      "heading": "Explore Other Communities",
+      "subtitle": "This is the only community in this area — here are others you might like."
+    },
     "miniMap": {
       "heading": "Community Location",
       "alt": "Map of {community} in {area}",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -918,6 +918,10 @@
     "similarCommunities": {
       "heading": "Comunidades Similares"
     },
+    "exploreCommunities": {
+      "heading": "Explorar Otras Comunidades",
+      "subtitle": "Esta es la única comunidad en esta zona — aquí tienes otras que podrían interesarte."
+    },
     "miniMap": {
       "heading": "Ubicación de la Comunidad",
       "alt": "Mapa de {community} en {area}",

--- a/tests/unit/community/community-queries.spec.ts
+++ b/tests/unit/community/community-queries.spec.ts
@@ -432,11 +432,12 @@ describe("getSimilarCommunities — same-area community lookup (AC #6)", () => {
 
       const result = await getSimilarCommunities("uuid-area-1", "rise");
 
-      expect(result).toHaveLength(1);
-      expect(result[0].slug).toBe("santa-elena-hills");
+      expect(result.communities).toHaveLength(1);
+      expect(result.isFallback).toBe(false);
+      expect(result.communities[0].slug).toBe("santa-elena-hills");
       // Must NOT include the excluded community
       expect(
-        result.every(
+        result.communities.every(
           (c: Record<string, unknown>) => c.slug !== "rise",
         ),
       ).toBe(true);
@@ -444,12 +445,13 @@ describe("getSimilarCommunities — same-area community lookup (AC #6)", () => {
   );
 
   it(
-    "[P1] given area with only one community when called then returns empty array",
+    "[P1] given area with only one community when called then falls back to other areas",
     async () => {
       const { getSimilarCommunities } = await import(
         "@/lib/db/queries/communities"
       );
 
+      // First call: same-area query returns empty
       const mockSimilarOrderBy = vi.fn().mockResolvedValueOnce([]);
       const mockSimilarWhere = vi
         .fn()
@@ -459,9 +461,22 @@ describe("getSimilarCommunities — same-area community lookup (AC #6)", () => {
         .mockReturnValue({ where: mockSimilarWhere });
       mockSelect.mockReturnValueOnce({ from: mockSimilarFrom });
 
+      // Second call: fallback query returns communities from other areas
+      const fallbackCommunity = makeCommunity();
+      const mockFallbackLimit = vi.fn().mockResolvedValueOnce([
+        { community: fallbackCommunity, areaSlug: "perez-zeledon", areaNameEn: "Pérez Zeledón", areaNameEs: "Pérez Zeledón" },
+      ]);
+      const mockFallbackOrderBy = vi.fn().mockReturnValue({ limit: mockFallbackLimit });
+      const mockFallbackWhere = vi.fn().mockReturnValue({ orderBy: mockFallbackOrderBy });
+      const mockFallbackInnerJoin = vi.fn().mockReturnValue({ where: mockFallbackWhere });
+      const mockFallbackFrom = vi.fn().mockReturnValue({ innerJoin: mockFallbackInnerJoin });
+      mockSelect.mockReturnValueOnce({ from: mockFallbackFrom });
+
       const result = await getSimilarCommunities("uuid-area-2", "serena-del-mar");
 
-      expect(result).toEqual([]);
+      expect(result.isFallback).toBe(true);
+      expect(result.communities).toHaveLength(1);
+      expect(result.fallbackAreaMap).not.toBeNull();
     },
   );
 
@@ -487,7 +502,7 @@ describe("getSimilarCommunities — same-area community lookup (AC #6)", () => {
 
       const result = await getSimilarCommunities("uuid-area-1", "serena");
 
-      expect(result[0].name.localeCompare(result[1].name)).toBeLessThanOrEqual(0);
+      expect(result.communities[0].name.localeCompare(result.communities[1].name)).toBeLessThanOrEqual(0);
     },
   );
 });

--- a/tests/unit/listing/property-gallery.spec.tsx
+++ b/tests/unit/listing/property-gallery.spec.tsx
@@ -356,7 +356,7 @@ describe("PropertyGallery (Story 4.1)", () => {
   // ---------------------------------------------------------------------------
 
   it(
-    "[P2] 4.1-COMP-002: first image has blur placeholder (blurDataURL passed to next/image)",
+    "[P2] 4.1-COMP-002: first image does NOT use blur placeholder (removed to fix cycling artifact)",
     () => {
       render(
         <PropertyGallery
@@ -365,15 +365,15 @@ describe("PropertyGallery (Story 4.1)", () => {
         />,
       );
 
-      // Our next/image mock sets data-blur-data-url="has-blur" when blurDataURL is provided
-      // and data-placeholder="blur" when placeholder="blur"
+      // Blur placeholder was intentionally removed to fix a visual artifact
+      // that appeared when cycling through gallery images.
       const heroContainer = screen.getByTestId("gallery-hero");
       const firstImage = heroContainer.querySelector("img");
       expect(firstImage).toBeDefined();
 
-      // Assert that blur placeholder was passed
-      expect(firstImage?.getAttribute("data-blur-data-url")).toBe("has-blur");
-      expect(firstImage?.getAttribute("data-placeholder")).toBe("blur");
+      // Assert that blur placeholder is NOT passed
+      expect(firstImage?.getAttribute("data-blur-data-url")).toBeNull();
+      expect(firstImage?.getAttribute("data-placeholder")).toBeNull();
     },
   );
 


### PR DESCRIPTION
# Community & UI Polish

## Overview

This branch addresses four distinct issues found in the community pages and property gallery, improving navigation accuracy, visual quality, and content discovery when community data is sparse.

## Changes

### 1. Similar Communities — Cross-Area Fallback Slider

When a community is the only one in its area, the "Similar Communities" slider was empty. Now the query falls back to communities from other areas (up to 6), displaying them under an "Explore Other Communities" heading with a contextual subtitle.

**Files changed:**

- `communities.ts` — `getSimilarCommunities` now returns a structured object `{ communities, isFallback, fallbackAreaMap }`. When no same-area communities exist, it performs a cross-area join to fetch alternatives with their area metadata.
- `similar-communities-slider.tsx` — Accepts new `isFallback` and `fallbackAreaMap` props. Resolves per-card area slug and name from the fallback map so each card links to its correct area. Switches heading between "Similar Communities" and "Explore Other Communities".
- `page.tsx` — Destructures the new structured return value and passes `isFallback` / `fallbackAreaMap` to the slider.
- `en.json` / `es.json` — Added `exploreCommunities.heading` and `exploreCommunities.subtitle` i18n keys in both languages.

---

### 2. Property Gallery — Blur Placeholder Removal

A persistent blur artifact appeared when cycling through images in the property gallery. The root cause was the `blurDataURL` / `placeholder="blur"` props on Next.js `<Image>`, which caused a visible flash during re-renders.

**Files changed:**

- `property-gallery.tsx` — Removed the conditional spread of `placeholder: "blur"` and `blurDataURL` from both the hero and lightbox `<Image>` components.

---

### 3. RISE Community Navigation URL Fix

The RISE community link in the navbar pointed to `/communities/rise` instead of the correct slug `/communities/rise-costa-rica`, resulting in a 404.

**Files changed:**

- `navigation.ts` — Updated the RISE nav item `href` from `rise` to `rise-costa-rica`.

---

### 4. Community Card — Always-Visible CTA

The "View Details →" link was hidden when a community had zero listings. Now it is always rendered, while the listing count text simply becomes empty for zero-listing communities.

**Files changed:**

- `community-card.tsx` — Refactored the footer section to always render the CTA link. The listing count label conditionally displays only when `listingCount > 0`.

---

## Testing

### Unit Tests Updated

- `community-queries.spec.ts` — Updated to match the new structured return type. Added fallback scenario test verifying `isFallback: true` and non-null `fallbackAreaMap`.
- `property-gallery.spec.tsx` — Updated blur placeholder test to assert that `data-blur-data-url` and `data-placeholder` are `null`, confirming the fix.

### Verification

- Lint: ✅ 0 errors (warnings only — pre-existing)
- Build: ✅ Compiled successfully