### PR TITLE
Feature : GTM, Facebook Pixel and WordPress Redirects

### DIFF
--- a/src/app/[locale]/admin/visibility/page.tsx
+++ b/src/app/[locale]/admin/visibility/page.tsx
@@ -52,6 +52,8 @@ export default async function AdminVisibilityPage({ params, searchParams }: Page
 
   const { getSettingAction } = await import("@/app/actions/admin-settings-actions");
   const ga4Setting = await getSettingAction("GA_MEASUREMENT_ID");
+  const gtmSetting = await getSettingAction("GTM_CONTAINER_ID");
+  const fbSetting = await getSettingAction("FACEBOOK_PIXEL_ID");
 
   return (
     <div className="flex-1 p-6 md:p-10 max-w-7xl mx-auto w-full">
@@ -74,6 +76,8 @@ export default async function AdminVisibilityPage({ params, searchParams }: Page
         totalPages={totalPages}
         showHiddenOnly={showHiddenOnly}
         initialGa4MeasurementId={ga4Setting.value || ""}
+        initialGtmContainerId={gtmSetting.value || ""}
+        initialFacebookPixelId={fbSetting.value || ""}
       />
     </div>
   );

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -79,10 +79,44 @@ export default async function LocaleLayout({
   const ga4SettingValue = await getCachedSetting("GA_MEASUREMENT_ID");
   const gaId = ga4SettingValue || process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || "G-E2EMOCK123";
 
+  // Try to fetch GTM Container ID from cached query, fallback to environment variable
+  const gtmSettingValue = await getCachedSetting("GTM_CONTAINER_ID");
+  const gtmId =
+    gtmSettingValue || process.env.NEXT_PUBLIC_GTM_CONTAINER_ID || process.env.NEXT_PUBLIC_GTM_ID;
+
+  // Try to fetch Facebook Pixel ID from cached query, fallback to environment variable
+  const fbSettingValue = await getCachedSetting("FACEBOOK_PIXEL_ID");
+  const fbPixelId =
+    fbSettingValue ||
+    process.env.NEXT_PUBLIC_FACEBOOK_PIXEL_ID ||
+    process.env.NEXT_PUBLIC_FB_PIXEL_ID;
+
   return (
     <html lang={locale} className={cn("font-sans", montserrat.variable)}>
       <head />
       <body>
+        {gtmId && (
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?id=${gtmId}`}
+              height="0"
+              width="0"
+              style={{ display: "none", visibility: "hidden" }}
+            />
+          </noscript>
+        )}
+        {fbPixelId && (
+          <noscript>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              height="1"
+              width="1"
+              style={{ display: "none" }}
+              src={`https://www.facebook.com/tr?id=${fbPixelId}&ev=PageView&noscript=1`}
+              alt=""
+            />
+          </noscript>
+        )}
         {gaId && (
           <>
             <Script
@@ -109,6 +143,33 @@ export default async function LocaleLayout({
               `}
             </Script>
           </>
+        )}
+        {gtmId && (
+          <Script id="gtm-script" strategy="afterInteractive">
+            {`
+              (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+              new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+              })(window,document,'script','dataLayer','${gtmId}');
+            `}
+          </Script>
+        )}
+        {fbPixelId && (
+          <Script id="fb-pixel" strategy="afterInteractive">
+            {`
+              !function(f,b,e,v,n,t,s)
+              {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+              n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+              if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+              n.queue=[];t=b.createElement(e);t.async=!0;
+              t.src=v;s=b.getElementsByTagName(e)[0];
+              s.parentNode.insertBefore(t,s)}(window, document,'script',
+              'https://connect.facebook.net/en_US/fbevents.js');
+              fbq('init', '${fbPixelId}');
+              fbq('track', 'PageView');
+            `}
+          </Script>
         )}
         <NextIntlClientProvider locale={locale} messages={messages}>
           <SkipToContent />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -19,6 +19,9 @@ import { getAllAreaSlugs } from "@/lib/db/queries/areas";
 import { getAllCommunityParams } from "@/lib/db/queries/communities";
 import { SITE_ORIGIN, LOCALES } from "@/lib/seo/constants";
 
+// Force dynamic execution at runtime to avoid build-time DB dependencies (which fail on Coolify / CI)
+export const dynamic = "force-dynamic";
+
 const staticRoutes = [
   "",
   "/search",
@@ -30,6 +33,15 @@ const staticRoutes = [
 ];
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const staticEntries: MetadataRoute.Sitemap = LOCALES.flatMap((locale) =>
+    staticRoutes.map((route) => ({
+      url: `${SITE_ORIGIN}/${locale}${route}`,
+      lastModified: new Date(),
+      changeFrequency: "weekly" as const,
+      priority: route === "" ? 1.0 : 0.5,
+    })),
+  );
+
   try {
     const [propertySlugs, agentSlugs, areaSlugs, communityParams] = await Promise.all([
       getAllPropertySlugs(),
@@ -37,15 +49,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       getAllAreaSlugs(),
       getAllCommunityParams(),
     ]);
-
-    const staticEntries: MetadataRoute.Sitemap = LOCALES.flatMap((locale) =>
-      staticRoutes.map((route) => ({
-        url: `${SITE_ORIGIN}/${locale}${route}`,
-        lastModified: new Date(),
-        changeFrequency: "weekly" as const,
-        priority: route === "" ? 1.0 : 0.5,
-      })),
-    );
 
     const propertyEntries: MetadataRoute.Sitemap = LOCALES.flatMap((locale) =>
       propertySlugs.map((slug) => ({
@@ -90,8 +93,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       ...areaEntries,
       ...communityEntries,
     ];
-  } catch {
-    // Build continues; sitemap generates on-demand at runtime
-    return [];
+  } catch (error) {
+    // Dynamic generation failed (e.g. database down); return at least the static entries
+    console.error("Sitemap dynamic generation failed:", error);
+    return staticEntries;
   }
 }

--- a/src/components/admin/admin-visibility-dashboard.tsx
+++ b/src/components/admin/admin-visibility-dashboard.tsx
@@ -45,6 +45,8 @@ interface AdminVisibilityDashboardProps {
   totalPages: number;
   showHiddenOnly: boolean;
   initialGa4MeasurementId: string;
+  initialGtmContainerId: string;
+  initialFacebookPixelId: string;
 }
 
 export function AdminVisibilityDashboard({
@@ -55,6 +57,8 @@ export function AdminVisibilityDashboard({
   totalPages,
   showHiddenOnly,
   initialGa4MeasurementId,
+  initialGtmContainerId,
+  initialFacebookPixelId,
 }: AdminVisibilityDashboardProps) {
   const t = useTranslations("AdminVisibility");
   const router = useRouter();
@@ -68,6 +72,14 @@ export function AdminVisibilityDashboard({
   // GA4 Configuration state
   const [ga4Id, setGa4Id] = useState(initialGa4MeasurementId);
   const [isSavingGa4, setIsSavingGa4] = useState(false);
+
+  // GTM Configuration state
+  const [gtmId, setGtmId] = useState(initialGtmContainerId);
+  const [isSavingGtm, setIsSavingGtm] = useState(false);
+
+  // Facebook Pixel Configuration state
+  const [fbPixelId, setFbPixelId] = useState(initialFacebookPixelId);
+  const [isSavingFb, setIsSavingFb] = useState(false);
 
   useEffect(() => {
     setLocalProperties(properties);
@@ -143,23 +155,83 @@ export function AdminVisibilityDashboard({
 
   const handleSaveGa4Id = async () => {
     setIsSavingGa4(true);
+    setAlert(null);
     try {
       const { updateSettingAction } = await import("@/app/actions/admin-settings-actions");
       const res = await updateSettingAction("GA_MEASUREMENT_ID", ga4Id);
       if (res.success) {
         setAlert({
           type: "success",
-          message: "Google Analytics 4 Measurement ID guardado correctamente.",
+          message:
+            t("successGa4Saved") || "Google Analytics 4 Measurement ID guardado correctamente.",
         });
         router.refresh();
       } else {
-        setAlert({ type: "error", message: "Error al guardar el Measurement ID de GA4." });
+        setAlert({
+          type: "error",
+          message: t("errorGa4Saved") || "Error al guardar el Measurement ID de GA4.",
+        });
       }
     } catch (error) {
       console.error(error);
       setAlert({ type: "error", message: "Error al guardar el Measurement ID de GA4." });
     } finally {
       setIsSavingGa4(false);
+      setTimeout(() => setAlert(null), 3000);
+    }
+  };
+
+  const handleSaveGtmId = async () => {
+    setIsSavingGtm(true);
+    setAlert(null);
+    try {
+      const { updateSettingAction } = await import("@/app/actions/admin-settings-actions");
+      const res = await updateSettingAction("GTM_CONTAINER_ID", gtmId);
+      if (res.success) {
+        setAlert({
+          type: "success",
+          message:
+            t("successGtmSaved") || "Google Tag Manager Container ID guardado correctamente.",
+        });
+        router.refresh();
+      } else {
+        setAlert({
+          type: "error",
+          message: t("errorGtmSaved") || "Error al guardar el Container ID de GTM.",
+        });
+      }
+    } catch (error) {
+      console.error(error);
+      setAlert({ type: "error", message: "Error al guardar el Container ID de GTM." });
+    } finally {
+      setIsSavingGtm(false);
+      setTimeout(() => setAlert(null), 3000);
+    }
+  };
+
+  const handleSaveFacebookPixelId = async () => {
+    setIsSavingFb(true);
+    setAlert(null);
+    try {
+      const { updateSettingAction } = await import("@/app/actions/admin-settings-actions");
+      const res = await updateSettingAction("FACEBOOK_PIXEL_ID", fbPixelId);
+      if (res.success) {
+        setAlert({
+          type: "success",
+          message: t("successFacebookSaved") || "Facebook Pixel ID guardado correctamente.",
+        });
+        router.refresh();
+      } else {
+        setAlert({
+          type: "error",
+          message: t("errorFacebookSaved") || "Error al guardar el Pixel ID de Facebook.",
+        });
+      }
+    } catch (error) {
+      console.error(error);
+      setAlert({ type: "error", message: "Error al guardar el Pixel ID de Facebook." });
+    } finally {
+      setIsSavingFb(false);
       setTimeout(() => setAlert(null), 3000);
     }
   };
@@ -527,7 +599,7 @@ export function AdminVisibilityDashboard({
                 <div className="flex items-center gap-2 bg-slate-950 p-3 rounded-lg border border-slate-850">
                   <div className="flex-1">
                     <label className="text-[10px] font-extrabold text-slate-500 uppercase tracking-wider block mb-1">
-                      Measurement ID
+                      GA4 Measurement ID
                     </label>
                     <input
                       type="text"
@@ -543,7 +615,55 @@ export function AdminVisibilityDashboard({
                     className="self-end px-4 py-1.5 bg-slate-800 hover:bg-slate-700 text-slate-200 font-semibold rounded text-sm transition-all focus:ring-2 focus:ring-slate-500 disabled:opacity-50 cursor-pointer flex items-center gap-2"
                   >
                     {isSavingGa4 ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : null}
-                    <span>Guardar</span>
+                    <span>{t("btnSave")}</span>
+                  </button>
+                </div>
+
+                {/* GTM Configuration Input */}
+                <div className="flex items-center gap-2 bg-slate-950 p-3 rounded-lg border border-slate-850">
+                  <div className="flex-1">
+                    <label className="text-[10px] font-extrabold text-slate-500 uppercase tracking-wider block mb-1">
+                      {t("labelGtmContainerId")}
+                    </label>
+                    <input
+                      type="text"
+                      value={gtmId}
+                      onChange={(e) => setGtmId(e.target.value)}
+                      placeholder={t("placeholderGtm") || "GTM-XXXXXXX"}
+                      className="w-full bg-slate-900 border border-slate-800 rounded px-3 py-1.5 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 transition-colors font-mono"
+                    />
+                  </div>
+                  <button
+                    onClick={handleSaveGtmId}
+                    disabled={isSavingGtm || gtmId === initialGtmContainerId}
+                    className="self-end px-4 py-1.5 bg-slate-800 hover:bg-slate-700 text-slate-200 font-semibold rounded text-sm transition-all focus:ring-2 focus:ring-slate-500 disabled:opacity-50 cursor-pointer flex items-center gap-2"
+                  >
+                    {isSavingGtm ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : null}
+                    <span>{t("btnSave")}</span>
+                  </button>
+                </div>
+
+                {/* Facebook Pixel Configuration Input */}
+                <div className="flex items-center gap-2 bg-slate-950 p-3 rounded-lg border border-slate-850">
+                  <div className="flex-1">
+                    <label className="text-[10px] font-extrabold text-slate-500 uppercase tracking-wider block mb-1">
+                      {t("labelFacebookPixelId")}
+                    </label>
+                    <input
+                      type="text"
+                      value={fbPixelId}
+                      onChange={(e) => setFbPixelId(e.target.value)}
+                      placeholder={t("placeholderFacebook") || "15-digit ID"}
+                      className="w-full bg-slate-900 border border-slate-800 rounded px-3 py-1.5 text-sm text-slate-200 focus:outline-none focus:ring-1 focus:ring-red-500 focus:border-red-500 transition-colors font-mono"
+                    />
+                  </div>
+                  <button
+                    onClick={handleSaveFacebookPixelId}
+                    disabled={isSavingFb || fbPixelId === initialFacebookPixelId}
+                    className="self-end px-4 py-1.5 bg-slate-800 hover:bg-slate-700 text-slate-200 font-semibold rounded text-sm transition-all focus:ring-2 focus:ring-slate-500 disabled:opacity-50 cursor-pointer flex items-center gap-2"
+                  >
+                    {isSavingFb ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : null}
+                    <span>{t("btnSave")}</span>
                   </button>
                 </div>
               </div>

--- a/src/lib/seo/redirects.ts
+++ b/src/lib/seo/redirects.ts
@@ -48,4 +48,8 @@ export const staticRedirects: RedirectEntry[] = [
   // WordPress agent index pages
   { source: "/agents", destination: "/en/agents", permanent: true },
   { source: "/agentes", destination: "/es/agents", permanent: true },
+
+  // WordPress legacy city/area pages to new area guides
+  { source: "/city/:slug*", destination: "/en/areas/:slug*", permanent: true },
+  { source: "/ciudad/:slug*", destination: "/es/areas/:slug*", permanent: true },
 ];

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1107,7 +1107,21 @@
     "ga4Views": "Views",
     "ga4Saves": "Saves",
     "tabProperties": "Listings",
-    "tabAnalytics": "SEO Dashboard"
+    "tabAnalytics": "SEO Dashboard",
+    "gtmTitle": "Google Tag Manager (GTM)",
+    "fbPixelTitle": "Facebook Pixel (Meta)",
+    "labelGtmContainerId": "GTM Container ID",
+    "labelFacebookPixelId": "Facebook Pixel ID",
+    "placeholderGtm": "GTM-XXXXXXX",
+    "placeholderFacebook": "15-digit ID",
+    "btnSave": "Save",
+    "btnSaving": "Saving...",
+    "successGa4Saved": "Google Analytics 4 Measurement ID saved successfully.",
+    "errorGa4Saved": "Failed to save GA4 Measurement ID.",
+    "successGtmSaved": "Google Tag Manager Container ID saved successfully.",
+    "errorGtmSaved": "Failed to save Google Tag Manager Container ID.",
+    "successFacebookSaved": "Facebook Pixel ID saved successfully.",
+    "errorFacebookSaved": "Failed to save Facebook Pixel ID."
   },
   "Admin": {
     "portalTitle": "Admin Portal",

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -1107,7 +1107,21 @@
     "ga4Views": "Vistas",
     "ga4Saves": "Guardados",
     "tabProperties": "Propiedades",
-    "tabAnalytics": "Panel SEO"
+    "tabAnalytics": "Panel SEO",
+    "gtmTitle": "Google Tag Manager (GTM)",
+    "fbPixelTitle": "Facebook Pixel (Meta)",
+    "labelGtmContainerId": "ID de Contenedor GTM",
+    "labelFacebookPixelId": "ID de Pixel de Facebook",
+    "placeholderGtm": "GTM-XXXXXXX",
+    "placeholderFacebook": "ID de 15 dígitos",
+    "btnSave": "Guardar",
+    "btnSaving": "Guardando...",
+    "successGa4Saved": "ID de Medición de Google Analytics 4 guardado correctamente.",
+    "errorGa4Saved": "Error al guardar el ID de Medición de GA4.",
+    "successGtmSaved": "ID de Contenedor de Google Tag Manager guardado correctamente.",
+    "errorGtmSaved": "Error al guardar el ID de Contenedor de GTM.",
+    "successFacebookSaved": "ID de Pixel de Facebook guardado correctamente.",
+    "errorFacebookSaved": "Error al guardar el ID de Pixel de Facebook."
   },
   "Admin": {
     "portalTitle": "Portal de Administración",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,15 +2,41 @@ import { NextRequest, NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 
+import {
+  isWordPressAgentUrl,
+  isWordPressPropertyUrl,
+} from "./lib/seo/wordpress-redirect-middleware";
+
 const intlMiddleware = createMiddleware(routing);
 
 export default function middleware(request: NextRequest) {
-  // Detect paths of the form /<something>/... where <something> looks like a
-  // locale code (2-5 lowercase chars) but is NOT one we support. Redirect
+  const { pathname } = request.nextUrl;
+
+  // 1. WordPress Dynamic Listing Redirects (Phase 1 Strategy: Temporary 302 to Search)
+  const wpPropertyId = isWordPressPropertyUrl(pathname);
+  if (wpPropertyId) {
+    const isSpanish = pathname.startsWith("/propiedad/");
+    const url = request.nextUrl.clone();
+    url.pathname = isSpanish ? `/es/search` : `/en/search`;
+    url.searchParams.set("q", wpPropertyId);
+    return NextResponse.redirect(url, { status: 302 });
+  }
+
+  // 2. WordPress Dynamic Agent Redirects (Redirect directly to their slug under /agents)
+  const wpAgentName = isWordPressAgentUrl(pathname);
+  if (wpAgentName) {
+    const isSpanish = pathname.startsWith("/agente/");
+    const url = request.nextUrl.clone();
+    url.pathname = isSpanish ? `/es/agents/${wpAgentName}` : `/en/agents/${wpAgentName}`;
+    return NextResponse.redirect(url, { status: 302 });
+  }
+
+  // 3. Detect paths of the form /<something>/... where <something> looks like a
+  // locale code (2-3 lowercase chars) but is NOT one we support. Redirect
   // those to the default locale so visitors with a mistyped or unsupported
   // locale prefix land on a working page instead of a 404 (AC #6).
-  const firstSegment = request.nextUrl.pathname.split("/")[1] ?? "";
-  const looksLikeLocaleCode = /^[a-z]{2,5}(-[a-z]{2,4})?$/i.test(firstSegment);
+  const firstSegment = pathname.split("/")[1] ?? "";
+  const looksLikeLocaleCode = /^[a-z]{2,3}(-[a-z]{2,4})?$/i.test(firstSegment);
   const isSupportedLocale = (routing.locales as readonly string[]).includes(firstSegment);
 
   if (looksLikeLocaleCode && !isSupportedLocale) {

--- a/tests/unit/actions/admin-settings-actions.spec.ts
+++ b/tests/unit/actions/admin-settings-actions.spec.ts
@@ -1,0 +1,118 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// Hoisted mocks for database client and next/cache
+const { mockInsert, mockSelect, mockDb, mockRevalidatePath, mockRevalidateTag } = vi.hoisted(() => {
+  const mockOnConflictDoUpdate = vi.fn().mockResolvedValue({ success: true });
+  const mockInsertValues = vi.fn().mockReturnValue({
+    onConflictDoUpdate: mockOnConflictDoUpdate,
+  });
+  const mockInsert = vi.fn().mockReturnValue({
+    values: mockInsertValues,
+  });
+
+  const mockLimit = vi.fn();
+  const mockWhere = vi.fn().mockReturnValue({
+    limit: mockLimit,
+  });
+  const mockFrom = vi.fn().mockReturnValue({
+    where: mockWhere,
+  });
+  const mockSelect = vi.fn().mockReturnValue({
+    from: mockFrom,
+  });
+
+  const mockDb: any = {
+    insert: mockInsert,
+    select: mockSelect,
+  };
+
+  const mockRevalidatePath = vi.fn();
+  const mockRevalidateTag = vi.fn();
+
+  return {
+    mockInsert,
+    mockSelect,
+    mockDb,
+    mockRevalidatePath,
+    mockRevalidateTag,
+    mockInsertValues,
+    mockOnConflictDoUpdate,
+    mockLimit,
+    mockWhere,
+    mockFrom,
+  };
+});
+
+vi.mock("@/lib/db/client", () => ({
+  db: mockDb,
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mockRevalidatePath,
+  revalidateTag: mockRevalidateTag,
+}));
+
+import { updateSettingAction, getSettingAction } from "@/app/actions/admin-settings-actions";
+
+describe("Admin Settings Server Actions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("updateSettingAction", () => {
+    it("should successfully insert/update setting and trigger revalidation", async () => {
+      const result = await updateSettingAction("GTM_CONTAINER_ID", "GTM-TEST123");
+
+      expect(mockInsert).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(mockRevalidateTag).toHaveBeenCalledWith("settings");
+      expect(mockRevalidatePath).toHaveBeenCalledWith("/", "layout");
+    });
+  });
+
+  describe("getSettingAction", () => {
+    it("should fetch setting value successfully from database", async () => {
+      const mockResult = [{ key: "GTM_CONTAINER_ID", value: "GTM-TEST123" }];
+      // Setup chain resolved value
+      const mockLimitFn = vi.fn().mockResolvedValue(mockResult);
+      const mockWhereFn = vi.fn().mockReturnValue({
+        limit: mockLimitFn,
+      });
+      const mockFromFn = vi.fn().mockReturnValue({
+        where: mockWhereFn,
+      });
+      mockSelect.mockReturnValue({
+        from: mockFromFn,
+      });
+
+      const result = await getSettingAction("GTM_CONTAINER_ID");
+
+      expect(mockSelect).toHaveBeenCalled();
+      expect(result.success).toBe(true);
+      expect(result.value).toBe("GTM-TEST123");
+    });
+
+    it("should return null if key is not found", async () => {
+      const mockLimitFn = vi.fn().mockResolvedValue([]);
+      const mockWhereFn = vi.fn().mockReturnValue({
+        limit: mockLimitFn,
+      });
+      const mockFromFn = vi.fn().mockReturnValue({
+        where: mockWhereFn,
+      });
+      mockSelect.mockReturnValue({
+        from: mockFromFn,
+      });
+
+      const result = await getSettingAction("GTM_CONTAINER_ID");
+
+      expect(result.success).toBe(true);
+      expect(result.value).toBeNull();
+    });
+  });
+});

--- a/tests/unit/seo/redirects.spec.ts
+++ b/tests/unit/seo/redirects.spec.ts
@@ -143,6 +143,21 @@ describe("staticRedirects data shape (4.4-UNIT-003)", () => {
       expect(sources).toContain("/join");
     },
   );
+
+  it(
+    "covers legacy WordPress city/area redirects",
+    () => {
+      const cityEntry = staticRedirects.find((r: RedirectEntry) => r.source === "/city/:slug*");
+      expect(cityEntry).toBeDefined();
+      expect(cityEntry?.destination).toBe("/en/areas/:slug*");
+      expect(cityEntry?.permanent).toBe(true);
+
+      const ciudadEntry = staticRedirects.find((r: RedirectEntry) => r.source === "/ciudad/:slug*");
+      expect(ciudadEntry).toBeDefined();
+      expect(ciudadEntry?.destination).toBe("/es/areas/:slug*");
+      expect(ciudadEntry?.permanent).toBe(true);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
# GTM, Facebook Pixel and WordPress Redirects

## Overview
This feature adds Google Tag Manager (GTM) and Facebook (Meta) Pixel tracking configurations into the Admin Visibility/SEO Panel, rendering their scripts dynamically in the site layout. It also configures legacy WordPress redirects to map old structure URLs (properties, agents, city/area pages) to the new structure, fixes Next.js middleware locale regex match parsing, and increases sitemap compilation robustness against build-time database connection locks.

## Changes

### Analytics & Tracker Config (Admin Settings)
- **layout.tsx**: Injected GTM and Facebook Pixel tracker scripts into the layout header and body based on values configured in settings.
- **admin-visibility-dashboard.tsx**: Implemented styling and state logic in the SEO panel dashboard to retrieve, edit, and save tracking IDs.
- **page.tsx**: Fetched active database configurations for both GTM and Facebook Pixel IDs.
- **en.json** & **es.json**: Added English and Spanish localized labels and action notifications.

### Redirects & Middleware Integration
- **redirects.ts**: Configured 301 static redirects for legacy WordPress city (`/city/:slug*` -> `/en/areas/:slug*`) and ciudad (`/ciudad/:slug*` -> `/es/areas/:slug*`) endpoints.
- **middleware.ts**:
  - Intercepts legacy WordPress listing URLs (`/propiedad/:id`, `/property/:id`) and redirects them to the search query with a temporary 302 code.
  - Intercepts legacy WordPress agent URLs (`/agente/:slug`, `/agent/:slug`) and redirects them to their equivalent Next.js localized paths.
  - Tightened locale regex checks from `/^[a-z]{2,5}.../` to `/^[a-z]{2,3}.../` to avoid misidentifying extended slug patterns.

### Build and Robustness
- **sitemap.ts**: Marked with `force-dynamic` execution at runtime to bypass Next.js build-time database constraints, falling back cleanly to static entries if connection fails.

### Testing & Verification
- **admin-settings-actions.spec.ts**: Added server action unit tests for setting retrieval and storage behavior.
- **redirects.spec.ts**: Covered the new static city and area mapping redirects.

## Testing
- Ran all ESLint check suites successfully without errors.
- Verified build and static generation via `npm run build` compilation to completion.
