### PR TITLE
Feature : Email Lead Workflow & Form Updates

### DIFF
--- a/src/app/api/leads/route.ts
+++ b/src/app/api/leads/route.ts
@@ -274,7 +274,7 @@ export async function POST(request: Request) {
         const locale = data.preferredLanguage === "es" ? "es" : "en";
 
         // Property-specific email (existing behavior for property inquiry forms)
-        if (data.source === "contact_form" && data.shortlistPropertyIds.length > 0) {
+        if (data.source === "contact_form" && data.shortlistPropertyIds.length === 1) {
           const [property] = await db
             .select({
               titleEn: properties.titleEn,
@@ -308,7 +308,12 @@ export async function POST(request: Request) {
             });
           }
         } else {
-          // Generic confirmation for seller, CMA, VIP, contact, agent_contact forms
+          // Generic confirmation for seller, CMA, VIP, contact, agent_contact, and shortlist forms
+          // Extract shortlist URL from notes if present (added by shortlist form)
+          const shortlistUrlMatch = data.notes?.match(/Shortlist Link: (https?:\/\/\S+)/);
+          const shortlistUrl =
+            data.shortlistPropertyIds.length > 1 && shortlistUrlMatch ? shortlistUrlMatch[1] : null;
+
           const { subject, html } = renderGenericLeadConfirmationEmail({
             locale,
             source: data.source,
@@ -317,6 +322,7 @@ export async function POST(request: Request) {
             agentEmail: agentDetails?.email,
             agentPhone: agentDetails?.whatsapp || agentDetails?.phone,
             contactedAgentName: data.source === "agent_contact" ? agentDetails?.name : null,
+            shortlistUrl,
           });
 
           sendEmailInBackground({
@@ -359,9 +365,13 @@ export async function POST(request: Request) {
     }
 
     // -----------------------------------------------------------------------
-    // Office notification email — notify the office for seller and CMA leads
+    // Office notification email — notify the office for seller, CMA, and
+    // unrouted contact_form leads (general contact, VIP, recruitment)
     // -----------------------------------------------------------------------
-    if (isSellerOrCma) {
+    const shouldNotifyOffice =
+      isSellerOrCma || (data.source === "contact_form" && !agentDetails?.email);
+
+    if (shouldNotifyOffice) {
       try {
         const locale = data.preferredLanguage === "es" ? "es" : "en";
         const { subject, html } = renderAgentLeadNotificationEmail({

--- a/src/components/agent/agent-contact-form.tsx
+++ b/src/components/agent/agent-contact-form.tsx
@@ -217,9 +217,11 @@ export function AgentContactForm({
 
       <input
         type="text"
-        name="company"
+        name="_hp_field"
         tabIndex={-1}
         autoComplete="off"
+        data-1p-ignore
+        data-lpignore="true"
         aria-label="Leave this field empty"
         value={honeypot}
         onChange={(e) => setHoneypot(e.target.value)}

--- a/src/components/lead/contact-form.tsx
+++ b/src/components/lead/contact-form.tsx
@@ -209,9 +209,11 @@ export function ContactForm() {
           the input a programmatic name so axe's label rule passes. */}
       <input
         type="text"
-        name="company"
+        name="_hp_field"
         tabIndex={-1}
         autoComplete="off"
+        data-1p-ignore
+        data-lpignore="true"
         aria-label="Leave this field empty"
         value={honeypot}
         onChange={(e) => setHoneypot(e.target.value)}
@@ -483,9 +485,11 @@ export function RecruitmentForm() {
       {/* Honeypot — see ContactForm for rationale (no aria-hidden). */}
       <input
         type="text"
-        name="company"
+        name="_hp_field"
         tabIndex={-1}
         autoComplete="off"
+        data-1p-ignore
+        data-lpignore="true"
         aria-label="Leave this field empty"
         value={honeypot}
         onChange={(e) => setHoneypot(e.target.value)}

--- a/src/components/lead/vip-inquiry-form.tsx
+++ b/src/components/lead/vip-inquiry-form.tsx
@@ -147,9 +147,11 @@ export function VipInquiryForm() {
       {/* Honeypot */}
       <input
         type="text"
-        name="company"
+        name="_hp_field"
         tabIndex={-1}
         autoComplete="off"
+        data-1p-ignore
+        data-lpignore="true"
         aria-label="Leave this field empty"
         value={honeypot}
         onChange={(e) => setHoneypot(e.target.value)}

--- a/src/components/listing/property-inquiry-form.tsx
+++ b/src/components/listing/property-inquiry-form.tsx
@@ -311,9 +311,11 @@ export function PropertyInquiryForm({
         {/* Honeypot anti-spam input */}
         <input
           type="text"
-          name="comp"
+          name="_hp_field"
           tabIndex={-1}
           autoComplete="off"
+          data-1p-ignore
+          data-lpignore="true"
           aria-hidden="true"
           value={honeypot}
           onChange={(e) => setHoneypot(e.target.value)}

--- a/src/lib/emails/GenericLeadConfirmationEmail.ts
+++ b/src/lib/emails/GenericLeadConfirmationEmail.ts
@@ -25,6 +25,8 @@ export interface GenericLeadConfirmationEmailProps {
   agentPhone?: string | null;
   /** Only used for agent_contact — shows the specific agent they reached out to */
   contactedAgentName?: string | null;
+  /** When set, overrides the contact_form copy to reference the shortlist */
+  shortlistUrl?: string | null;
 }
 
 /**
@@ -34,6 +36,7 @@ function getSourceCopy(
   source: LeadSource,
   isEs: boolean,
   contactedAgentName?: string | null,
+  shortlistUrl?: string | null,
 ): { subject: string; headline: string; message: string } {
   switch (source) {
     case "seller_form":
@@ -69,6 +72,17 @@ function getSourceCopy(
 
     case "contact_form":
     default:
+      if (shortlistUrl) {
+        return {
+          subject: isEs
+            ? "Hemos recibido su consulta sobre su lista de propiedades"
+            : "We have received your inquiry about your property shortlist",
+          headline: isEs ? "¡Consulta recibida!" : "Inquiry Received!",
+          message: isEs
+            ? `Gracias por ponerse en contacto con RE/MAX Altitud. Hemos recibido su consulta sobre su <a href="${shortlistUrl}" style="color: #d4af37; font-weight: bold;">lista de propiedades</a> y uno de nuestros agentes se comunicará con usted a la brevedad posible.`
+            : `Thank you for contacting RE/MAX Altitud. We have received your inquiry about your <a href="${shortlistUrl}" style="color: #d4af37; font-weight: bold;">property shortlist</a> and one of our agents will get in touch with you as soon as possible.`,
+        };
+      }
       return {
         subject: isEs ? "Hemos recibido su consulta" : "We have received your inquiry",
         headline: isEs ? "¡Consulta recibida!" : "Inquiry Received!",
@@ -89,6 +103,7 @@ export function renderGenericLeadConfirmationEmail(props: GenericLeadConfirmatio
     props.source,
     isEs,
     props.contactedAgentName,
+    props.shortlistUrl,
   );
 
   const greeting = isEs ? `¡Hola, ${props.leadName}!` : `Hello, ${props.leadName}!`;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -884,7 +884,8 @@
     },
     "communities": {
       "heading": "Communities in This Area"
-    }
+    },
+    "searchProperties": "Search Properties in this Area"
   },
   "CommunityPage": {
     "meta": {

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -884,7 +884,8 @@
     },
     "communities": {
       "heading": "Comunidades en Esta Zona"
-    }
+    },
+    "searchProperties": "Buscar Propiedades en esta Zona"
   },
   "CommunityPage": {
     "meta": {


### PR DESCRIPTION
# Email Lead Workflow & Form Updates

## Overview
This PR implements improvements to the email lead workflow, particularly for shortlist inquiries, enhances the honeypot anti-spam fields across all forms to prevent false positives from password managers, and adds missing translation keys for the Area Guide.

## Changes

### Email Workflow & Routing
#### [MODIFY] route.ts
- Enhanced the lead API to correctly parse the shortlist URL from notes when processing a contact form with a shortlist.
- Passed the `shortlistUrl` to the `renderGenericLeadConfirmationEmail` template.
- Updated office notification logic to include unrouted `contact_form` leads.

#### [MODIFY] GenericLeadConfirmationEmail.ts
- Added support for displaying the `shortlistUrl` in the confirmation email sent to the user, providing a customized message and direct link back to their shortlisted properties.

### Form Improvements (Honeypot Anti-Spam)
#### [MODIFY] agent-contact-form.tsx
#### [MODIFY] contact-form.tsx
#### [MODIFY] vip-inquiry-form.tsx
#### [MODIFY] property-inquiry-form.tsx
- Changed the honeypot field name from `company`/`comp` to `_hp_field` to prevent 1Password and LastPass from auto-filling it.
- Added `data-1p-ignore` and `data-lpignore="true"` attributes to further instruct password managers to ignore the field.

### Translations
#### [MODIFY] en.json
#### [MODIFY] es.json
- Added the `searchProperties` key under the `AreaGuide` namespace to fix placeholder text on the area guide pages.

## Testing
- Verified successful compilation through the production build (`npm run build`).
- Checked that no lint errors or regressions were introduced.
