### PR TITLE
Feature : Accent-Insensitive Search Normalization

### DIFF
--- a/src/app/actions/map-actions.ts
+++ b/src/app/actions/map-actions.ts
@@ -23,6 +23,7 @@ import type { SQL } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { properties, areas } from "@/lib/db/schema";
 import { normalizePropertyImages } from "@/lib/utils/normalize-images";
+import { normalizeAreaSlug, normalizeSubLocation } from "@/lib/normalize-search-params";
 import type { OptimizedImage } from "@/types/images";
 
 export type MapProperty = {
@@ -249,10 +250,12 @@ export async function getPropertiesForMap(
   const lotSizeMaxCondition =
     lotSizeMax !== undefined ? lte(properties.lotSizeM2, lotSizeMax) : undefined;
 
-  // Area / sub-location conditions
-  const areaCondition = filters?.areaSlug ? eq(properties.areaSlug, filters.areaSlug) : undefined;
+  // Area / sub-location conditions (normalized for accent/case/space tolerance)
+  const areaCondition = filters?.areaSlug
+    ? eq(properties.areaSlug, normalizeAreaSlug(filters.areaSlug))
+    : undefined;
   const subLocationCondition = filters?.subLocation
-    ? eq(properties.subLocation, filters.subLocation)
+    ? eq(properties.subLocation, normalizeSubLocation(filters.subLocation))
     : undefined;
 
   // Lifestyle tags — OR filter using PostgreSQL && (overlap) operator

--- a/src/app/actions/search-actions.ts
+++ b/src/app/actions/search-actions.ts
@@ -20,6 +20,7 @@ import type { SearchFilters, SearchResult, PropertySearchItem, FilterFacets } fr
 import { mapPropertyRowToSearchItem, propertySearchColumns } from "@/lib/db/queries/properties";
 import { trackSearchInBackground } from "@/lib/services/tracking";
 import { getDistrictLabel } from "@/lib/locations";
+import { normalizeAreaSlug, normalizeSubLocation } from "@/lib/normalize-search-params";
 
 export type RawBounds = {
   north: number;
@@ -427,9 +428,11 @@ export async function searchProperties(
       bathrooms: bathrooms !== undefined ? gte(properties.bathrooms, bathrooms) : undefined,
       lotSizeMin: safeLotMin !== undefined ? gte(properties.lotSizeM2, safeLotMin) : undefined,
       lotSizeMax: safeLotMax !== undefined ? lte(properties.lotSizeM2, safeLotMax) : undefined,
-      areaSlug: filters.areaSlug ? eq(properties.areaSlug, filters.areaSlug) : undefined,
+      areaSlug: filters.areaSlug
+        ? eq(properties.areaSlug, normalizeAreaSlug(filters.areaSlug))
+        : undefined,
       subLocation: filters.subLocation
-        ? eq(properties.subLocation, filters.subLocation)
+        ? eq(properties.subLocation, normalizeSubLocation(filters.subLocation))
         : undefined,
       // Story 3.4: lifestyle tag OR filter using PostgreSQL && (overlap) operator on GIN-indexed array
       // The && operator returns rows where lifestyleTags and the filter array share at least one element

--- a/src/components/home/hero-search-shell.tsx
+++ b/src/components/home/hero-search-shell.tsx
@@ -28,6 +28,7 @@ import { useRouter, Link } from "@/i18n/navigation";
 import { getAvailableAreas } from "@/app/actions/search-actions";
 import { useSearchHistory } from "@/hooks/use-search-history";
 import { AreaSearchCombobox } from "@/components/search/area-search-combobox";
+import { stripDiacritics } from "@/lib/normalize-search-params";
 
 type Variant = "desktop-overlay" | "mobile-inline";
 
@@ -322,9 +323,14 @@ function parseQuery(queryText: string, locale: string = "en"): ParsedSearch {
     (a, b) => b[0].length - a[0].length,
   );
 
+  // Accent-stripped version of the remaining text for fallback matching
+  const remainingTextNorm = stripDiacritics(remainingText);
+
   // Try sub-location keywords first (more specific)
   for (const [key, subSlug] of sortedSubLocationKeywords) {
-    if (remainingText.includes(key)) {
+    // Match with original text OR accent-stripped text against accent-stripped key
+    const keyNorm = stripDiacritics(key);
+    if (remainingText.includes(key) || remainingTextNorm.includes(keyNorm)) {
       if (!params.sub_location) {
         params.area = "perez-zeledon"; // Sub-locations are all in PZ
         params.sub_location = subSlug;
@@ -339,6 +345,10 @@ function parseQuery(queryText: string, locale: string = "en"): ParsedSearch {
       // Remove all occurrences of keys that map to the same sub_location
       if (params.sub_location === subSlug) {
         remainingText = remainingText.replace(new RegExp(key, "gi"), " ");
+        // Also strip the accent-stripped variant if it differs
+        if (keyNorm !== key) {
+          remainingText = remainingText.replace(new RegExp(keyNorm, "gi"), " ");
+        }
       }
     }
   }
@@ -346,7 +356,9 @@ function parseQuery(queryText: string, locale: string = "en"): ParsedSearch {
   // If no sub-location matched, try main area keywords
   if (!matchedAreaKey) {
     for (const [key, slug] of sortedAreaKeywords) {
-      if (remainingText.includes(key)) {
+      // Match with original text OR accent-stripped text against accent-stripped key
+      const keyNorm = stripDiacritics(key);
+      if (remainingText.includes(key) || remainingTextNorm.includes(keyNorm)) {
         if (!params.area) {
           params.area = slug;
           matchedAreaKey = key;
@@ -360,6 +372,10 @@ function parseQuery(queryText: string, locale: string = "en"): ParsedSearch {
         // Remove all occurrences of keys that map to the same area
         if (params.area === slug) {
           remainingText = remainingText.replace(new RegExp(key, "gi"), " ");
+          // Also strip the accent-stripped variant if it differs
+          if (keyNorm !== key) {
+            remainingText = remainingText.replace(new RegExp(keyNorm, "gi"), " ");
+          }
         }
       }
     }
@@ -798,11 +814,18 @@ function getSuggestions(query: string, locale: string): Suggestion[] {
   const suggestions: Suggestion[] = [];
   const maxPerCategory = 3;
 
-  // Match areas
+  // Match areas (accent-insensitive)
+  const normalizedNorm = stripDiacritics(normalized);
   let areaCount = 0;
   for (const [keyword, slug] of Object.entries(AREA_KEYWORDS)) {
     if (areaCount >= maxPerCategory) break;
-    if (keyword.includes(normalized) || normalized.includes(keyword)) {
+    const keywordNorm = stripDiacritics(keyword);
+    if (
+      keyword.includes(normalized) ||
+      normalized.includes(keyword) ||
+      keywordNorm.includes(normalizedNorm) ||
+      normalizedNorm.includes(keywordNorm)
+    ) {
       // Skip duplicates (same slug)
       if (suggestions.some((s) => s.category === "area" && s.value === slug)) continue;
       suggestions.push({

--- a/src/hooks/use-search-filters.ts
+++ b/src/hooks/use-search-filters.ts
@@ -17,6 +17,7 @@
 import { useCallback, useMemo, useRef } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import type { SearchFilters, SortOption } from "@/types/search";
+import { normalizeAreaSlug, normalizeSubLocation } from "@/lib/normalize-search-params";
 
 export interface UseSearchFiltersReturn {
   filters: SearchFilters;
@@ -127,10 +128,10 @@ function parseFilters(params: URLSearchParams): SearchFilters {
   if (Number.isFinite(lotSizeMax) && lotSizeMax >= 0) filters.lotSizeMax = lotSizeMax;
 
   const areaSlug = params.get("area");
-  if (areaSlug) filters.areaSlug = areaSlug;
+  if (areaSlug) filters.areaSlug = normalizeAreaSlug(areaSlug);
 
   const subLocation = params.get("sub_location");
-  if (subLocation) filters.subLocation = subLocation;
+  if (subLocation) filters.subLocation = normalizeSubLocation(subLocation);
 
   const sort = params.get("sort");
   if (sort && VALID_SORT_OPTIONS.includes(sort as SortOption)) {

--- a/src/lib/normalize-search-params.ts
+++ b/src/lib/normalize-search-params.ts
@@ -1,0 +1,133 @@
+/**
+ * Normalize search URL parameters — accent-insensitive, case-insensitive,
+ * space-tolerant slug resolution for area and sub-location filters.
+ *
+ * Converts raw user input (from URL params, manual entry, shared links) into
+ * canonical database slugs so that "Pérez Zeledón", "Perez Zeledon",
+ * "PEREZ-ZELEDON", etc. all resolve to "perez-zeledon".
+ */
+
+/**
+ * Strip diacritics / combining marks from a string.
+ * "Pérez Zeledón" → "Perez Zeledon"
+ */
+export function stripDiacritics(text: string): string {
+  return text.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+/**
+ * Convert raw text into a URL-style slug.
+ * Lowercases, strips accents, replaces spaces/underscores with hyphens,
+ * collapses multiple hyphens, trims leading/trailing hyphens.
+ */
+function toSlug(raw: string): string {
+  return stripDiacritics(raw)
+    .toLowerCase()
+    .trim()
+    .replace(/[\s_]+/g, "-") // spaces / underscores → hyphen
+    .replace(/-+/g, "-") // collapse multiple hyphens
+    .replace(/^-|-$/g, ""); // trim leading/trailing hyphens
+}
+
+// ── Canonical area slug lookup ──────────────────────────────────────────────
+// Maps every known variant (slugified) → canonical DB slug.
+// Built from the same dictionaries used in hero-search-shell.tsx AREA_KEYWORDS
+// plus display labels from AREA_LABELS.
+const AREA_SLUG_ALIASES: Record<string, string> = {
+  // Canonical slugs (identity)
+  "perez-zeledon": "perez-zeledon",
+  uvita: "uvita",
+  dominical: "dominical",
+  ojochal: "ojochal",
+  quepos: "quepos",
+  "manuel-antonio": "manuel-antonio",
+  jaco: "jaco",
+  tamarindo: "tamarindo",
+  nosara: "nosara",
+  samara: "samara",
+  "santa-teresa": "santa-teresa",
+  "playa-hermosa": "playa-hermosa",
+  "tinamastes-platanillo": "tinamastes-platanillo",
+  // Abbreviations / common aliases
+  pz: "perez-zeledon",
+  // Sub-district names that map to perez-zeledon as area
+  "san-isidro": "perez-zeledon",
+  "san-isidro-de-el-general": "perez-zeledon",
+  cajon: "perez-zeledon",
+  rivas: "perez-zeledon",
+  "daniel-flores": "perez-zeledon",
+  pejibaye: "perez-zeledon",
+  "general-viejo": "perez-zeledon",
+  "san-gerardo": "perez-zeledon",
+  "san-gerardo-de-rivas": "perez-zeledon",
+  platanares: "perez-zeledon",
+  // Barú / Tinamastes aliases
+  tinamastes: "tinamastes-platanillo",
+  platanillo: "tinamastes-platanillo",
+  baru: "tinamastes-platanillo",
+};
+
+// ── Canonical sub-location slug lookup ──────────────────────────────────────
+const SUB_LOCATION_SLUG_ALIASES: Record<string, string> = {
+  // Canonical slugs (identity)
+  "san-isidro": "san-isidro",
+  "el-general": "el-general",
+  "daniel-flores": "daniel-flores",
+  rivas: "rivas",
+  "san-pedro": "san-pedro",
+  platanares: "platanares",
+  pejibaye: "pejibaye",
+  cajon: "cajon",
+  baru: "baru",
+  "rio-nuevo": "rio-nuevo",
+  paramo: "paramo",
+  "la-amistad": "la-amistad",
+  // Accented display-label variants (after slug normalization)
+  "san-isidro-de-el-general": "san-isidro",
+  "general-viejo": "el-general",
+  "san-gerardo": "rivas",
+  "san-gerardo-de-rivas": "rivas",
+};
+
+/**
+ * Normalize a raw area value from URL params to its canonical DB slug.
+ *
+ * Examples:
+ *   "Pérez Zeledón"  → "perez-zeledon"
+ *   "Perez Zeledon"  → "perez-zeledon"
+ *   "PEREZ-ZELEDON"  → "perez-zeledon"
+ *   "Manuel Antonio" → "manuel-antonio"
+ *   "perez-zeledon"  → "perez-zeledon" (no-op)
+ */
+export function normalizeAreaSlug(raw: string): string {
+  const slugified = toSlug(raw);
+
+  // Direct alias lookup
+  if (AREA_SLUG_ALIASES[slugified]) {
+    return AREA_SLUG_ALIASES[slugified];
+  }
+
+  // Already a valid-looking slug, return as-is (handles unknown future areas)
+  return slugified;
+}
+
+/**
+ * Normalize a raw sub-location value from URL params to its canonical DB slug.
+ *
+ * Examples:
+ *   "San Isidro"     → "san-isidro"
+ *   "Daniel Flores"  → "daniel-flores"
+ *   "Río Nuevo"      → "rio-nuevo"
+ *   "rio-nuevo"      → "rio-nuevo" (no-op)
+ */
+export function normalizeSubLocation(raw: string): string {
+  const slugified = toSlug(raw);
+
+  // Direct alias lookup
+  if (SUB_LOCATION_SLUG_ALIASES[slugified]) {
+    return SUB_LOCATION_SLUG_ALIASES[slugified];
+  }
+
+  // Already a valid-looking slug, return as-is
+  return slugified;
+}


### PR DESCRIPTION
# Accent-Insensitive Search Normalization

## Overview

Adds accent-insensitive (diacritic-tolerant) normalization across all search entry points so that Costa Rican location names like "Pérez Zeledón", "Perez Zeledon", "perez-zeledon", and "PEREZ-ZELEDON" all resolve to the same canonical database slug. This eliminates broken searches caused by accented characters in URLs, shared links, manual input, and autocomplete.

## Changes

### [NEW] normalize-search-params.ts
Core normalization library with:
- `stripDiacritics()` — removes combining marks via Unicode NFD decomposition
- `toSlug()` — lowercases, strips accents, replaces spaces/underscores with hyphens
- `normalizeAreaSlug()` — resolves raw area input to canonical DB slug via alias lookup table
- `normalizeSubLocation()` — resolves raw sub-location input to canonical DB slug via alias lookup table
- Comprehensive alias maps for all known Costa Rica South Pacific areas and sub-locations

### [MODIFY] search-actions.ts
Server-side search action now normalizes `areaSlug` and `subLocation` filters through `normalizeAreaSlug()` / `normalizeSubLocation()` before building SQL `WHERE` clauses.

### [MODIFY] map-actions.ts
Map properties action applies the same normalization to area and sub-location filters, ensuring map view stays consistent with search results.

### [MODIFY] use-search-filters.ts
Client-side URL parameter parser now normalizes `area` and `sub_location` params when reading from the URL, catching malformed values before they reach the UI or server actions.

### [MODIFY] hero-search-shell.tsx
- Search parser (`parseQuery`) now performs accent-insensitive matching for both sub-location and area keywords using `stripDiacritics()` on both the query text and keyword dictionaries.
- Autocomplete suggestions (`getSuggestions`) now match accent-stripped variants, so typing "perez" suggests "Pérez Zeledón".

## Testing

- Lint check: 0 errors (pre-existing warnings only)
- Production build: verified successful compilation
- The normalization is applied at three defense layers (URL params → client hook → server actions) to ensure no accented/malformed slug reaches the database query