### PR TITLE
Chore : Split CI Tests into a Separate Job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,29 @@ on:
     branches: [main, development]
 
 jobs:
+  test:
+    name: Run Unit & Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
   build:
+    name: Build & Verify Application
+    needs: test
     runs-on: ubuntu-latest
 
     steps:
@@ -32,9 +54,6 @@ jobs:
       - name: Format check
         run: npm run format:check
 
-      - name: Run tests
-        run: npm test
-
       - name: Build
         run: npm run build
         env:
@@ -42,3 +61,4 @@ jobs:
           # the Next.js build-time page-data collection step. No real connection
           # is made — route handlers that use the DB are marked force-dynamic.
           DATABASE_URL: postgresql://ci:ci@localhost:5432/ci_db
+

--- a/task.md
+++ b/task.md
@@ -1,9 +1,7 @@
-# Task: Update Footer Email Link to Open Contact Form
+# Task: Split CI Tests into a Separate Job
 
-- [x] Implement Footer Contact Button component
-  - [x] Create `src/components/layout/footer-contact-button.tsx` with modal and form
-- [x] Integrate into Footer component
-  - [x] Modify `src/components/layout/footer.tsx` to use the new button component
+- [x] Update GitHub Actions CI Workflow
+  - [x] Modify `.github/workflows/ci.yml` to split tests into a dedicated job
 - [x] Verification
-  - [x] Run `npm run test` to verify unit and integration tests pass
-  - [x] Run `npm run build` to verify clean build and static generation
+  - [x] Validate YAML syntax
+  - [/] Commit, push, and create a Pull Request


### PR DESCRIPTION
We split the tests step in the GitHub Actions CI workflow into its own dedicated job. This ensures that:
1. "Run Unit & Integration Tests" shows up as a separate, distinct check on pull requests instead of being hidden inside the generic `build` status check.
2. The NextJS `build` job is only executed if the tests pass successfully (configured via the `needs: test` dependency).

## Changes Made

### CI/CD Workflow Configs

#### [MODIFY] `.github/workflows/ci.yml`
- Split the single `build` job into two distinct jobs: `test` and `build`.
- `test`: Checkout, setup node, install dependencies, and run unit & integration tests (`npm test`).
- `build`: Requires `test` to pass (`needs: test`), runs TypeScript checking, lint check, format check, and compiles the production bundle (`npm run build`).

---

## Verification Results

### YAML Syntax Verification
- Verified that the `.github/workflows/ci.yml` is correctly structured and follows standard GitHub Actions YAML schema design.