### PR TITLE
Fix : Search Filter Bar Sticky Offset

### DIFF
--- a/src/components/search/search-filter-bar.tsx
+++ b/src/components/search/search-filter-bar.tsx
@@ -278,7 +278,7 @@ export function SearchFilterBar({
   return (
     <div
       data-testid="search-filter-bar"
-      className="sticky top-[var(--header-height)] flex-shrink-0 z-20 shadow-sm py-1 md:py-1.5 bg-background border-b border-border flex flex-col"
+      className="sticky top-0 flex-shrink-0 z-20 shadow-sm py-1 md:py-1.5 bg-background border-b border-border flex flex-col"
     >
       {/* Filter controls row */}
       <div className="flex items-stretch px-4 gap-3 h-full">

--- a/tests/unit/search/search-filter-bar.spec.tsx
+++ b/tests/unit/search/search-filter-bar.spec.tsx
@@ -138,10 +138,10 @@ describe("SearchFilterBar", () => {
       expect(filterBar).not.toBeNull();
 
       // sticky + offset are the critical positioning classes (AC #6)
-      // Filter bar sits below the global sticky header, so its `top` must
-      // equal the header height — not `0` — to avoid stacking on top of it.
+      // Filter bar uses top-0 since the header offset is handled by the
+      // page layout container, avoiding a double-offset gap.
       expect(filterBar?.className).toContain("sticky");
-      expect(filterBar?.className).toContain("top-[var(--header-height)]");
+      expect(filterBar?.className).toContain("top-0");
 
       // z-index must be above content but below modals (z-40)
       expect(filterBar?.className).toContain("z-20");


### PR DESCRIPTION
# Fix Search Filter Bar Sticky Offset

## Overview

Removes the double-offset gap that appeared between the global header and the search filter bar on the search page. The filter bar was using `top-[var(--header-height)]` for sticky positioning, but since the page layout container already accounts for the header height, this produced a visible whitespace gap. Changing to `top-0` eliminates the duplication and aligns the filter bar flush beneath the header.

## Changes

### `src/components/search/search-filter-bar.tsx`
- Changed the sticky positioning class from `top-[var(--header-height)]` to `top-0` on the root `<div>` of the filter bar component.
- The header offset is handled by the parent page layout container, so the filter bar only needs `top-0` to stick directly below the header without a gap.

### `tests/unit/search/search-filter-bar.spec.tsx`
- Updated the unit test assertions to expect `top-0` instead of `top-[var(--header-height)]`.
- Revised the test comments to explain the corrected positioning rationale (page layout handles the header offset, avoiding double-offset).

## Testing

- Unit tests updated and passing.
- Visual verification confirms the whitespace gap is eliminated on both desktop and mobile viewports.