### PR TITLE
Feature : Update Footer Email Link to Open Contact Form

### DIFF
--- a/src/components/layout/footer-contact-button.tsx
+++ b/src/components/layout/footer-contact-button.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { Mail } from "lucide-react";
+import { ContactForm } from "@/components/lead/contact-form";
+
+export function FooterContactButton() {
+  const t = useTranslations("Footer");
+  const tContact = useTranslations("ContactPage");
+  const [isOpen, setIsOpen] = useState(false);
+
+  // Close modal on Escape key press
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsOpen(false);
+    };
+    if (isOpen) {
+      window.addEventListener("keydown", handleKeyDown);
+    }
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen]);
+
+  // Lock background scroll when modal is open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        aria-label={t("socialEmail")}
+        className="flex size-11 items-center justify-center rounded-full text-text-on-dark transition-colors duration-[var(--duration-fast)] hover:bg-brand-gold/20 hover:text-brand-gold cursor-pointer bg-transparent border-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-gold"
+      >
+        <Mail className="size-5" />
+      </button>
+
+      {isOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4 animate-in fade-in duration-200"
+        >
+          {/* Backdrop click close */}
+          <div
+            className="absolute inset-0"
+            onClick={() => setIsOpen(false)}
+            aria-hidden="true"
+          ></div>
+
+          {/* Modal Content */}
+          <div className="relative bg-white rounded-2xl shadow-2xl max-w-lg w-full max-h-[90vh] flex flex-col overflow-hidden animate-in fade-in zoom-in-95 duration-200">
+            {/* Header */}
+            <div className="p-6 border-b border-slate-100 flex items-center justify-between">
+              <h2 className="text-xl font-bold text-brand-navy">{tContact("pageTitle")}</h2>
+              <button
+                onClick={() => setIsOpen(false)}
+                className="text-slate-400 hover:text-slate-600 transition-colors p-1.5 rounded-full hover:bg-slate-50 flex-shrink-0 cursor-pointer"
+                aria-label="Close modal"
+              >
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2.5}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            {/* Scrollable Body */}
+            <div className="p-6 overflow-y-auto flex-1 bg-brand-light/30">
+              <div className="text-left text-brand-navy">
+                <ContactForm />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -6,10 +6,11 @@
  */
 
 import { getTranslations } from "next-intl/server";
-import { MessageCircle, Mail } from "lucide-react";
+import { MessageCircle } from "lucide-react";
 import { Link } from "@/i18n/navigation";
 import { offices } from "@/lib/constants/offices";
 import { LanguageToggle } from "@/components/layout/language-toggle";
+import { FooterContactButton } from "@/components/layout/footer-contact-button";
 
 function FacebookIcon({ className }: { className?: string }) {
   return (
@@ -81,7 +82,6 @@ const socialLinks = [
     icon: YoutubeIcon,
   },
   { key: "socialWhatsApp", href: "https://wa.me/50660788887", icon: MessageCircle },
-  { key: "socialEmail", href: "mailto:hola@remax-altitud.cr", icon: Mail },
 ] as const;
 
 const legalLinks = [
@@ -153,6 +153,7 @@ export async function Footer() {
                   </a>
                 );
               })}
+              <FooterContactButton />
             </div>
           </div>
 

--- a/task.md
+++ b/task.md
@@ -1,17 +1,9 @@
-# Task: Website Performance Optimization
+# Task: Update Footer Email Link to Open Contact Form
 
-- [x] Caching & Third-Party Scripts
-  - [x] Create `src/lib/db/queries/settings.ts` with `getCachedSetting` (`unstable_cache`)
-  - [x] Modify `src/app/actions/admin-settings-actions.ts` to clear cache on update
-  - [x] Update `src/app/[locale]/layout.tsx` to use cached setting and `next/script`
-- [x] Image & Gallery SSR Optimization
-  - [x] Enable SSR in `src/components/listing/property-gallery-loader.tsx`
-- [x] Hidden Content Reduction (Print View)
-  - [x] Make `PropertyPrintView` a Client Component and remove image preloading
-  - [x] Load `PropertyPrintView` dynamically with `ssr: false` in `listing-detail-layout.tsx`
-- [x] Offscreen Assets Deferral
-  - [x] Lazy load YouTube iframes in `listing-detail-layout.tsx`
-  - [x] Implement native `IntersectionObserver` lazy loading for map in `map-view-loader.tsx`
+- [x] Implement Footer Contact Button component
+  - [x] Create `src/components/layout/footer-contact-button.tsx` with modal and form
+- [x] Integrate into Footer component
+  - [x] Modify `src/components/layout/footer.tsx` to use the new button component
 - [x] Verification
   - [x] Run `npm run test` to verify unit and integration tests pass
   - [x] Run `npm run build` to verify clean build and static generation


### PR DESCRIPTION
We updated the 5th child of the social icons container in the page footer (the email icon). Previously, it linked directly to a mailto address (`mailto:hola@remax-altitud.cr`). Now, it opens the unified generic contact form modal exactly like the one on the `/en/contact` page.

## Changes Made

### Layout & Navigation Components

#### [NEW] `src/components/layout/footer-contact-button.tsx`
- Implemented a Client Component `FooterContactButton` that renders the Lucide `Mail` icon styled identically to other footer social elements.
- When clicked, it displays an overlay modal (`role="dialog"` and `aria-modal="true"`) housing the generic `<ContactForm />` component.
- Implemented backdrop click dismiss, an Escape key listener, and scroll locks (`overflow: hidden`) on `document.body` while the modal is open.
- Integrated translation namespaces `Footer` and `ContactPage` for full multilingual accessibility support (English and Spanish translations of `ContactPage.pageTitle` are reused).

#### [MODIFY] `src/components/layout/footer.tsx`
- Removed `socialEmail` from the mapped static links list.
- Appended the new client-side `<FooterContactButton />` component at the end of the social links flex container.
- This preserves the DOM placement (making it the 5th child in `footer > div > div.grid > div:nth-child(3) > div`), matching the exact selector targeted by the user request.

---

## Verification Results

### Automated Tests
- Ran the project unit and integration tests using Vitest (`npm run test`):
  ```bash
  Test Files  90 passed | 1 skipped (91)
  Tests  1084 passed | 4 skipped (1088)
  ```
- Re-ran the full Next.js production build (`npm run build`) to ensure there are no compilation, TypeScript, static generation, or hydration mismatches:
  ```bash
  ✓ Generating static pages (68/68)
  Finalizing page optimization ...
  Collecting build traces ...
  ```
  The build compiled successfully, indicating zero compilation errors.